### PR TITLE
ci: fix draft workflow to trigger on main branch

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - main
 
 permissions:
   contents: write
@@ -12,6 +12,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@master
+      # Use local action (dogfooding)
+      - uses: aaronsteers/semantic-pr-release-drafter@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes the Release Drafter workflow that wasn't triggering after PR #3 was merged. The workflow was still configured to trigger on pushes to `master`, but the repository's default branch is `main`.

Changes:
- Update branch trigger from `master` to `main`
- Switch from upstream `release-drafter/release-drafter@master` to `aaronsteers/semantic-pr-release-drafter@main` (dogfooding)

## Review & Testing Checklist for Human

- [ ] Verify the action reference `aaronsteers/semantic-pr-release-drafter@main` is correct
- [ ] After merging, verify a release draft is created in the Releases section

### Notes

This PR cannot be tested before merge since the workflow only triggers on pushes to `main`. After merging, the workflow should run and create a release draft based on the commits since the last release.

**Link to Devin run:** https://app.devin.ai/sessions/a62579288ea34c20bec299d93aebbe48
**Requested by:** @aaronsteers