### PR TITLE
feat!: add release tag template variables, add release notes history link, (!) move footer links to footer template

### DIFF
--- a/.github/workflows/e2e-smoke-tests.yml
+++ b/.github/workflows/e2e-smoke-tests.yml
@@ -151,7 +151,7 @@ jobs:
 
               ---
 
-              See also: [Full Release Notes (v1.x family)](https://github.com/aaronsteers/semantic-pr-release-drafter/releases?q=tag:v1) | [Full Changelog (v1.0.0...v1.1.0)](https://github.com/aaronsteers/semantic-pr-release-drafter/compare/v1.0.0...v1.1.0)
+              _See also: [Full Release Notes (v1.x family)](https://github.com/aaronsteers/semantic-pr-release-drafter/releases?q=tag:v1) | [Full Changelog (v1.0.0...v1.1.0)](https://github.com/aaronsteers/semantic-pr-release-drafter/compare/v1.0.0...v1.1.0)_
             # No template, change-template, category-template, or categories provided
             # This tests the zero-config path
 

--- a/.github/workflows/e2e-smoke-tests.yml
+++ b/.github/workflows/e2e-smoke-tests.yml
@@ -151,7 +151,7 @@ jobs:
 
               ---
 
-              **Full Changelog**: https://github.com/aaronsteers/semantic-pr-release-drafter/compare/v1.0.0...v1.1.0
+              See also: [Full Release Notes (v1.x family)](https://github.com/aaronsteers/semantic-pr-release-drafter/releases?q=tag:v1) | [Full Changelog (v1.0.0...v1.1.0)](https://github.com/aaronsteers/semantic-pr-release-drafter/compare/v1.0.0...v1.1.0)
             # No template, change-template, category-template, or categories provided
             # This tests the zero-config path
 

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -42,7 +42,7 @@ jobs:
         #
         #     ---
         #
-        #     **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+        #     See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)
         #   change-template: '* $TITLE ($URL) $SHA'
         #   categories: |
         #     - title: '⚠️ Breaking Changes'

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -41,8 +41,8 @@ jobs:
         #     $CHANGES
         #
         #     ---
-        #
-        #     See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)
+        #   footer: |
+        #     _See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)_
         #   change-template: '* $TITLE ($URL) $SHA'
         #   categories: |
         #     - title: '⚠️ Breaking Changes'

--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ jobs:
             $CHANGES
 
             ---
-
-            See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)
+          footer: |
+            _See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)_
           categories: |
             - title: 'Breaking Changes'
               commit-types:
@@ -243,8 +243,8 @@ template: |
   $CHANGES
 
   ---
-
-  See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)
+footer: |
+  _See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)_
 change-template: '* $TITLE (#$NUMBER)'
 category-template: '## $TITLE'
 categories:
@@ -275,8 +275,8 @@ template: |
   $CHANGES
 
   ---
-
-  See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)
+footer: |
+  _See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)_
 change-template: '* $TITLE (#$NUMBER)'
 category-template: '## $TITLE'
 categories:
@@ -420,16 +420,16 @@ Release Drafter also supports [Probot Config](https://github.com/probot/probot-c
 
 You can use any of the following variables in your `template`, `header` and `footer`:
 
-| Variable              | Description                                                                                                           |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `$CHANGES`            | The markdown list of pull requests that have been merged.                                                             |
-| `$CONTRIBUTORS`       | A comma separated list of contributors to this release (pull request authors, commit authors, and commit committers). |
-| `$PREVIOUS_TAG`       | The previous releases’s tag.                                                                                          |
-| `$REPOSITORY`         | Current Repository.                                                                                                   |
-| `$OWNER`              | Current Repository Owner.                                                                                             |
-| `$TAG_PREFIX`         | The configured `tag-prefix`, such as `v` or `dummy-project-a/v`.                                                      |
-| `$RESOLVED_TAG`       | The resolved tag for the release after rendering `tag-template`.                                                      |
-| `$RESOLVED_MAJOR_TAG` | The configured `tag-prefix` plus the resolved major version, such as `v1` or `dummy-project-a/v0`.                    |
+| Variable              | Description                                                                                                               |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `$CHANGES`            | The markdown list of pull requests that have been merged.                                                                 |
+| `$CONTRIBUTORS`       | A comma separated list of contributors to this release (pull request authors, commit authors, and commit committers).     |
+| `$PREVIOUS_TAG`       | The previous releases’s tag.                                                                                              |
+| `$REPOSITORY`         | Current Repository.                                                                                                       |
+| `$OWNER`              | Current Repository Owner.                                                                                                 |
+| `$TAG_PREFIX`         | The effective tag prefix from configured `tag-prefix` or derived from `tag-template`, such as `v` or `dummy-project-a/v`. |
+| `$RESOLVED_TAG`       | The resolved tag for the release after rendering `tag-template`.                                                          |
+| `$RESOLVED_MAJOR_TAG` | The effective tag prefix plus the resolved major version, such as `v1` or `dummy-project-a/v0`.                           |
 
 ## Category Template Variables
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ jobs:
 
             ---
 
-            **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+            See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)
           categories: |
             - title: 'Breaking Changes'
               commit-types:
