### PR TITLE
fix: prevent draft version from overriding semantic version bump

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -148801,7 +148801,7 @@ var require_versions = __commonJS({
       const templatableVersion = getTemplatableVersion({
         version: version2,
         template,
-        inputVersion: inputVersion || draftVersion,
+        inputVersion: inputVersion || (!version2 ? draftVersion : void 0),
         versionKeyIncrement,
         preReleaseIdentifier
       });

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -287,10 +287,13 @@ const getVersionInfo = (
     versionKeyIncrement = 'prerelease'
   }
 
+  // Only fall back to draftVersion when there's no last release to compute
+  // increments from. When a last release exists, the semantic bump from commits
+  // should determine the version; draftVersion is applied later as a floor.
   const templatableVersion = getTemplatableVersion({
     version,
     template,
-    inputVersion: inputVersion || draftVersion,
+    inputVersion: inputVersion || (!version ? draftVersion : undefined),
     versionKeyIncrement,
     preReleaseIdentifier,
   })

--- a/test/versions.test.js
+++ b/test/versions.test.js
@@ -226,4 +226,66 @@ describe('versions', () => {
     expect(versionInfo.$RESOLVED_VERSION.version).toEqual('0.1.0')
     expect(versionInfo.$NEXT_PATCH_VERSION.version).toEqual('0.1.1')
   })
+
+  it('semantic minor bump is not overridden by a lower draft version', () => {
+    // Scenario: last release is v0.64.5, draft release is v0.64.6 (patch),
+    // but commits include feat → should bump minor to v0.65.0, not stay at v0.64.6
+    const versionInfo = getVersionInfo(
+      { tag_name: 'v0.64.5', name: 'v0.64.5' },
+      '$MAJOR.$MINOR.$PATCH',
+      undefined, // no explicit override
+      'minor', // semantic bump from feat commits
+      'v',
+      undefined,
+      '0.64.6' // draft release version (should NOT override)
+    )
+
+    expect(versionInfo.$RESOLVED_VERSION.version).toEqual('0.65.0')
+    expect(versionInfo.$INPUT_VERSION).toBeUndefined()
+  })
+
+  it('semantic patch bump is not overridden by a stale draft version', () => {
+    // Draft has same version as what patch bump would produce
+    const versionInfo = getVersionInfo(
+      { tag_name: 'v1.2.3', name: 'v1.2.3' },
+      '$MAJOR.$MINOR.$PATCH',
+      undefined,
+      'patch',
+      'v',
+      undefined,
+      '1.2.4' // draft matches computed patch
+    )
+
+    expect(versionInfo.$RESOLVED_VERSION.version).toEqual('1.2.4')
+  })
+
+  it('draft version acts as floor when higher than computed version', () => {
+    // Last release v1.0.0, semantic bump is patch → v1.0.1,
+    // but draft is at v1.2.0 (manually advanced) → should use v1.2.0 as floor
+    const versionInfo = getVersionInfo(
+      { tag_name: 'v1.0.0', name: 'v1.0.0' },
+      '$MAJOR.$MINOR.$PATCH',
+      undefined,
+      'patch',
+      'v',
+      undefined,
+      '1.2.0' // draft is higher than computed v1.0.1
+    )
+
+    expect(versionInfo.$RESOLVED_VERSION.version).toEqual('1.2.0')
+  })
+
+  it('explicit input version overrides both computed and draft versions', () => {
+    const versionInfo = getVersionInfo(
+      { tag_name: 'v0.64.5', name: 'v0.64.5' },
+      '$MAJOR.$MINOR.$PATCH',
+      '2.0.0', // explicit override
+      'patch',
+      'v',
+      undefined,
+      '0.64.6' // draft version (should be ignored)
+    )
+
+    expect(versionInfo.$RESOLVED_VERSION.version).toEqual('2.0.0')
+  })
 })


### PR DESCRIPTION
## Summary

When both a last release and a draft release exist, `getVersionInfo` passes `draftVersion` as the `inputVersion` fallback to `getTemplatableVersion`:

```js
// before (bug)
inputVersion: inputVersion || draftVersion
```

Inside `getTemplatableVersion`, any truthy `inputVersion` populates `$INPUT_VERSION`, which unconditionally overrides `$RESOLVED_VERSION`. This means the stale draft version (e.g. `0.64.6` from a prior patch-only run) replaces the semantic bump (e.g. `0.65.0` from `feat` commits).

The fix restricts the fallback so `draftVersion` is only used as `inputVersion` when there is no last release to compute increments from:

```js
// after (fix)
inputVersion: inputVersion || (!version ? draftVersion : undefined)
```

When a last release _does_ exist, the semantic bump determines the version, and the existing floor check still applies `draftVersion` afterward if it's higher than the computed version.

*Context:* This caused https://github.com/airbytehq/airbyte-ops-mcp/releases/tag/v0.64.6 to be a patch bump instead of a minor bump, despite 3 `feat` commits touching `include-paths`.

Link to Devin session: https://app.devin.ai/sessions/accf41118d334e39bb9af635e9f70550
Requested by: @aaronsteers