### PR TITLE
ci: add inline config to draft workflow

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -15,6 +15,8 @@ jobs:
       # Use local action (dogfooding)
       - uses: aaronsteers/semantic-pr-release-drafter@main
         with:
+          name-template: 'v$RESOLVED_VERSION'
+          tag-template: 'v$RESOLVED_VERSION'
           template: |
             $CHANGES
 
@@ -22,37 +24,29 @@ jobs:
 
             **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
           change-template: '* $TITLE ($URL) $SHA'
-          category-template: '## $TITLE'
           categories: |
-            - title: Breaking Changes
+            - title: '⚠️ Breaking Changes'
               commit-types:
-                - feat!
-                - fix!
-                - refactor!
-              collapse-after: 20
-            - title: Features
+                - 'breaking'
+            - title: '✨ New Features'
               commit-types:
-                - feat
-              collapse-after: 20
-            - title: Bug Fixes
+                - 'feat'
+            - title: '🐛 Bug Fixes'
               commit-types:
-                - fix
-              collapse-after: 20
-            - title: Refactoring
-              commit-types:
-                - refactor
-              collapse-after: 20
-            - title: Documentation
-              commit-types:
-                - docs
+                - 'fix'
+            - title: '📖 Documentation'
               collapse-after: 2
-            - title: Under the Hood
               commit-types:
-                - chore
-                - ci
-                - build
-                - test
-                - perf
+                - 'docs'
+            - title: '⚙️ Under the Hood'
               collapse-after: 2
+              commit-types:
+                - 'chore'
+                - 'ci'
+                - 'build'
+                - 'refactor'
+                - 'style'
+                - 'test'
+                - 'perf'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes the release drafter workflow that broke after PR #10 merged. PR #10 added inline config support and deleted the `.github/release-drafter.yml` config file, but the `draft.yml` workflow wasn't updated to use inline config inputs, causing immediate failure on the next push to main.

This PR adds the inline config inputs directly to the workflow file, incorporating the template configuration from PR #9.

## Updates since last revision

- Added `name-template` and `tag-template` inputs for consistent release naming (`v$RESOLVED_VERSION`)
- Updated categories to use emoji titles from PR #9 (e.g., "✨ New Features", "🐛 Bug Fixes")
- Simplified category structure with appropriate `collapse-after` values

## Review & Testing Checklist for Human

- [ ] **Verify commit-type mappings**: The categories use `'breaking'` for breaking changes - confirm this matches how the action parses breaking change commits (vs. `'feat!'`, `'fix!'` syntax used elsewhere)
- [ ] **Check YAML syntax**: Verify the inline YAML for `template` and `categories` is properly formatted (multiline strings, indentation)
- [ ] **Test after merge**: Trigger the draft workflow (push to main or manual trigger) and verify the release draft renders correctly with emoji category headers

### Notes

This is a critical fix - the release drafter is currently broken on main.

Requested by @aaronsteers

Link to Devin run: https://app.devin.ai/sessions/a62579288ea34c20bec299d93aebbe48