@@ -241,6 +241,10 @@ name-template: v$RESOLVED_VERSION
 tag-template: v$RESOLVED_VERSION
 template: |
   $CHANGES
+
+  ---
+
+  See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)
 change-template: '* $TITLE (#$NUMBER)'
 category-template: '## $TITLE'
 categories:
@@ -269,6 +273,10 @@ tag-prefix: dummy-project-a/v
 latest: 'false'
 template: |
   $CHANGES
+
+  ---
+
+  See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)
 change-template: '* $TITLE (#$NUMBER)'
 category-template: '## $TITLE'
 categories:
@@ -329,7 +337,7 @@ The [`dummy-project`](dummy-project/) directory contains fixture configs for one
 
 #### Filtering package releases in GitHub
 
-GitHub's Releases UI does not automatically group releases by tag namespace. To filter to one package's releases, type a tag query that exactly matches the package's tag prefix and includes at least the major-version precision you want to see:
+GitHub's Releases UI does not automatically group releases by tag namespace. To filter to one package's releases, type a tag query that exactly matches the package's tag prefix and includes at least the major-version precision you want to see. Release templates can use `$RESOLVED_MAJOR_TAG` to generate that query automatically.
 
 ```text
 tag:dummy-project-a/v0
@@ -412,13 +420,16 @@ Release Drafter also supports [Probot Config](https://github.com/probot/probot-c
 
 You can use any of the following variables in your `template`, `header` and `footer`:
 
-| Variable        | Description                                                                                                           |
-| --------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `$CHANGES`      | The markdown list of pull requests that have been merged.                                                             |
-| `$CONTRIBUTORS` | A comma separated list of contributors to this release (pull request authors, commit authors, and commit committers). |
-| `$PREVIOUS_TAG` | The previous releases’s tag.                                                                                          |
-| `$REPOSITORY`   | Current Repository                                                                                                    |
-| `$OWNER`        | Current Repository Owner                                                                                              |
+| Variable              | Description                                                                                                           |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `$CHANGES`            | The markdown list of pull requests that have been merged.                                                             |
+| `$CONTRIBUTORS`       | A comma separated list of contributors to this release (pull request authors, commit authors, and commit committers). |
+| `$PREVIOUS_TAG`       | The previous releases’s tag.                                                                                          |
+| `$REPOSITORY`         | Current Repository.                                                                                                   |
+| `$OWNER`              | Current Repository Owner.                                                                                             |
+| `$TAG_PREFIX`         | The configured `tag-prefix`, such as `v` or `dummy-project-a/v`.                                                      |
+| `$RESOLVED_TAG`       | The resolved tag for the release after rendering `tag-template`.                                                      |
+| `$RESOLVED_MAJOR_TAG` | The configured `tag-prefix` plus the resolved major version, such as `v1` or `dummy-project-a/v0`.                    |
 
 ## Category Template Variables
 
@@ -460,6 +471,8 @@ Version bumps are automatically determined based on semantic commit types:
 - **Breaking changes** (`feat!:`, `fix!:`, or commits with `BREAKING CHANGE:` in the body) - see below
 
 The `$RESOLVED_VERSION` variable reflects the calculated next version based on these rules.
+
+When `tag-prefix` is omitted, Release Drafter derives an effective tag prefix from the literal text before the first template variable in `tag-template`. For the default `tag-template: v$RESOLVED_VERSION`, the effective `$TAG_PREFIX` is `v`, so release selection and `$RESOLVED_MAJOR_TAG` stay scoped to unprefixed `v*` releases. Set `tag-prefix` explicitly for monorepo packages, such as `dummy-project-a/v`.
 
 ### Marketing-Aware Semver (Default Behavior)
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -146586,6 +146586,12 @@ var require_config = __commonJS({
       if (template) {
         overrides.template = template;
       }
+      const footer = core2.getInput("footer", {
+        trimWhitespace: false
+      });
+      if (footer) {
+        overrides.footer = footer;
+      }
       const scopeTemplate = core2.getInput("scope-template", {
         trimWhitespace: false
       });
@@ -146612,7 +146618,7 @@ var require_config = __commonJS({
       return overrides;
     }
     function hasInlineConfig() {
-      return core2.getInput("name-template") || core2.getInput("tag-template") || core2.getInput("change-template") || core2.getInput("template") || core2.getInput("scope-template") || core2.getInput("category-template") || core2.getInput("categories");
+      return core2.getInput("name-template") || core2.getInput("tag-template") || core2.getInput("change-template") || core2.getInput("template") || core2.getInput("footer") || core2.getInput("scope-template") || core2.getInput("category-template") || core2.getInput("categories");
     }
     async function getConfig({ context, configName, localGitRoot }) {
       try {
@@ -146676,6 +146682,9 @@ var require_config = __commonJS({
             ).join(", ")}`
           });
           repoConfig = { ...repoConfig, ...inlineOverrides };
