### PR TITLE
feat: add scope-template config for customizable scope rendering

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -267,7 +267,7 @@ jobs:
                 commit-types:
                   - fix
 
-          # Test $SCOPE template variable with force-lowercase and comma normalization
+          # Test $SCOPE template variable with scope-template, force-lowercase, and comma normalization
           - test-name: 'scope-template-variable'
             test-start-version-string: 'v1.0.0'
             test-commit-list: |
@@ -287,6 +287,7 @@ jobs:
             template: |
               $CHANGES
             change-template: '* $SCOPE$TITLE (#$NUMBER)'
+            scope-template: '$SCOPE: '
             category-template: '## $TITLE'
             categories: |
               - title: Features
@@ -468,6 +469,7 @@ jobs:
           base-ref-override: ${{ matrix.test-start-version-string }}
           template: ${{ matrix.template }}
           change-template: ${{ matrix.change-template }}
+          scope-template: ${{ matrix.scope-template }}
           category-template: ${{ matrix.category-template }}
           categories: ${{ matrix.categories }}
           attach-files: ${{ env.ATTACH_FILES_PATTERNS }}

--- a/action.yml
+++ b/action.yml
@@ -89,7 +89,7 @@ inputs:
       Inside this template, $SCOPE is the raw lowercase scope value (e.g., "registry", "cli, mcp").
       Multi-scopes are normalized with spaces (e.g., "cli,mcp" becomes "cli, mcp").
       When no scope is present, the entire scope-template is skipped and $SCOPE in change-template resolves to "".
-      Examples: '$SCOPE: ' (default), '[$SCOPE] ', '$SCOPE/ '.
+      Default is '' (disabled). Examples: '$SCOPE: ', '[$SCOPE] ', '$SCOPE/ '.
     required: false
     default: ''
   template:

--- a/action.yml
+++ b/action.yml
@@ -79,10 +79,17 @@ inputs:
   change-template:
     description: |
       The template for each changelog entry. Supports placeholders like $TITLE, $URL, $SHA, $NUMBER, $AUTHOR, $SCOPE.
-      $SCOPE is a pre-formatted scope prefix from the semantic commit scope (e.g., "registry: " for "feat(registry): ...").
-      Multi-scopes are normalized with spaces (e.g., "cli, mcp: " for "feat(cli,mcp): ...").
-      When no scope is present, $SCOPE resolves to an empty string. Use "$SCOPE$TITLE" to prefix scoped entries.
+      $SCOPE is rendered using scope-template when a scope is present, or an empty string when absent.
       This will override any `change-template` specified in your config file.
+    required: false
+    default: ''
+  scope-template:
+    description: |
+      The template for rendering the $SCOPE placeholder in change-template. Only rendered when a scope is present.
+      Inside this template, $SCOPE is the raw lowercase scope value (e.g., "registry", "cli, mcp").
+      Multi-scopes are normalized with spaces (e.g., "cli,mcp" becomes "cli, mcp").
+      When no scope is present, the entire scope-template is skipped and $SCOPE in change-template resolves to "".
+      Examples: '$SCOPE: ' (default), '[$SCOPE] ', '$SCOPE/ '.
     required: false
     default: ''
   template:

