### PR TITLE
ci: add LOG_LEVEL=warn to reduce Probot debug output

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -16,3 +16,4 @@ jobs:
       - uses: aaronsteers/semantic-pr-release-drafter@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LOG_LEVEL: warn


### PR DESCRIPTION
## Summary

Adds `LOG_LEVEL=warn` environment variable to the Release Drafter workflow to reduce verbose Probot debug output. This suppresses the noisy `{ name: 'event', id: '...' }` messages that were appearing in workflow logs from Probot's internal event handling.

## Review & Testing Checklist for Human

- [ ] Verify `warn` is the appropriate log level (not too restrictive - errors and warnings will still be logged)
- [ ] After merging, check the next Release Drafter workflow run to confirm debug noise is reduced while important output remains visible

### Notes

This change cannot be tested before merge since the workflow only triggers on pushes to `main`. If the log level is too restrictive, it can be adjusted to `info` in a follow-up PR.

**Link to Devin run:** https://app.devin.ai/sessions/a62579288ea34c20bec299d93aebbe48
**Requested by:** @aaronsteers