+        }
+        if (Object.prototype.hasOwnProperty.call(repoConfig, "template") && !Object.prototype.hasOwnProperty.call(repoConfig, "footer")) {
+          repoConfig.footer = "";
         }
         const config = validateSchema(context, repoConfig);
         return config;

--- a/dist/index.js
+++ b/dist/index.js
@@ -146300,7 +146300,9 @@ var require_default_config = __commonJS({
     ];
     var DEFAULT_TEMPLATE = `$CHANGES
 
----`;
+---
+
+`;
     var DEFAULT_FOOTER = `_See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)_`;
     var DEFAULT_CONFIG = Object.freeze({
       "name-template": "v$RESOLVED_VERSION",

--- a/dist/index.js
+++ b/dist/index.js
@@ -146302,7 +146302,7 @@ var require_default_config = __commonJS({
 
 ---
 
-**Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION`;
+See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)`;
     var DEFAULT_CONFIG = Object.freeze({
       "name-template": "v$RESOLVED_VERSION",
       "tag-template": "v$RESOLVED_VERSION",
@@ -148820,6 +148820,23 @@ var require_versions = __commonJS({
   }
 });
 
+// lib/tag-prefix.js
+var require_tag_prefix = __commonJS({
+  "lib/tag-prefix.js"(exports2, module2) {
+    var templateVariablePattern = /\$[A-Z][\dA-Z_]*/g;
+    var getEffectiveTagPrefix = (config) => {
+      if (config["tag-prefix"]) {
+        return config["tag-prefix"];
+      }
+      const tagTemplate = config["tag-template"] || "";
+      return tagTemplate.split(templateVariablePattern)[0];
+    };
+    module2.exports = {
+      getEffectiveTagPrefix
+    };
+  }
+});
+
 // lib/semantic-commits.js
 var require_semantic_commits = __commonJS({
   "lib/semantic-commits.js"(exports2) {
@@ -149352,6 +149369,7 @@ var require_releases = __commonJS({
     var { getVersionInfo } = require_versions();
     var { template } = require_template2();
     var { log } = require_log3();
+    var { getEffectiveTagPrefix } = require_tag_prefix();
     var {
       resolveVersionBumpFromCommits,
       ReleaseChangeLineItems
@@ -149500,6 +149518,7 @@ var require_releases = __commonJS({
       targetCommitish
     }) => {
       const { owner, repo } = context.repo();
+      const tagPrefix = getEffectiveTagPrefix(config);
       let body = config["header"] + config.template + config["footer"];
       body = template(
         body,
@@ -149530,7 +149549,7 @@ var require_releases = __commonJS({
         // Falls back to tag or name for backwards compatibility
         overrideVersion || tag || name,
         versionKeyIncrement,
-        config["tag-prefix"],
+        tagPrefix,
         config["prerelease-identifier"],
         // draftVersion: from draft release (acts as floor vs computed)
         draftVersion
@@ -149547,6 +149566,14 @@ var require_releases = __commonJS({
         tag = template(tag, versionInfo);
       }
       core2.debug("tag: " + tag);
+      if (versionInfo) {
+        const tagInfo = {
+          $TAG_PREFIX: tagPrefix,
+          $RESOLVED_TAG: tag,
+          $RESOLVED_MAJOR_TAG: `${tagPrefix}${versionInfo.$RESOLVED_VERSION.$MAJOR}`
+        };
+        body = template(body, tagInfo);
+      }
       if (name === void 0) {
         name = versionInfo ? template(config["name-template"] || "", versionInfo) : "";
       } else if (versionInfo) {
@@ -153198,6 +153225,7 @@ var require_index = __commonJS({
       resolveFiles,
       deleteAllReleaseAssets
     } = require_assets();
+    var { getEffectiveTagPrefix } = require_tag_prefix();
     var semver = require_semver4();
     module2.exports = (app, { getRouter }) => {
       if (!runnerIsActions() && typeof getRouter === "function") {
@@ -153223,10 +153251,10 @@ var require_index = __commonJS({
           "filter-by-commitish": filterByCommitish,
           "include-pre-releases": includePreReleases,
           "prerelease-identifier": preReleaseIdentifier,
-          "tag-prefix": tagPrefix,
           latest,
           prerelease
         } = config;
+        const tagPrefix = getEffectiveTagPrefix(config);
         const shouldIncludePreReleases = Boolean(
           includePreReleases || preReleaseIdentifier
         );

--- a/dist/index.js
+++ b/dist/index.js
@@ -146300,9 +146300,8 @@ var require_default_config = __commonJS({
     ];
     var DEFAULT_TEMPLATE = `$CHANGES
 