--- a/dist/index.js
+++ b/dist/index.js
@@ -146331,7 +146331,7 @@ var require_default_config = __commonJS({
       "filter-by-commitish": false,
       commitish: "",
       "pull-request-limit": 5,
-      "scope-template": "$SCOPE: ",
+      "scope-template": "",
       "category-template": "## $TITLE",
       header: "",
       footer: ""

--- a/dist/index.js
+++ b/dist/index.js
@@ -146331,6 +146331,7 @@ var require_default_config = __commonJS({
       "filter-by-commitish": false,
       commitish: "",
       "pull-request-limit": 5,
+      "scope-template": "$SCOPE: ",
       "category-template": "## $TITLE",
       header: "",
       footer: ""
@@ -146508,6 +146509,7 @@ var require_schema6 = __commonJS({
           "no-auto-major": Joi.boolean().default(true),
           default: Joi.string().valid("major", "minor", "patch").default("patch")
         }).default(DEFAULT_CONFIG["version-resolver"]),
+        "scope-template": Joi.string().allow("").default(DEFAULT_CONFIG["scope-template"]),
         "category-template": Joi.string().allow("").default(DEFAULT_CONFIG["category-template"]),
         header: Joi.string().allow("").default(DEFAULT_CONFIG.header),
         template: Joi.string().required(),
@@ -146583,6 +146585,10 @@ var require_config = __commonJS({
       if (template) {
         overrides.template = template;
       }
+      const scopeTemplate = core2.getInput("scope-template");
+      if (scopeTemplate) {
+        overrides["scope-template"] = scopeTemplate;
+      }
       const categoryTemplate = core2.getInput("category-template");
       if (categoryTemplate) {
         overrides["category-template"] = categoryTemplate;
@@ -146603,7 +146609,7 @@ var require_config = __commonJS({
       return overrides;
     }
     function hasInlineConfig() {
-      return core2.getInput("name-template") || core2.getInput("tag-template") || core2.getInput("change-template") || core2.getInput("template") || core2.getInput("category-template") || core2.getInput("categories");
+      return core2.getInput("name-template") || core2.getInput("tag-template") || core2.getInput("change-template") || core2.getInput("template") || core2.getInput("scope-template") || core2.getInput("category-template") || core2.getInput("categories");
     }
     async function getConfig({ context, configName, localGitRoot }) {
       try {
@@ -149031,6 +149037,7 @@ var require_semantic_commits = __commonJS({
         const categories = config.categories || [];
         const categoryTemplate = config["category-template"] || "## $TITLE";
         const changeTemplate = config["change-template"] || "* $TITLE";
+        const scopeTemplate = config["scope-template"] !== void 0 ? config["scope-template"] : "";
         const escapeChars = config["change-title-escapes"] || "";
         const repoInfo = context ? context.repo() : { owner: "", repo: "" };
         const categorizedItems = categories.map((cat) => ({
@@ -149083,13 +149090,14 @@ var require_semantic_commits = __commonJS({
           const processedTitle = TITLE_POST_PROCESSORS["sentence-case"](
             item.description
           );
-          const scopePrefix = item.scope ? item.scope.toLowerCase().replace(/,/g, ", ").replace(/, +/g, ", ") + ": " : "";
+          const rawScope = item.scope ? item.scope.toLowerCase().replace(/,/g, ", ").replace(/, +/g, ", ") : "";
+          const renderedScope = rawScope && scopeTemplate ? template(scopeTemplate, { $SCOPE: rawScope }) : "";
           return template(changeTemplate, {
             $TITLE: escapeTitle(processedTitle),
             $NUMBER: prNumber,
             $AUTHOR: item.author || "ghost",
             $SHA: item.shortSha || "",
-            $SCOPE: scopePrefix,
+            $SCOPE: renderedScope,
             $URL: prNumber && repoInfo.owner && repoInfo.repo ? `https://github.com/${repoInfo.owner}/${repoInfo.repo}/pull/${prNumber}` : ""
           });
         };

--- a/dist/index.js
+++ b/dist/index.js
@@ -146585,7 +146585,9 @@ var require_config = __commonJS({
       if (template) {
         overrides.template = template;
       }
-      const scopeTemplate = core2.getInput("scope-template");
+      const scopeTemplate = core2.getInput("scope-template", {
+        trimWhitespace: false
+      });
       if (scopeTemplate) {
         overrides["scope-template"] = scopeTemplate;
       }

--- a/lib/config.js
+++ b/lib/config.js
@@ -32,6 +32,11 @@ function getInlineConfigOverrides() {
     overrides.template = template
   }
 
+  const scopeTemplate = core.getInput('scope-template')
+  if (scopeTemplate) {
+    overrides['scope-template'] = scopeTemplate
+  }
+
   const categoryTemplate = core.getInput('category-template')
   if (categoryTemplate) {
     overrides['category-template'] = categoryTemplate
@@ -62,6 +67,7 @@ function hasInlineConfig() {
     core.getInput('tag-template') ||
     core.getInput('change-template') ||
     core.getInput('template') ||
+    core.getInput('scope-template') ||
     core.getInput('category-template') ||
     core.getInput('categories')
   )

--- a/lib/config.js
+++ b/lib/config.js
@@ -32,7 +32,9 @@ function getInlineConfigOverrides() {
     overrides.template = template
   }
 
-  const scopeTemplate = core.getInput('scope-template')
+  const scopeTemplate = core.getInput('scope-template', {
+    trimWhitespace: false,
+  })
   if (scopeTemplate) {
     overrides['scope-template'] = scopeTemplate
   }

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -79,7 +79,7 @@ const DEFAULT_CONFIG = Object.freeze({
   'filter-by-commitish': false,
   commitish: '',
   'pull-request-limit': 5,
-  'scope-template': '$SCOPE: ',
+  'scope-template': '',
   'category-template': '## $TITLE',
   header: '',
   footer: '',

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -79,6 +79,7 @@ const DEFAULT_CONFIG = Object.freeze({
   'filter-by-commitish': false,
   commitish: '',
   'pull-request-limit': 5,
+  'scope-template': '$SCOPE: ',
   'category-template': '## $TITLE',
   header: '',
   footer: '',

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -141,6 +141,10 @@ const schema = (context) => {
         })
         .default(DEFAULT_CONFIG['version-resolver']),
 
+      'scope-template': Joi.string()
+        .allow('')
+        .default(DEFAULT_CONFIG['scope-template']),
+
       'category-template': Joi.string()
         .allow('')
         .default(DEFAULT_CONFIG['category-template']),

--- a/lib/semantic-commits.js
+++ b/lib/semantic-commits.js
@@ -308,6 +308,8 @@ class ReleaseChangeLineItems {
     const categories = config.categories || []
     const categoryTemplate = config['category-template'] || '## $TITLE'
     const changeTemplate = config['change-template'] || '* $TITLE'
+    const scopeTemplate =
+      config['scope-template'] !== undefined ? config['scope-template'] : ''
     const escapeChars = config['change-title-escapes'] || ''
     const repoInfo = context ? context.repo() : { owner: '', repo: '' }
 
@@ -384,18 +386,23 @@ class ReleaseChangeLineItems {
       const processedTitle = TITLE_POST_PROCESSORS['sentence-case'](
         item.description
       )
-      // Format scope as a lowercase prefix with ": " suffix, or empty string when no scope
-      // Commas in multi-scopes are normalized to ", " for readability
-      const scopePrefix = item.scope
-        ? item.scope.toLowerCase().replace(/,/g, ', ').replace(/, +/g, ', ') +
-          ': '
+      // Format scope as lowercase with comma normalization (raw value, no punctuation)
+      const rawScope = item.scope
+        ? item.scope.toLowerCase().replace(/,/g, ', ').replace(/, +/g, ', ')
         : ''
+
+      // Render $SCOPE using scope-template when scope is present, empty string when absent
+      const renderedScope =
+        rawScope && scopeTemplate
+          ? template(scopeTemplate, { $SCOPE: rawScope })
+          : ''
+
       return template(changeTemplate, {
         $TITLE: escapeTitle(processedTitle),
         $NUMBER: prNumber,
         $AUTHOR: item.author || 'ghost',
         $SHA: item.shortSha || '',
-        $SCOPE: scopePrefix,
+        $SCOPE: renderedScope,
         $URL:
           prNumber && repoInfo.owner && repoInfo.repo
             ? `https://github.com/${repoInfo.owner}/${repoInfo.repo}/pull/${prNumber}`

--- a/test/semantic-commits.test.js
+++ b/test/semantic-commits.test.js
@@ -535,6 +535,7 @@ describe('ReleaseChangeLineItems', () => {
       const config = {
         ...defaultConfig,
         'change-template': '* $SCOPE$TITLE',
+        'scope-template': '$SCOPE: ',
       }
 
       const result = collection.renderWithConfig(config)
@@ -548,6 +549,7 @@ describe('ReleaseChangeLineItems', () => {
       const config = {
         ...defaultConfig,
         'change-template': '* $SCOPE$TITLE',
+        'scope-template': '$SCOPE: ',
       }
 
       const result = collection.renderWithConfig(config)
@@ -564,6 +566,7 @@ describe('ReleaseChangeLineItems', () => {
       const config = {
         ...defaultConfig,
         'change-template': '* $SCOPE$TITLE',
+        'scope-template': '$SCOPE: ',
       }
 
       const result = collection.renderWithConfig(config)
@@ -578,6 +581,7 @@ describe('ReleaseChangeLineItems', () => {
       const config = {
         ...defaultConfig,
         'change-template': '* $SCOPE$TITLE',
+        'scope-template': '$SCOPE: ',
       }
 
       const result = collection.renderWithConfig(config)
@@ -598,10 +602,40 @@ describe('ReleaseChangeLineItems', () => {
       const config = {
         ...defaultConfig,
         'change-template': '* $SCOPE$TITLE (#$NUMBER) $SHA',
+        'scope-template': '$SCOPE: ',
       }
 
       const result = collection.renderWithConfig(config)
       expect(result).toContain('* registry: Add delete command (#42) abc123d')
+    })
+
+    test('scope-template supports custom formatting', () => {
+      const commits = createMockCommits([
+        'feat(registry): add delete command',
+        'fix: resolve bug',
+      ])
+      const collection = ReleaseChangeLineItems.fromCommits(commits)
+      const config = {
+        ...defaultConfig,
+        'change-template': '* $SCOPE$TITLE',
+        'scope-template': '[$SCOPE] ',
+      }
+
+      const result = collection.renderWithConfig(config)
+      expect(result).toContain('* [registry] Add delete command')
+      expect(result).toContain('* Resolve bug')
+    })
+
+    test('$SCOPE without scope-template renders empty', () => {
+      const commits = createMockCommits(['feat(registry): add delete command'])
+      const collection = ReleaseChangeLineItems.fromCommits(commits)
+      const config = {
+        ...defaultConfig,
+        'change-template': '* $SCOPE$TITLE',
+      }
+
+      const result = collection.renderWithConfig(config)
+      expect(result).toContain('* Add delete command')
     })
 
     test('always applies sentence-case to titles', () => {


### PR DESCRIPTION
## Summary

Fixes the `$SCOPE` template variable so that scope formatting is fully customizable via a new `scope-template` config option, following the existing `*-template` pattern (`name-template`, `tag-template`, `category-template`).

**Before (v1.2.0):** `$SCOPE` baked in the `": "` suffix, so `change-template: '* $SCOPE: $TITLE'` produced double colons (`* registry: : Title`).

**After:** `$SCOPE` in `change-template` is rendered through `scope-template`. When scope is present, `scope-template` is evaluated with the raw lowercase scope value; when absent, `$SCOPE` resolves to `""`. Scope rendering is **opt-in** — users must explicitly set `scope-template` to enable it.

Example config:
```yaml
change-template: '* $SCOPE$TITLE (#$NUMBER)'
scope-template: '$SCOPE: '
```
- `feat(registry): add command` → `* registry: Add command (#600)`
- `feat(cli,mcp): stuff` → `* cli, mcp: Stuff (#601)`  
- `fix: resolve bug` → `* Resolve bug (#602)`

Users can customize: `'[$SCOPE] '`, `'$SCOPE/ '`, etc.

**Files changed:** `default-config.js`, `schema.js`, `config.js` (new config plumbing), `semantic-commits.js` (core rendering logic), `action.yml` (docs), tests, integration test workflow, `dist/index.js` (rebuilt).

### Updates since last revision

- **Fixed trailing whitespace trimming**: `core.getInput()` strips whitespace by default, which turned `'$SCOPE: '` into `'$SCOPE:'` (missing trailing space). Fixed by passing `{ trimWhitespace: false }` for the `scope-template` input specifically. This was caught by the `scope-template-variable` integration test failing in CI.
- **Changed default `scope-template` from `'$SCOPE: '` to `''` (empty)**: Scope rendering is now opt-in. Users must explicitly set `scope-template` to get scope prefixes in their release notes. This is safer — adding `$SCOPE` to `change-template` without configuring `scope-template` won't produce unexpected output.

## Review & Testing Checklist for Human

- [ ] **Verify opt-in default behavior is correct**: With `scope-template` defaulting to `''`, any existing configs that use `$SCOPE` in `change-template` without explicitly setting `scope-template` will render `$SCOPE` as an empty string. Confirm this is acceptable (there are no known users of `$SCOPE` yet besides the downstream airbyte-ops-mcp PR, which explicitly sets `scope-template`).
- [ ] **Verify `trimWhitespace: false` is only needed for `scope-template`**: Other template inputs (`change-template`, `name-template`, etc.) still use default trimming. Confirm no other template inputs rely on significant trailing/leading whitespace.
- [ ] **Confirm `$SCOPE` variable name reuse is clear enough**: `$SCOPE` means "raw scope" inside `scope-template` but "rendered scope-template output" inside `change-template`. Two separate `template()` calls handle this, but verify the docs in `action.yml` make this unambiguous.
- [ ] **Verify the integration test `scope-template-variable` matrix job passes** — this is the end-to-end proof that the feature works correctly with the action runner. Note: this test explicitly sets `scope-template: '$SCOPE: '`, so it does not exercise the empty-default path.

**Recommended test plan:** After merging, create a test release in a repo with mixed scoped/unscoped commits and confirm release notes render correctly. Also verify that omitting `scope-template` causes `$SCOPE` to resolve to empty string (opt-in behavior).

### Notes
- The downstream PR (airbytehq/airbyte-ops-mcp#542) explicitly sets `scope-template: '$SCOPE: '`, so it is unaffected by the default change.
- Default `scope-template` is `''` (disabled). Users must explicitly configure it to enable scope rendering.

Link to Devin session: https://app.devin.ai/sessions/bfacd1050f404f3580bbd2af0f0c58ca
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aaronsteers/semantic-pr-release-drafter/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
