### PR TITLE
docs: add common releasing guide for consumer repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ This fork DROPS all support for:
 - **Label-based version resolver** - Version is determined by conventional-commit `type` properties, not labels.
 - **Label-based categorization** - Categories are determined by conventional-commit `scope` and `type` properties, not labels.
 
+## How to Release
+
+For a step-by-step guide on publishing releases in repos that use this action, see **[How to Release](docs/releasing.md)**.
+
+We recommend linking to this guide from your repo's `CONTRIBUTING.md` so contributors know how the release process works.
+
 ## Recommended Repo Configuration
 
 To get the most out of this action, we recommend configuring your repository as follows:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,6 +1,6 @@
 # How to Release
 
-> [!INFO]
+> [!NOTE]
 > If your repo uses `semantic-pr-release-drafter`, we recommend linking to this guide from your `CONTRIBUTING.md` rather than duplicating release instructions. For example, add a `## Releasing` section with a link to this page.
 
 This guide covers the common release workflow for repositories using [`semantic-pr-release-drafter`](https://github.com/aaronsteers/semantic-pr-release-drafter).

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,67 @@
+# How to Release
+
+This guide covers the common release workflow for repositories using [`semantic-pr-release-drafter`](https://github.com/aaronsteers/semantic-pr-release-drafter).
+
+## How It Works
+
+1. **Semantic PR titles** drive versioning. Every PR merged to `main` should have a title following [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat: add new feature`, `fix: resolve bug`, `breaking: remove deprecated API`).
+2. **Draft releases are updated automatically.** On each push to `main`, the release drafter workflow creates or updates a draft GitHub Release with auto-generated release notes and a resolved version number.
+3. **You publish when ready.** A maintainer reviews the draft and clicks "Publish release" to finalize it.
+
+## Version Resolution
+
+Versions are resolved automatically based on the semantic commit types of merged PRs:
+
+| Commit type | Version bump |
+|---|---|
+| `breaking` | Major (e.g., `1.2.3` -> `2.0.0`) |
+| `feat` | Minor (e.g., `1.2.3` -> `1.3.0`) |
+| `fix`, `docs`, `chore`, `ci`, `refactor`, `test`, `perf`, `build`, `style` | Patch (e.g., `1.2.3` -> `1.2.4`) |
+
+### Pre-1.0 Projects
+
+For projects that haven't reached `v1.0.0` yet, semver safety rules apply automatically:
+
+- Major bumps become minor bumps (e.g., `0.2.3` -> `0.3.0` instead of `1.0.0`)
+- Minor bumps become patch bumps (e.g., `0.2.3` -> `0.2.4` instead of `0.3.0`)
+
+## Publishing a Release
+
+1. Navigate to your repository's [Releases](../../releases) page.
+2. You should see a **Draft** release at the top with auto-generated release notes.
+3. Review the draft:
+   - Verify the version number is correct.
+   - Review the changelog entries.
+   - Optionally edit the release notes if needed.
+4. Click **"Publish release"** to finalize.
+
+Once published, any downstream workflows (e.g., PyPI publish, npm publish, Docker build) will be triggered automatically via the `on: release` event.
+
+## Version Preservation
+
+If you manually set the draft release version (e.g., to `v2.0.0`), the action will never bump it backwards. Prerelease identifiers (like `-beta`, `-rc.1`) are also preserved exactly as set.
+
+This is useful when you want to:
+
+- Force a major version bump for marketing or strategic reasons.
+- Create release candidates (e.g., `v2.0.0-rc.1`).
+
+## Pre-releases
+
+To publish a pre-release:
+
+1. Edit the draft release and set the `Title` and `Tag` to your desired prerelease version (e.g., `v1.0.0-rc.1`).
+2. Save the draft, then re-run the release drafter workflow from the Actions tab to regenerate assets with the correct version.
+3. Publish the release.
+
+> **Note:** Whether to check GitHub's "Set as a pre-release" checkbox depends on your project. Some registries (e.g., Terraform Registry) will not sync pre-releases, so check your project's specific guidance.
+
+## Recommended Repository Configuration
+
+For the best experience with this action, configure your repository as follows:
+
+1. **Enable squash merging** as the default (or only) merge method.
+2. **Set the default commit message** to "Pull request title" so the squashed commit inherits the semantic PR title.
+3. **Add PR title validation** using [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request) to enforce conventional commit format on all PRs.
+
+For full configuration details, see the [semantic-pr-release-drafter README](https://github.com/aaronsteers/semantic-pr-release-drafter#readme).

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,6 +1,24 @@
 # How to Release
 
+> [!INFO]
+> If your repo uses `semantic-pr-release-drafter`, we recommend linking to this guide from your `CONTRIBUTING.md` rather than duplicating release instructions. For example, add a `## Releasing` section with a link to this page.
+
 This guide covers the common release workflow for repositories using [`semantic-pr-release-drafter`](https://github.com/aaronsteers/semantic-pr-release-drafter).
+
+## Publishing a Release
+
+1. Navigate to your repository's [Releases](../../releases) page.
+2. You should see a **Draft** release at the top with auto-generated release notes.
+3. Review the draft:
+   - Verify the version number is correct.
+   - Review the changelog entries.
+   - Optionally edit the release notes if needed.
+4. Click **"Publish release"** to finalize.
+
+Once published, any downstream workflows (e.g., PyPI publish, npm publish, Docker build) will be triggered automatically via the `on: release` event.
+
+<details>
+<summary><b>🔍 How It Works</b></summary>
 
 ## How It Works
 
@@ -25,17 +43,10 @@ For projects that haven't reached `v1.0.0` yet, semver safety rules apply automa
 - Major bumps become minor bumps (e.g., `0.2.3` -> `0.3.0` instead of `1.0.0`)
 - Minor bumps become patch bumps (e.g., `0.2.3` -> `0.2.4` instead of `0.3.0`)
 
-## Publishing a Release
+</details>
 
-1. Navigate to your repository's [Releases](../../releases) page.
-2. You should see a **Draft** release at the top with auto-generated release notes.
-3. Review the draft:
-   - Verify the version number is correct.
-   - Review the changelog entries.
-   - Optionally edit the release notes if needed.
-4. Click **"Publish release"** to finalize.
-
-Once published, any downstream workflows (e.g., PyPI publish, npm publish, Docker build) will be triggered automatically via the `on: release` event.
+<details>
+<summary><b>⚙️ Advanced Usage</b></summary>
 
 ## Version Preservation
 
@@ -65,3 +76,5 @@ For the best experience with this action, configure your repository as follows:
 3. **Add PR title validation** using [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request) to enforce conventional commit format on all PRs.
 
 For full configuration details, see the [semantic-pr-release-drafter README](https://github.com/aaronsteers/semantic-pr-release-drafter#readme).
+
+</details>

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -7,7 +7,7 @@ This guide covers the common release workflow for repositories using [`semantic-
 
 ## Publishing a Release
 
-1. Navigate to your repository's [Releases](../../releases) page.
+1. Navigate to your repository's **Releases** page (e.g., `https://github.com/<owner>/<repo>/releases`).
 2. You should see a **Draft** release at the top with auto-generated release notes.
 3. Review the draft:
    - Verify the version number is correct.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -22,7 +22,7 @@ Once published, any downstream workflows (e.g., PyPI publish, npm publish, Docke
 
 ## How It Works
 
-1. **Semantic PR titles** drive versioning. Every PR merged to `main` should have a title following [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat: add new feature`, `fix: resolve bug`, `breaking: remove deprecated API`).
+1. **Semantic PR titles** drive versioning. Every PR merged to `main` should have a title following [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat: add new feature`, `fix: resolve bug`, `feat!: remove deprecated API`).
 2. **Draft releases are updated automatically.** On each push to `main`, the release drafter workflow creates or updates a draft GitHub Release with auto-generated release notes and a resolved version number.
 3. **You publish when ready.** A maintainer reviews the draft and clicks "Publish release" to finalize it.
 
@@ -32,9 +32,11 @@ Versions are resolved automatically based on the semantic commit types of merged
 
 | Commit type | Version bump |
 |---|---|
-| `breaking` | Major (e.g., `1.2.3` -> `2.0.0`) |
+| Breaking change (`feat!:`, `fix!:`, etc.) | Minor* (e.g., `1.2.3` -> `1.3.0`) |
 | `feat` | Minor (e.g., `1.2.3` -> `1.3.0`) |
 | `fix`, `docs`, `chore`, `ci`, `refactor`, `test`, `perf`, `build`, `style` | Patch (e.g., `1.2.3` -> `1.2.4`) |
+
+\*By default, breaking changes trigger minor bumps (marketing-friendly semver). To enable automatic major bumps for breaking changes, set `allow-major-bumps: true` in your workflow configuration.
 
 ### Pre-1.0 Projects
 


### PR DESCRIPTION
# docs: add common releasing guide for consumer repos

## Summary

Adds `docs/releasing.md` — a shared "How to Release" guide intended as a single source of truth for all repositories that use `semantic-pr-release-drafter`. Also adds a "How to Release" section to the README that links to this guide.

Consumer repos identified: `PyAirbyte`, `terraform-provider-airbyte`, `airbyte-python-cdk`, `fastmcp-extensions`, `awesome-python-template`, `devin-action`, `devin-reminders-action`, `tk-todo-check-action`, `zenbyte-app-internal`.

The guide covers:
- **Publishing a Release** (front and center at the top)
- How it works / version resolution (collapsible `<details>` section)
- Advanced usage: version preservation, pre-releases, recommended config (collapsible `<details>` section)
- A `[!NOTE]` callout recommending consumer repos link here from their CONTRIBUTING.md

Changes to `README.md`:
- New "How to Release" section (between "Removed Features" and "Recommended Repo Configuration") linking to `docs/releasing.md`

## Updates since last revision

- Changed `[!INFO]` callout to `[!NOTE]` (a recognized GitHub callout type)
- Fixed version resolution table to accurately reflect default behavior:
  - Breaking changes (`feat!:`, `fix!:`, etc.) now correctly shown as triggering **minor** bumps by default (not major), matching the action's `no-auto-major: true` default
  - Added footnote about `allow-major-bumps: true` to opt into major bumps for breaking changes
  - Clarified that breaking changes use `!` suffix on commit type, not a `breaking` prefix
- Updated example in "How It Works" from `breaking: remove deprecated API` to `feat!: remove deprecated API`
- All 9 consumer repo follow-up PRs have been moved from draft to ready-for-review

## Review & Testing Checklist for Human

- [ ] **Verify the relative `[Releases](../../releases)` link behavior.** When viewed at `github.com/aaronsteers/semantic-pr-release-drafter/blob/main/docs/releasing.md`, this resolves to the *drafter repo's* releases page, not a consumer repo's. The surrounding text says "Navigate to your repository's Releases page" which may be sufficient context — confirm this is intentional.
- [ ] **Verify `allow-major-bumps: true` is the correct config option name.** The footnote references this option for enabling major bumps on breaking changes. Confirm this matches the action's actual input/config parameter.
- [ ] **Review the `on: release` trigger claim.** Some consumer repos may use `on: push: tags:` instead of `on: release` for their publish workflows. Consider whether the wording should be more general.

### Notes

- This is a docs-only change — no code or workflow modifications.
- The `build` CI job fails (pre-existing: it checks `github.repository == 'release-drafter/release-drafter'`). The required `check-dist` check passes.
- Follow-up PRs for all 9 consumer repos have been created and are now ready for review.

---
Requested by: @aaronsteers
[Devin session](https://app.devin.ai/sessions/d59fa353515f488ab1818b8888d0c3bf)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aaronsteers/semantic-pr-release-drafter/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->