----
-
-See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)`;
+---`;
+    var DEFAULT_FOOTER = `_See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)_`;
     var DEFAULT_CONFIG = Object.freeze({
       "name-template": "v$RESOLVED_VERSION",
       "tag-template": "v$RESOLVED_VERSION",
@@ -146334,7 +146333,7 @@ See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com
       "scope-template": "",
       "category-template": "## $TITLE",
       header: "",
-      footer: ""
+      footer: DEFAULT_FOOTER
     });
     exports2.DEFAULT_CONFIG = DEFAULT_CONFIG;
   }

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const {
   resolveFiles,
   deleteAllReleaseAssets,
 } = require('./lib/assets')
+const { getEffectiveTagPrefix } = require('./lib/tag-prefix')
 const semver = require('semver')
 
 module.exports = (app, { getRouter }) => {
@@ -56,10 +57,10 @@ module.exports = (app, { getRouter }) => {
       'filter-by-commitish': filterByCommitish,
       'include-pre-releases': includePreReleases,
       'prerelease-identifier': preReleaseIdentifier,
-      'tag-prefix': tagPrefix,
       latest,
       prerelease,
     } = config
+    const tagPrefix = getEffectiveTagPrefix(config)
 
     const shouldIncludePreReleases = Boolean(
       includePreReleases || preReleaseIdentifier

--- a/lib/config.js
+++ b/lib/config.js
@@ -32,6 +32,13 @@ function getInlineConfigOverrides() {
     overrides.template = template
   }
 
+  const footer = core.getInput('footer', {
+    trimWhitespace: false,
+  })
+  if (footer) {
+    overrides.footer = footer
+  }
+
   const scopeTemplate = core.getInput('scope-template', {
     trimWhitespace: false,
   })
@@ -69,6 +76,7 @@ function hasInlineConfig() {
     core.getInput('tag-template') ||
     core.getInput('change-template') ||
     core.getInput('template') ||
+    core.getInput('footer') ||
     core.getInput('scope-template') ||
     core.getInput('category-template') ||
     core.getInput('categories')
@@ -145,6 +153,13 @@ async function getConfig({ context, configName, localGitRoot }) {
         ).join(', ')}`,
       })
       repoConfig = { ...repoConfig, ...inlineOverrides }
+    }
+
+    if (
+      Object.prototype.hasOwnProperty.call(repoConfig, 'template') &&
+      !Object.prototype.hasOwnProperty.call(repoConfig, 'footer')
+    ) {
+      repoConfig.footer = ''
     }
 
     const config = validateSchema(context, repoConfig)

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -47,9 +47,9 @@ const DEFAULT_CATEGORIES = [
 
 const DEFAULT_TEMPLATE = `$CHANGES
 
----
+---`
 
-See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)`
+const DEFAULT_FOOTER = `_See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)_`
 
 const DEFAULT_CONFIG = Object.freeze({
   'name-template': 'v$RESOLVED_VERSION',
@@ -82,7 +82,7 @@ const DEFAULT_CONFIG = Object.freeze({
   'scope-template': '',
   'category-template': '## $TITLE',
   header: '',
-  footer: '',
+  footer: DEFAULT_FOOTER,
 })
 
 exports.DEFAULT_CONFIG = DEFAULT_CONFIG

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -47,7 +47,9 @@ const DEFAULT_CATEGORIES = [
 
 const DEFAULT_TEMPLATE = `$CHANGES
 
----`
+---
+
+`
 
 const DEFAULT_FOOTER = `_See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)_`
 

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -49,7 +49,7 @@ const DEFAULT_TEMPLATE = `$CHANGES
 
 ---
 
-**Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION`
+See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)`
 
 const DEFAULT_CONFIG = Object.freeze({
   'name-template': 'v$RESOLVED_VERSION',

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -5,6 +5,7 @@ const core = require('@actions/core')
 const { getVersionInfo } = require('./versions')
 const { template } = require('./template')
 const { log } = require('./log')
+const { getEffectiveTagPrefix } = require('./tag-prefix')
 const {
   resolveVersionBumpFromCommits,
   ReleaseChangeLineItems,
@@ -202,6 +203,7 @@ const generateReleaseInfo = ({
   targetCommitish,
 }) => {
   const { owner, repo } = context.repo()
+  const tagPrefix = getEffectiveTagPrefix(config)
 
   let body = config['header'] + config.template + config['footer']
   body = template(
@@ -236,7 +238,7 @@ const generateReleaseInfo = ({
     // Falls back to tag or name for backwards compatibility
     overrideVersion || tag || name,
     versionKeyIncrement,
-    config['tag-prefix'],
+    tagPrefix,
     config['prerelease-identifier'],
     // draftVersion: from draft release (acts as floor vs computed)
     draftVersion
@@ -257,6 +259,15 @@ const generateReleaseInfo = ({
   }
 
   core.debug('tag: ' + tag)
+
+  if (versionInfo) {
+    const tagInfo = {
+      $TAG_PREFIX: tagPrefix,
+      $RESOLVED_TAG: tag,
+      $RESOLVED_MAJOR_TAG: `${tagPrefix}${versionInfo.$RESOLVED_VERSION.$MAJOR}`,
+    }
+    body = template(body, tagInfo)
+  }
 
   if (name === undefined) {
     name = versionInfo

--- a/lib/tag-prefix.js
+++ b/lib/tag-prefix.js
@@ -1,0 +1,14 @@
+const templateVariablePattern = /\$[A-Z][\dA-Z_]*/g
+
+const getEffectiveTagPrefix = (config) => {
+  if (config['tag-prefix']) {
+    return config['tag-prefix']
+  }
+
+  const tagTemplate = config['tag-template'] || ''
+  return tagTemplate.split(templateVariablePattern)[0]
+}
+
+module.exports = {
+  getEffectiveTagPrefix,
+}

--- a/schema.json
+++ b/schema.json
@@ -216,6 +216,10 @@
       },
       "additionalProperties": false
     },
+    "scope-template": {
+      "type": "string",
+      "default": ""
+    },
     "category-template": {
       "type": "string",
       "default": "## $TITLE"
@@ -229,7 +233,7 @@
     },
     "footer": {
       "type": "string",
-      "default": ""
+      "default": "_See also: [Full Release Notes ($RESOLVED_MAJOR_TAG.x family)](https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG) | [Full Changelog ($PREVIOUS_TAG...$RESOLVED_TAG)](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG)_"
     },
     "_extends": {
       "type": "string"

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -24,6 +24,7 @@ describe('getConfig', () => {
     expect(config).toEqual({
       ...DEFAULT_CONFIG,
       template: '$CHANGES',
+      footer: '',
       references: ['master'],
     })
   })

--- a/test/fixtures/config/config-with-release-family-template-vars.yml
+++ b/test/fixtures/config/config-with-release-family-template-vars.yml
@@ -7,3 +7,4 @@ template: |
   Major tag: $RESOLVED_MAJOR_TAG
   Releases: https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG
   Compare: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG
+footer: ''

--- a/test/fixtures/config/config-with-release-family-template-vars.yml
+++ b/test/fixtures/config/config-with-release-family-template-vars.yml
@@ -1,0 +1,9 @@
+name-template: 'static-tag-prefix-v$RESOLVED_VERSION 🌈'
+tag-template: 'static-tag-prefix-v$RESOLVED_VERSION'
+tag-prefix: static-tag-prefix-v
+template: |
+  Prefix: $TAG_PREFIX
+  Resolved tag: $RESOLVED_TAG
+  Major tag: $RESOLVED_MAJOR_TAG
+  Releases: https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG
+  Compare: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG

--- a/test/fixtures/config/config-with-tag-prefix.yml
+++ b/test/fixtures/config/config-with-tag-prefix.yml
@@ -5,3 +5,4 @@ template: |
   ## Previous release
 
   $PREVIOUS_TAG
+footer: ''

--- a/test/fixtures/config/config-with-unprefixed-release-family-template-vars.yml
+++ b/test/fixtures/config/config-with-unprefixed-release-family-template-vars.yml
@@ -1,0 +1,8 @@
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
+template: |
+  Prefix: $TAG_PREFIX
+  Resolved tag: $RESOLVED_TAG
+  Major tag: $RESOLVED_MAJOR_TAG
+  Releases: https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG
+  Compare: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG

--- a/test/fixtures/config/config-with-unprefixed-release-family-template-vars.yml
+++ b/test/fixtures/config/config-with-unprefixed-release-family-template-vars.yml
@@ -6,3 +6,4 @@ template: |
   Major tag: $RESOLVED_MAJOR_TAG
   Releases: https://github.com/$OWNER/$REPOSITORY/releases?q=tag:$RESOLVED_MAJOR_TAG
   Compare: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_TAG
+footer: ''

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3360,6 +3360,88 @@ describe('release-drafter', () => {
 
         expect.assertions(1)
       })
+
+      it('renders release-family template variables for prefixed tags', async () => {
+        getConfigMock('config-with-release-family-template-vars.yml')
+        const alteredReleasePayload = {
+          ...releasePayload,
+          tag_name: 'static-tag-prefix-v2.1.4',
+        }
+
+        nock('https://api.github.com')
+          .post('/graphql', (body) =>
+            body.query.includes('query findCommitsWithAssociatedPullRequests')
+          )
+          .reply(200, graphqlCommitsNoPRsPayload)
+
+        nock('https://api.github.com')
+          .get('/repos/toolmantim/release-drafter-test-project/releases')
+          .query(true)
+          .reply(200, [alteredReleasePayload])
+          .post(
+            '/repos/toolmantim/release-drafter-test-project/releases',
+            (body) => {
+              expect(body).toMatchObject({
+                body:
+                  'Prefix: static-tag-prefix-v\n' +
+                  'Resolved tag: static-tag-prefix-v2.1.5\n' +
+                  'Major tag: static-tag-prefix-v2\n' +
+                  'Releases: https://github.com/toolmantim/release-drafter-test-project/releases?q=tag:static-tag-prefix-v2\n' +
+                  'Compare: https://github.com/toolmantim/release-drafter-test-project/compare/static-tag-prefix-v2.1.4...static-tag-prefix-v2.1.5\n',
+                name: 'static-tag-prefix-v2.1.5 🌈',
+                tag_name: 'static-tag-prefix-v2.1.5',
+              })
+              return true
+            }
+          )
+          .reply(200, alteredReleasePayload)
+
+        await probot.receive({
+          name: 'push',
+          payload: pushPayload,
+        })
+
+        expect.assertions(1)
+      })
+
+      it('renders release-family template variables for unprefixed v tags', async () => {
+        getConfigMock('config-with-unprefixed-release-family-template-vars.yml')
+
+        nock('https://api.github.com')
+          .post('/graphql', (body) =>
+            body.query.includes('query findCommitsWithAssociatedPullRequests')
+          )
+          .reply(200, graphqlCommitsNoPRsPayload)
+
+        nock('https://api.github.com')
+          .get('/repos/toolmantim/release-drafter-test-project/releases')
+          .query(true)
+          .reply(200, [releasePayload])
+          .post(
+            '/repos/toolmantim/release-drafter-test-project/releases',
+            (body) => {
+              expect(body).toMatchObject({
+                body:
+                  'Prefix: v\n' +
+                  'Resolved tag: v2.0.1\n' +
+                  'Major tag: v2\n' +
+                  'Releases: https://github.com/toolmantim/release-drafter-test-project/releases?q=tag:v2\n' +
+                  'Compare: https://github.com/toolmantim/release-drafter-test-project/compare/v2.0.0...v2.0.1\n',
+                name: 'v2.0.1 🌈',
+                tag_name: 'v2.0.1',
+              })
+              return true
+            }
+          )
+          .reply(200, releasePayload)
+
+        await probot.receive({
+          name: 'push',
+          payload: pushPayload,
+        })
+
+        expect.assertions(1)
+      })
     })
 
     describe('with custom version resolver', () => {


### PR DESCRIPTION
## Summary
Adds release-tag template variables for monorepo-friendly release notes and makes the default `v$RESOLVED_VERSION` tag template behave as an effective `v` tag prefix when `tag-prefix` is omitted.

Changes:
- Adds `$TAG_PREFIX`, `$RESOLVED_TAG`, and `$RESOLVED_MAJOR_TAG` for `template`, `header`, and `footer` rendering.
- Derives an effective tag prefix from explicit `tag-prefix`, or from the literal prefix in `tag-template` when `tag-prefix` is omitted.
- Uses the effective prefix for release filtering and version coercion, so default `v*` projects do not accidentally consider package-prefixed tags.
- Updates the default footer to a one-line “See also” block with major-family release notes and compare changelog links.
- Documents the new variables and adds prefixed/unprefixed tests.
- Updates the zero-config smoke-test expectation for the new default footer.

## Review & Testing Checklist for Human
- [ ] Confirm the effective-prefix behavior is acceptable for existing configs that omit `tag-prefix` but use a literal prefix in `tag-template`.
- [ ] Confirm the default footer wording/link format is desired upstream.

### Notes
Local verification:
- `yarn --cwd /home/ubuntu/repos/semantic-pr-release-drafter --ignore-engines lint`
- `yarn --cwd /home/ubuntu/repos/semantic-pr-release-drafter --ignore-engines test --runInBand test/index.test.js -t "tag-prefix"`
- `yarn --cwd /home/ubuntu/repos/semantic-pr-release-drafter --ignore-engines test --runInBand test/index.test.js -t "multiple existing draft releases"`

Used `--ignore-engines` because the VM has Node 20.19.0 while this repo declares Node >=24.

CI is currently green on this PR, including `check-dist` and the zero-config smoke test.

---
[Devin session](https://app.devin.ai/sessions/1c4ee1b4df794a289f1c5d78190cb3e2)

Requested by: @aaronsteers