### PR TITLE
ci: apply prettier formatting to docs/releasing.md

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -30,11 +30,11 @@ Once published, any downstream workflows (e.g., PyPI publish, npm publish, Docke
 
 Versions are resolved automatically based on the semantic commit types of merged PRs:
 
-| Commit type | Version bump |
-|---|---|
-| Breaking change (`feat!:`, `fix!:`, etc.) | Minor* (e.g., `1.2.3` -> `1.3.0`) |
-| `feat` | Minor (e.g., `1.2.3` -> `1.3.0`) |
-| `fix`, `docs`, `chore`, `ci`, `refactor`, `test`, `perf`, `build`, `style` | Patch (e.g., `1.2.3` -> `1.2.4`) |
+| Commit type                                                                | Version bump                       |
+| -------------------------------------------------------------------------- | ---------------------------------- |
+| Breaking change (`feat!:`, `fix!:`, etc.)                                  | Minor\* (e.g., `1.2.3` -> `1.3.0`) |
+| `feat`                                                                     | Minor (e.g., `1.2.3` -> `1.3.0`)   |
+| `fix`, `docs`, `chore`, `ci`, `refactor`, `test`, `perf`, `build`, `style` | Patch (e.g., `1.2.3` -> `1.2.4`)   |
 
 \*By default, breaking changes trigger minor bumps (marketing-friendly semver). To enable automatic major bumps for breaking changes, set `allow-major-bumps: true` in your workflow configuration.
 


### PR DESCRIPTION
# ci: apply prettier formatting to docs/releasing.md

## Summary

Applies prettier auto-formatting to the markdown table in `docs/releasing.md`. The table was merged in PR #41 without prettier formatting, which caused the `build` CI job to fail (it runs `yarn prettier` and then checks for unstaged changes via `.github/no-unstaged-files.sh`).

The only change is column-width alignment and escaping `*` → `\*` in the table cell — no content changes.

## Review & Testing Checklist for Human

- [ ] Verify the rendered markdown table still displays correctly on GitHub, especially the `Minor*` footnote row (prettier escapes it to `Minor\*`)
- [ ] Confirm the `build` CI job passes on this PR

### Notes

Requested by: @aaronsteers
[Devin session](https://app.devin.ai/sessions/d59fa353515f488ab1818b8888d0c3bf)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aaronsteers/semantic-pr-release-drafter/pull/42" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
