### PR TITLE
ci: draft demo project releases

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -12,11 +12,33 @@ permissions:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        release:
+          - name: release
+            config-name: release-drafter.yml
+          - name: demo-project/package-a
+            config-name: release-drafter-package-a.yml
+            config-source: demo-project/release-drafter-package-a.yml
+          - name: demo-project/package-b
+            config-name: release-drafter-package-b.yml
+            config-source: demo-project/release-drafter-package-b.yml
+          - name: demo-project/existing-project
+            config-name: release-drafter-demo-existing-project.yml
+            config-source: demo-project/release-drafter.yml
+    name: Draft release (${{ matrix.release.name }})
     steps:
       - uses: actions/checkout@v4
 
+      - name: Copy demo release config
+        if: matrix.release.config-source != ''
+        run: cp "${{ matrix.release.config-source }}" ".github/${{ matrix.release.config-name }}"
+
       # Use local action (dogfooding)
       - uses: ./
+        with:
+          config-name: ${{ matrix.release.config-name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # The following config is commented out because it now matches the defaults.


### PR DESCRIPTION
## Summary
- Update the real `Release Drafter` workflow to run a matrix of release-drafter invocations instead of only the default repo release.
- Keep the normal repo draft on `.github/release-drafter.yml`.
- Copy the inert `demo-project` fixture configs into the root `.github` directory during the workflow run, then invoke the action with each copied config so it drafts releases for:
  - `demo-project/package-a`
  - `demo-project/package-b`
  - `demo-project/existing-project`

## Review & Testing Checklist for Human
- [ ] Confirm the matrix entries are the expected real post-merge drafts for the demo project packages.
- [ ] Confirm copying fixture configs into `.github` at runtime is acceptable for dogfooding without committing active root configs.
- [ ] After merge, verify the `Release Drafter` workflow creates/updates the expected draft releases.

### Notes
Post-merge finding from PR 45: the `Release Drafter` workflow succeeded, but only created the default `v1.3.1` draft because it had a single action invocation and no matrix entries for the demo configs.

Local checks passed:
- `yarn prettier`
- `yarn lint`
- `yarn build`
- `git diff --check`

Link to Devin session: https://app.devin.ai/sessions/1c4ee1b4df794a289f1c5d78190cb3e2
Requested by: @aaronsteers