### PR TITLE
docs: add example usages section linking to dependents page

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This ensures that when PRs are merged, the resulting commit on main has a proper
 Looking for real-world examples? Here are two ways to find how others have integrated this action into their workflows:
 
 - [Dependent repositories](https://github.com/aaronsteers/semantic-pr-release-drafter/network/dependents) - Browse repos that use this action
-- [Code search](https://github.com/search?q=uses%3A+aaronsteers%2Fsemantic-pr-release-drafter%40&type=code) - Find workflow file examples (requires GitHub sign-in)
+- [Code search](https://github.com/search?q=uses%3A+aaronsteers%2Fsemantic-pr-release-drafter%40&type=code) - Find workflow file examples
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a new "Example Usages" subsection to the README that provides two ways for users to find real-world examples of how others have integrated this action into their workflows:

- **[Dependent repositories](https://github.com/aaronsteers/semantic-pr-release-drafter/network/dependents)** - Browse repos that use this action
- **[Code search](https://github.com/search?q=uses%3A+aaronsteers%2Fsemantic-pr-release-drafter%40&type=code)** - Find workflow file examples directly (requires GitHub sign-in)

The section is placed under "Recommended Repo Configuration" in the "About This Fork" area, before the main "Usage" section.

## Review & Testing Checklist for Human

- [ ] Verify the [dependents link](https://github.com/aaronsteers/semantic-pr-release-drafter/network/dependents) works and shows useful examples
- [ ] Verify the [code search link](https://github.com/search?q=uses%3A+aaronsteers%2Fsemantic-pr-release-drafter%40&type=code) works when signed in to GitHub
- [ ] Confirm the placement of this section makes sense in the document flow

### Notes

Requested by @aaronsteers

Link to Devin run: https://app.devin.ai/sessions/54aa6e5fe3f34ac2a493b273b15a9e1b