### PR TITLE
feat: add `not-ready` input for 3-step draft workflow with admin timestamp

### DIFF
--- a/.github/workflows/e2e-smoke-tests.yml
+++ b/.github/workflows/e2e-smoke-tests.yml
@@ -651,7 +651,7 @@ jobs:
           BODY=$(echo "$BODY" | sed -E 's/ [0-9a-f]{7}$//')
 
           # Strip the admin metadata comment (appended by the action on every run)
-          BODY=$(echo "$BODY" | sed '/^<!-- Release draft timestamp: .* -->$/d')
+          BODY=$(echo "$BODY" | sed '/^<!-- Release drafted at .* -->$/d')
 
           # Normalize whitespace for comparison (trim leading/trailing, normalize newlines)
           BODY_NORMALIZED=$(echo "$BODY" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr -s '\n')

--- a/.github/workflows/e2e-smoke-tests.yml
+++ b/.github/workflows/e2e-smoke-tests.yml
@@ -624,6 +624,9 @@ jobs:
           # Dry-run test repositories produce fresh SHAs on every run, so normalize them out.
           BODY=$(echo "$BODY" | sed -E 's/ [0-9a-f]{7}$//')
 
+          # Strip the admin timestamp comment (appended by the action on every run)
+          BODY=$(echo "$BODY" | sed '/^<!-- Release draft last updated: .* -->$/d')
+
           # Normalize whitespace for comparison (trim leading/trailing, normalize newlines)
           BODY_NORMALIZED=$(echo "$BODY" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr -s '\n')
           EXPECTED_NORMALIZED=$(echo "$EXPECTED_BODY" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr -s '\n')

--- a/.github/workflows/e2e-smoke-tests.yml
+++ b/.github/workflows/e2e-smoke-tests.yml
@@ -370,6 +370,31 @@ jobs:
             # Flag to indicate this test needs attach-files setup
             needs-attach-files: true
 
+          # Test not-ready input: banner is prepended to body
+          - test-name: 'not-ready-banner'
+            test-start-version-string: 'v1.0.0'
+            test-commit-list: |
+              feat: add new feature (#110)
+            expected-version-string: '1.1.0'
+            expected-body: |
+              > [!CAUTION]
+              > **NOT READY FOR PUBLISHING**
+              >
+              > This release draft is still being prepared. Do not publish until this banner is removed.
+
+              ## Features
+
+              * Add new feature (#110)
+            template: |
+              $CHANGES
+            change-template: '* $TITLE (#$NUMBER)'
+            category-template: '## $TITLE'
+            categories: |
+              - title: Features
+                commit-types:
+                  - feat
+            not-ready: 'true'
+
           # Test attach-files failure when no files match the pattern
           # Verifies that the action fails with a clear error message
           - test-name: 'attach-files-no-match-fails'
@@ -544,6 +569,7 @@ jobs:
           categories: ${{ matrix.categories }}
           attach-files: ${{ env.ATTACH_FILES_PATTERNS }}
           allow-major-bumps: ${{ matrix.allow-major-bumps }}
+          not-ready: ${{ matrix.not-ready }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -624,8 +650,8 @@ jobs:
           # Dry-run test repositories produce fresh SHAs on every run, so normalize them out.
           BODY=$(echo "$BODY" | sed -E 's/ [0-9a-f]{7}$//')
 
-          # Strip the admin timestamp comment (appended by the action on every run)
-          BODY=$(echo "$BODY" | sed '/^<!-- Release draft last updated: .* -->$/d')
+          # Strip the admin metadata comment (appended by the action on every run)
+          BODY=$(echo "$BODY" | sed '/^<!-- Release draft timestamp: .* -->$/d')
 
           # Normalize whitespace for comparison (trim leading/trailing, normalize newlines)
           BODY_NORMALIZED=$(echo "$BODY" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr -s '\n')

--- a/README.md
+++ b/README.md
@@ -895,7 +895,7 @@ The `not-ready` input accepts `'true'` (default banner) or a custom string (used
 Every draft release body includes a hidden HTML comment with provenance metadata:
 
 ```html
-<!-- Release draft timestamp: 2025-01-15 4:00pm Pacific | Commit used in draft: https://github.com/owner/repo/commit/abc123 -->
+<!-- Release drafted at `2025-01-15 4:00pm Pacific` from https://github.com/owner/repo/commit/abc123 -->
 ```
 
 This is invisible in the rendered release notes but visible when editing the raw markdown, helping administrators verify when the draft was last updated and which commit was used.

--- a/README.md
+++ b/README.md
@@ -895,7 +895,7 @@ The `not-ready` input accepts `'true'` (default banner) or a custom string (used
 Every draft release body includes a hidden HTML comment with provenance metadata:
 
 ```html
-<!-- Release drafted at `2025-01-15 4:00pm Pacific` from https://github.com/owner/repo/commit/abc123 -->
+<!-- Release drafted at 2025-01-15 4:00pm Pacific from https://github.com/owner/repo/commit/abc123 -->
 ```
 
 This is invisible in the rendered release notes but visible when editing the raw markdown, helping administrators verify when the draft was last updated and which commit was used.

--- a/README.md
+++ b/README.md
@@ -857,6 +857,49 @@ In some cases, you may need to resolve the version string before building. In su
       dist/*.whl
 ```
 
+## 3-Step Immutable Release Workflow (`not-ready`)
+
+When building immutable releases that require assets to be attached before publishing, use the `not-ready` input to prevent premature publishing:
+
+```yaml
+# Step 1: Create draft with WIP banner
+- name: Create draft (not ready)
+  id: draft
+  uses: aaronsteers/semantic-pr-release-drafter@main
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    not-ready: true # or a custom message string
+
+# Step 2: Build and attach assets (banner still visible)
+- run: build-artifacts --version=${{ steps.draft.outputs.resolved-version }}
+- name: Attach assets
+  uses: aaronsteers/semantic-pr-release-drafter@main
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    not-ready: true
+    attach-files: dist/*.whl
+
+# Step 3: Remove WIP banner — draft is now ready to publish
+- name: Finalize draft
+  uses: aaronsteers/semantic-pr-release-drafter@main
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+The `not-ready` input accepts `'true'` (default banner) or a custom string (used as the banner message). When set, a visible `> [!CAUTION]` banner is prepended to the release body warning administrators not to publish.
+
+### Admin Timestamp
+
+Every draft release body includes a hidden HTML comment with provenance metadata:
+
+```html
+<!-- Release draft timestamp: 2025-01-15 4:00pm Pacific | Commit used in draft: https://github.com/owner/repo/commit/abc123 -->
+```
+
+This is invisible in the rendered release notes but visible when editing the raw markdown, helping administrators verify when the draft was last updated and which commit was used.
+
 ## Action Inputs
 
 See [action.yml](action.yml) for the full list of supported inputs and their descriptions.

--- a/README.md
+++ b/README.md
@@ -868,6 +868,7 @@ Since each run regenerates the body from scratch, calling the action without `no
 ```yaml
 # Step 1: Create draft with WIP banner
 - name: Create draft (not ready)
+  id: not-ready-draft
   uses: aaronsteers/semantic-pr-release-drafter@main
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -883,6 +884,8 @@ Since each run regenerates the body from scratch, calling the action without `no
   uses: aaronsteers/semantic-pr-release-drafter@main
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    version: ${{ steps.not-ready-draft.outputs.tag-name }}
 ```
 
 ### Pattern B: Release-drafter-managed uploads
@@ -890,7 +893,7 @@ Since each run regenerates the body from scratch, calling the action without `no
 ```yaml
 # Step 1: Create draft with WIP banner
 - name: Create draft (not ready)
-  id: draft
+  id: not-ready-draft
   uses: aaronsteers/semantic-pr-release-drafter@main
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -898,7 +901,7 @@ Since each run regenerates the body from scratch, calling the action without `no
     not-ready: true
 
 # Step 2: Build assets
-- run: build-artifacts --version=${{ steps.draft.outputs.resolved-version }}
+- run: build-artifacts --version=${{ steps.not-ready-draft.outputs.resolved-version }}
 
 # Step 3: Attach assets and finalize (no not-ready = banner removed)
 - name: Attach assets and finalize
@@ -906,6 +909,7 @@ Since each run regenerates the body from scratch, calling the action without `no
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
+    version: ${{ steps.not-ready-draft.outputs.tag-name }}
     attach-files: dist/*.whl
 ```
 

--- a/README.md
+++ b/README.md
@@ -857,9 +857,35 @@ In some cases, you may need to resolve the version string before building. In su
       dist/*.whl
 ```
 
-## 3-Step Immutable Release Workflow (`not-ready`)
+## Safe Release Workflow (`not-ready`)
 
-When building immutable releases that require assets to be attached before publishing, use the `not-ready` input to prevent premature publishing:
+Use the `not-ready` input to prevent admins from prematurely publishing a draft while assets are still being prepared. The `not-ready` input accepts `'true'` (default banner) or a custom string (used as the banner message). When set, a visible `> [!CAUTION]` banner is prepended to the release body.
+
+Since each run regenerates the body from scratch, calling the action without `not-ready` automatically removes the banner.
+
+### Pattern A: Third-party asset attacher
+
+```yaml
+# Step 1: Create draft with WIP banner
+- name: Create draft (not ready)
+  uses: aaronsteers/semantic-pr-release-drafter@main
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    not-ready: true
+
+# Step 2: Attach assets via third-party action (e.g. GoReleaser)
+- uses: goreleaser/goreleaser-action@v5
+  ...
+
+# Step 3: Regenerate draft without banner — ready to publish
+- name: Finalize draft
+  uses: aaronsteers/semantic-pr-release-drafter@main
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Pattern B: Release-drafter-managed uploads
 
 ```yaml
 # Step 1: Create draft with WIP banner
@@ -869,26 +895,19 @@ When building immutable releases that require assets to be attached before publi
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
-    not-ready: true # or a custom message string
+    not-ready: true
 
-# Step 2: Build and attach assets (banner still visible)
+# Step 2: Build assets
 - run: build-artifacts --version=${{ steps.draft.outputs.resolved-version }}
-- name: Attach assets
+
+# Step 3: Attach assets and finalize (no not-ready = banner removed)
+- name: Attach assets and finalize
   uses: aaronsteers/semantic-pr-release-drafter@main
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
-    not-ready: true
     attach-files: dist/*.whl
-
-# Step 3: Remove WIP banner — draft is now ready to publish
-- name: Finalize draft
-  uses: aaronsteers/semantic-pr-release-drafter@main
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
-
-The `not-ready` input accepts `'true'` (default banner) or a custom string (used as the banner message). When set, a visible `> [!CAUTION]` banner is prepended to the release body warning administrators not to publish.
 
 ### Admin Timestamp
 

--- a/action.yml
+++ b/action.yml
@@ -195,7 +195,7 @@ inputs:
       Typical 3-step workflow for immutable releases:
         1. Run with `not-ready: true` to create the draft with a WIP banner.
         2. Run with `not-ready: true` and `attach-files` to upload assets.
-        3. Run with `not-ready: false` to finalize the draft (banner removed).
+        3. Run with `not-ready: false` (or omitted) to finalize the draft (banner removed).
     required: false
     default: ''
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -192,10 +192,17 @@ inputs:
       will be shown as the banner message.
       Set to 'false' (or omit) to remove the banner.
 
-      Typical 3-step workflow for immutable releases:
-        1. Run with `not-ready: true` to create the draft with a WIP banner.
-        2. Run with `not-ready: true` and `attach-files` to upload assets.
-        3. Run with `not-ready: false` (or omitted) to finalize the draft (banner removed).
+      Usage patterns:
+
+        A. Third-party asset attacher (e.g. GoReleaser):
+          1. Run with `not-ready: true` to create/update the draft with a WIP banner.
+          2. (Attach assets via third-party action.)
+          3. Run without `not-ready` to regenerate the draft (banner removed).
+
+        B. Release-drafter-managed uploads:
+          1. Run with `not-ready: true` to create the draft with a WIP banner.
+          2. (Build assets via custom steps.)
+          3. Run with `attach-files` (without `not-ready`) to attach assets and finalize.
     required: false
     default: ''
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -184,6 +184,20 @@ inputs:
           otherwise keep them.
     required: false
     default: 'auto'
+  not-ready:
+    description: |
+      When truthy, prepends a visible "NOT READY" banner to the release body,
+      signaling to administrators that the draft should not be published yet.
+      Accepts 'true' for a default warning message, or a custom string that
+      will be shown as the banner message.
+      Set to 'false' (or omit) to remove the banner.
+
+      Typical 3-step workflow for immutable releases:
+        1. Run with `not-ready: true` to create the draft with a WIP banner.
+        2. Run with `not-ready: true` and `attach-files` to upload assets.
+        3. Run with `not-ready: false` to finalize the draft (banner removed).
+    required: false
+    default: ''
 outputs:
   id:
     description: The ID of the release that was created or updated.

--- a/dist/index.js
+++ b/dist/index.js
@@ -154466,7 +154466,7 @@ var require_index = __commonJS({
         const pacificTimestamp = formatPacificTimestamp(/* @__PURE__ */ new Date());
         const commitUrl = getCommitUrl();
         releaseInfo.body += `
-<!-- Release drafted at \`${pacificTimestamp}\`` + (commitUrl ? ` from ${commitUrl}` : "") + ` -->
+<!-- Release drafted at ${pacificTimestamp}` + (commitUrl ? ` from ${commitUrl}` : "") + ` -->
 `;
         if (dryRun) {
           log({

--- a/dist/index.js
+++ b/dist/index.js
@@ -19278,9 +19278,9 @@ var require_context = __commonJS({
   }
 });
 
-// node_modules/yallist/iterator.js
+// node_modules/probot/node_modules/yallist/iterator.js
 var require_iterator = __commonJS({
-  "node_modules/yallist/iterator.js"(exports2, module2) {
+  "node_modules/probot/node_modules/yallist/iterator.js"(exports2, module2) {
     "use strict";
     module2.exports = function(Yallist) {
       Yallist.prototype[Symbol.iterator] = function* () {
@@ -19292,9 +19292,9 @@ var require_iterator = __commonJS({
   }
 });
 
-// node_modules/yallist/yallist.js
+// node_modules/probot/node_modules/yallist/yallist.js
 var require_yallist = __commonJS({
-  "node_modules/yallist/yallist.js"(exports2, module2) {
+  "node_modules/probot/node_modules/yallist/yallist.js"(exports2, module2) {
     "use strict";
     module2.exports = Yallist;
     Yallist.Node = Node;
@@ -19661,9 +19661,9 @@ var require_yallist = __commonJS({
   }
 });
 
-// node_modules/lru-cache/index.js
+// node_modules/probot/node_modules/lru-cache/index.js
 var require_lru_cache = __commonJS({
-  "node_modules/lru-cache/index.js"(exports2, module2) {
+  "node_modules/probot/node_modules/lru-cache/index.js"(exports2, module2) {
     "use strict";
     var Yallist = require_yallist();
     var MAX = /* @__PURE__ */ Symbol("max");
@@ -52420,6 +52420,144 @@ var require_denque = __commonJS({
 var require_commands = __commonJS({
   "node_modules/@ioredis/commands/built/commands.json"(exports2, module2) {
     module2.exports = {
+      vadd: {
+        arity: -5,
+        flags: [
+          "write",
+          "denyoom",
+          "module"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      vcard: {
+        arity: 2,
+        flags: [
+          "readonly",
+          "module",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      vdim: {
+        arity: 2,
+        flags: [
+          "readonly",
+          "module",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      vemb: {
+        arity: -3,
+        flags: [
+          "readonly",
+          "module",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      vgetattr: {
+        arity: 3,
+        flags: [
+          "readonly",
+          "module",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      vinfo: {
+        arity: 2,
+        flags: [
+          "readonly",
+          "module",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      vismember: {
+        arity: 3,
+        flags: [
+          "readonly",
+          "module"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      vlinks: {
+        arity: -3,
+        flags: [
+          "readonly",
+          "module",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      vrandmember: {
+        arity: -2,
+        flags: [
+          "readonly",
+          "module"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      vrange: {
+        arity: -4,
+        flags: [
+          "readonly",
+          "module"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      vrem: {
+        arity: 3,
+        flags: [
+          "write",
+          "module"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      vsetattr: {
+        arity: 4,
+        flags: [
+          "write",
+          "module",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      vsim: {
+        arity: -4,
+        flags: [
+          "readonly",
+          "module"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
       acl: {
         arity: -2,
         flags: [],
@@ -52429,6 +52567,182 @@ var require_commands = __commonJS({
       },
       append: {
         arity: 3,
+        flags: [
+          "write",
+          "denyoom",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      arcount: {
+        arity: 2,
+        flags: [
+          "readonly",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      ardel: {
+        arity: -3,
+        flags: [
+          "write",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      ardelrange: {
+        arity: -4,
+        flags: [
+          "write"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      arget: {
+        arity: 3,
+        flags: [
+          "readonly",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      argetrange: {
+        arity: 4,
+        flags: [
+          "readonly"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      argrep: {
+        arity: -6,
+        flags: [
+          "readonly"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      arinfo: {
+        arity: -2,
+        flags: [
+          "readonly"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      arinsert: {
+        arity: -3,
+        flags: [
+          "write",
+          "denyoom",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      arlastitems: {
+        arity: -3,
+        flags: [
+          "readonly"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      arlen: {
+        arity: 2,
+        flags: [
+          "readonly",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      armget: {
+        arity: -3,
+        flags: [
+          "readonly",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      armset: {
+        arity: -4,
+        flags: [
+          "write",
+          "denyoom",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      arnext: {
+        arity: 2,
+        flags: [
+          "readonly",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      arop: {
+        arity: -5,
+        flags: [
+          "readonly"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      arring: {
+        arity: -4,
+        flags: [
+          "write",
+          "denyoom"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      arscan: {
+        arity: -4,
+        flags: [
+          "readonly"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      arseek: {
+        arity: 3,
+        flags: [
+          "write",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      arset: {
+        arity: -4,
         flags: [
           "write",
           "denyoom",
@@ -53117,10 +53431,20 @@ var require_commands = __commonJS({
         keyStop: 1,
         step: 1
       },
-      hpexpire: {
+      hexpireat: {
         arity: -6,
         flags: [
           "write",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      hexpiretime: {
+        arity: -5,
+        flags: [
+          "readonly",
           "fast"
         ],
         keyStart: 1,
@@ -53141,6 +53465,26 @@ var require_commands = __commonJS({
         arity: 2,
         flags: [
           "readonly"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      hgetdel: {
+        arity: -5,
+        flags: [
+          "write",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      hgetex: {
+        arity: -5,
+        flags: [
+          "write",
+          "fast"
         ],
         keyStart: 1,
         keyStop: 1,
@@ -53208,6 +53552,56 @@ var require_commands = __commonJS({
         keyStop: 1,
         step: 1
       },
+      hpersist: {
+        arity: -5,
+        flags: [
+          "write",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      hpexpire: {
+        arity: -6,
+        flags: [
+          "write",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      hpexpireat: {
+        arity: -6,
+        flags: [
+          "write",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      hpexpiretime: {
+        arity: -5,
+        flags: [
+          "readonly",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      hpttl: {
+        arity: -5,
+        flags: [
+          "readonly",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
       hrandfield: {
         arity: -2,
         flags: [
@@ -53237,6 +53631,17 @@ var require_commands = __commonJS({
         keyStop: 1,
         step: 1
       },
+      hsetex: {
+        arity: -6,
+        flags: [
+          "write",
+          "denyoom",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
       hsetnx: {
         arity: 4,
         flags: [
@@ -53250,6 +53655,16 @@ var require_commands = __commonJS({
       },
       hstrlen: {
         arity: 3,
+        flags: [
+          "readonly",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      httl: {
+        arity: -5,
         flags: [
           "readonly",
           "fast"
@@ -53291,6 +53706,17 @@ var require_commands = __commonJS({
       },
       incrbyfloat: {
         arity: 3,
+        flags: [
+          "write",
+          "denyoom",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
+      increx: {
+        arity: -2,
         flags: [
           "write",
           "denyoom",
@@ -53548,6 +53974,17 @@ var require_commands = __commonJS({
         keyStart: 1,
         keyStop: -1,
         step: 2
+      },
+      msetex: {
+        arity: -4,
+        flags: [
+          "write",
+          "denyoom",
+          "movablekeys"
+        ],
+        keyStart: 0,
+        keyStop: 0,
+        step: 0
       },
       msetnx: {
         arity: -3,
@@ -54512,6 +54949,16 @@ var require_commands = __commonJS({
         keyStop: 1,
         step: 1
       },
+      xnack: {
+        arity: -7,
+        flags: [
+          "write",
+          "fast"
+        ],
+        keyStart: 1,
+        keyStop: 1,
+        step: 1
+      },
       xpending: {
         arity: -3,
         flags: [
@@ -54981,6 +55428,13 @@ var require_built = __commonJS({
         case "zintercard":
         case "zdiff": {
           keys.push(...takeDynamicKeys(args, 0));
+          break;
+        }
+        case "msetex": {
+          const numKeys = Number(args[0]);
+          for (let i = 0; i < numKeys; i++) {
+            keys.push(1 + i * 2);
+          }
           break;
         }
         case "georadius": {
@@ -58846,9 +59300,9 @@ var require_ScanStream = __commonJS({
   }
 });
 
-// node_modules/p-map/index.js
+// node_modules/ioredis/node_modules/p-map/index.js
 var require_p_map = __commonJS({
-  "node_modules/p-map/index.js"(exports2, module2) {
+  "node_modules/ioredis/node_modules/p-map/index.js"(exports2, module2) {
     "use strict";
     var pMap = (iterable, mapper, options2) => new Promise((resolve, reject) => {
       options2 = Object.assign({
@@ -65940,162 +66394,9 @@ var require_dist_node6 = __commonJS({
   }
 });
 
-// node_modules/@octokit/core/node_modules/@octokit/request/dist-node/index.js
+// node_modules/@octokit/request/dist-node/index.js
 var require_dist_node7 = __commonJS({
-  "node_modules/@octokit/core/node_modules/@octokit/request/dist-node/index.js"(exports2) {
-    "use strict";
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    function _interopDefault(ex) {
-      return ex && typeof ex === "object" && "default" in ex ? ex["default"] : ex;
-    }
-    var endpoint = require_dist_node4();
-    var universalUserAgent = require_dist_node3();
-    var isPlainObject = require_is_plain_object();
-    var nodeFetch = _interopDefault(require_lib6());
-    var requestError = require_dist_node6();
-    var VERSION = "5.6.3";
-    function getBufferResponse(response) {
-      return response.arrayBuffer();
-    }
-    function fetchWrapper(requestOptions) {
-      const log = requestOptions.request && requestOptions.request.log ? requestOptions.request.log : console;
-      if (isPlainObject.isPlainObject(requestOptions.body) || Array.isArray(requestOptions.body)) {
-        requestOptions.body = JSON.stringify(requestOptions.body);
-      }
-      let headers = {};
-      let status;
-      let url;
-      const fetch2 = requestOptions.request && requestOptions.request.fetch || nodeFetch;
-      return fetch2(requestOptions.url, Object.assign(
-        {
-          method: requestOptions.method,
-          body: requestOptions.body,
-          headers: requestOptions.headers,
-          redirect: requestOptions.redirect
-        },
-        // `requestOptions.request.agent` type is incompatible
-        // see https://github.com/octokit/types.ts/pull/264
-        requestOptions.request
-      )).then(async (response) => {
-        url = response.url;
-        status = response.status;
-        for (const keyAndValue of response.headers) {
-          headers[keyAndValue[0]] = keyAndValue[1];
-        }
-        if ("deprecation" in headers) {
-          const matches = headers.link && headers.link.match(/<([^>]+)>; rel="deprecation"/);
-          const deprecationLink = matches && matches.pop();
-          log.warn(`[@octokit/request] "${requestOptions.method} ${requestOptions.url}" is deprecated. It is scheduled to be removed on ${headers.sunset}${deprecationLink ? `. See ${deprecationLink}` : ""}`);
-        }
-        if (status === 204 || status === 205) {
-          return;
-        }
-        if (requestOptions.method === "HEAD") {
-          if (status < 400) {
-            return;
-          }
-          throw new requestError.RequestError(response.statusText, status, {
-            response: {
-              url,
-              status,
-              headers,
-              data: void 0
-            },
-            request: requestOptions
-          });
-        }
-        if (status === 304) {
-          throw new requestError.RequestError("Not modified", status, {
-            response: {
-              url,
-              status,
-              headers,
-              data: await getResponseData(response)
-            },
-            request: requestOptions
-          });
-        }
-        if (status >= 400) {
-          const data = await getResponseData(response);
-          const error = new requestError.RequestError(toErrorMessage(data), status, {
-            response: {
-              url,
-              status,
-              headers,
-              data
-            },
-            request: requestOptions
-          });
-          throw error;
-        }
-        return getResponseData(response);
-      }).then((data) => {
-        return {
-          status,
-          url,
-          headers,
-          data
-        };
-      }).catch((error) => {
-        if (error instanceof requestError.RequestError) throw error;
-        throw new requestError.RequestError(error.message, 500, {
-          request: requestOptions
-        });
-      });
-    }
-    async function getResponseData(response) {
-      const contentType = response.headers.get("content-type");
-      if (/application\/json/.test(contentType)) {
-        return response.json();
-      }
-      if (!contentType || /^text\/|charset=utf-8$/.test(contentType)) {
-        return response.text();
-      }
-      return getBufferResponse(response);
-    }
-    function toErrorMessage(data) {
-      if (typeof data === "string") return data;
-      if ("message" in data) {
-        if (Array.isArray(data.errors)) {
-          return `${data.message}: ${data.errors.map(JSON.stringify).join(", ")}`;
-        }
-        return data.message;
-      }
-      return `Unknown error: ${JSON.stringify(data)}`;
-    }
-    function withDefaults(oldEndpoint, newDefaults) {
-      const endpoint2 = oldEndpoint.defaults(newDefaults);
-      const newApi = function(route, parameters) {
-        const endpointOptions = endpoint2.merge(route, parameters);
-        if (!endpointOptions.request || !endpointOptions.request.hook) {
-          return fetchWrapper(endpoint2.parse(endpointOptions));
-        }
-        const request2 = (route2, parameters2) => {
-          return fetchWrapper(endpoint2.parse(endpoint2.merge(route2, parameters2)));
-        };
-        Object.assign(request2, {
-          endpoint: endpoint2,
-          defaults: withDefaults.bind(null, endpoint2)
-        });
-        return endpointOptions.request.hook(request2, endpointOptions);
-      };
-      return Object.assign(newApi, {
-        endpoint: endpoint2,
-        defaults: withDefaults.bind(null, endpoint2)
-      });
-    }
-    var request = withDefaults(endpoint.endpoint, {
-      headers: {
-        "user-agent": `octokit-request.js/${VERSION} ${universalUserAgent.getUserAgent()}`
-      }
-    });
-    exports2.request = request;
-  }
-});
-
-// node_modules/@octokit/graphql/node_modules/@octokit/request/dist-node/index.js
-var require_dist_node8 = __commonJS({
-  "node_modules/@octokit/graphql/node_modules/@octokit/request/dist-node/index.js"(exports2) {
+  "node_modules/@octokit/request/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     function _interopDefault(ex) {
@@ -66247,11 +66548,11 @@ var require_dist_node8 = __commonJS({
 });
 
 // node_modules/@octokit/graphql/dist-node/index.js
-var require_dist_node9 = __commonJS({
+var require_dist_node8 = __commonJS({
   "node_modules/@octokit/graphql/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    var request = require_dist_node8();
+    var request = require_dist_node7();
     var universalUserAgent = require_dist_node3();
     var VERSION = "4.8.0";
     function _buildMessageForResponseErrors(data) {
@@ -66344,7 +66645,7 @@ var require_dist_node9 = __commonJS({
 });
 
 // node_modules/@octokit/auth-token/dist-node/index.js
-var require_dist_node10 = __commonJS({
+var require_dist_node9 = __commonJS({
   "node_modules/@octokit/auth-token/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -66390,15 +66691,15 @@ var require_dist_node10 = __commonJS({
 });
 
 // node_modules/@octokit/core/dist-node/index.js
-var require_dist_node11 = __commonJS({
+var require_dist_node10 = __commonJS({
   "node_modules/@octokit/core/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var universalUserAgent = require_dist_node3();
     var beforeAfterHook = require_before_after_hook();
     var request = require_dist_node7();
-    var graphql = require_dist_node9();
-    var authToken = require_dist_node10();
+    var graphql = require_dist_node8();
+    var authToken = require_dist_node9();
     function _objectWithoutPropertiesLoose(source, excluded) {
       if (source == null) return {};
       var target = {};
@@ -66533,7 +66834,7 @@ var require_dist_node11 = __commonJS({
 });
 
 // node_modules/@octokit/plugin-enterprise-compatibility/dist-node/index.js
-var require_dist_node12 = __commonJS({
+var require_dist_node11 = __commonJS({
   "node_modules/@octokit/plugin-enterprise-compatibility/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -66566,7 +66867,7 @@ var require_dist_node12 = __commonJS({
 });
 
 // node_modules/@octokit/plugin-paginate-rest/dist-node/index.js
-var require_dist_node13 = __commonJS({
+var require_dist_node12 = __commonJS({
   "node_modules/@octokit/plugin-paginate-rest/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -66719,7 +67020,7 @@ var require_dist_node13 = __commonJS({
 });
 
 // node_modules/@octokit/plugin-rest-endpoint-methods/dist-node/index.js
-var require_dist_node14 = __commonJS({
+var require_dist_node13 = __commonJS({
   "node_modules/@octokit/plugin-rest-endpoint-methods/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -69112,7 +69413,7 @@ var require_light = __commonJS({
 });
 
 // node_modules/@octokit/plugin-retry/dist-node/index.js
-var require_dist_node15 = __commonJS({
+var require_dist_node14 = __commonJS({
   "node_modules/@octokit/plugin-retry/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -69174,7 +69475,7 @@ var require_dist_node15 = __commonJS({
 });
 
 // node_modules/@octokit/plugin-throttling/dist-node/index.js
-var require_dist_node16 = __commonJS({
+var require_dist_node15 = __commonJS({
   "node_modules/@octokit/plugin-throttling/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -69402,19 +69703,18 @@ var require_common4 = __commonJS({
       return [sequence];
     }
     function extend(target, source) {
-      var index, length, key, sourceKeys;
       if (source) {
-        sourceKeys = Object.keys(source);
-        for (index = 0, length = sourceKeys.length; index < length; index += 1) {
-          key = sourceKeys[index];
+        const sourceKeys = Object.keys(source);
+        for (let index = 0, length = sourceKeys.length; index < length; index += 1) {
+          const key = sourceKeys[index];
           target[key] = source[key];
         }
       }
       return target;
     }
     function repeat(string, count) {
-      var result = "", cycle;
-      for (cycle = 0; cycle < count; cycle += 1) {
+      let result = "";
+      for (let cycle = 0; cycle < count; cycle += 1) {
         result += string;
       }
       return result;
@@ -69436,7 +69736,8 @@ var require_exception = __commonJS({
   "node_modules/js-yaml/lib/exception.js"(exports2, module2) {
     "use strict";
     function formatError(exception, compact) {
-      var where = "", message = exception.reason || "(unknown reason)";
+      let where = "";
+      const message = exception.reason || "(unknown reason)";
       if (!exception.mark) return message;
       if (exception.mark.name) {
         where += 'in "' + exception.mark.name + '" ';
@@ -69474,9 +69775,9 @@ var require_snippet = __commonJS({
     "use strict";
     var common = require_common4();
     function getLine(buffer, lineStart, lineEnd, position, maxLineLength) {
-      var head = "";
-      var tail = "";
-      var maxHalfLength = Math.floor(maxLineLength / 2) - 1;
+      let head = "";
+      let tail = "";
+      const maxHalfLength = Math.floor(maxLineLength / 2) - 1;
       if (position - lineStart > maxHalfLength) {
         head = " ... ";
         lineStart = position - maxHalfLength + head.length;
@@ -69501,11 +69802,11 @@ var require_snippet = __commonJS({
       if (typeof options2.indent !== "number") options2.indent = 1;
       if (typeof options2.linesBefore !== "number") options2.linesBefore = 3;
       if (typeof options2.linesAfter !== "number") options2.linesAfter = 2;
-      var re = /\r?\n|\r|\0/g;
-      var lineStarts = [0];
-      var lineEnds = [];
-      var match;
-      var foundLineNo = -1;
+      const re = /\r?\n|\r|\0/g;
+      const lineStarts = [0];
+      const lineEnds = [];
+      let match;
+      let foundLineNo = -1;
       while (match = re.exec(mark.buffer)) {
         lineEnds.push(match.index);
         lineStarts.push(match.index + match[0].length);
@@ -69514,33 +69815,33 @@ var require_snippet = __commonJS({
         }
       }
       if (foundLineNo < 0) foundLineNo = lineStarts.length - 1;
-      var result = "", i, line;
-      var lineNoLength = Math.min(mark.line + options2.linesAfter, lineEnds.length).toString().length;
-      var maxLineLength = options2.maxLength - (options2.indent + lineNoLength + 3);
-      for (i = 1; i <= options2.linesBefore; i++) {
+      let result = "";
+      const lineNoLength = Math.min(mark.line + options2.linesAfter, lineEnds.length).toString().length;
+      const maxLineLength = options2.maxLength - (options2.indent + lineNoLength + 3);
+      for (let i = 1; i <= options2.linesBefore; i++) {
         if (foundLineNo - i < 0) break;
-        line = getLine(
+        const line2 = getLine(
           mark.buffer,
           lineStarts[foundLineNo - i],
           lineEnds[foundLineNo - i],
           mark.position - (lineStarts[foundLineNo] - lineStarts[foundLineNo - i]),
           maxLineLength
         );
-        result = common.repeat(" ", options2.indent) + padStart((mark.line - i + 1).toString(), lineNoLength) + " | " + line.str + "\n" + result;
+        result = common.repeat(" ", options2.indent) + padStart((mark.line - i + 1).toString(), lineNoLength) + " | " + line2.str + "\n" + result;
       }
-      line = getLine(mark.buffer, lineStarts[foundLineNo], lineEnds[foundLineNo], mark.position, maxLineLength);
+      const line = getLine(mark.buffer, lineStarts[foundLineNo], lineEnds[foundLineNo], mark.position, maxLineLength);
       result += common.repeat(" ", options2.indent) + padStart((mark.line + 1).toString(), lineNoLength) + " | " + line.str + "\n";
       result += common.repeat("-", options2.indent + lineNoLength + 3 + line.pos) + "^\n";
-      for (i = 1; i <= options2.linesAfter; i++) {
+      for (let i = 1; i <= options2.linesAfter; i++) {
         if (foundLineNo + i >= lineEnds.length) break;
-        line = getLine(
+        const line2 = getLine(
           mark.buffer,
           lineStarts[foundLineNo + i],
           lineEnds[foundLineNo + i],
           mark.position - (lineStarts[foundLineNo] - lineStarts[foundLineNo + i]),
           maxLineLength
         );
-        result += common.repeat(" ", options2.indent) + padStart((mark.line + i + 1).toString(), lineNoLength) + " | " + line.str + "\n";
+        result += common.repeat(" ", options2.indent) + padStart((mark.line + i + 1).toString(), lineNoLength) + " | " + line2.str + "\n";
       }
       return result.replace(/\n$/, "");
     }
@@ -69571,7 +69872,7 @@ var require_type = __commonJS({
       "mapping"
     ];
     function compileStyleAliases(map) {
-      var result = {};
+      const result = {};
       if (map !== null) {
         Object.keys(map).forEach(function(style) {
           map[style].forEach(function(alias) {
@@ -69619,9 +69920,9 @@ var require_schema = __commonJS({
     var YAMLException = require_exception();
     var Type = require_type();
     function compileList(schema, name) {
-      var result = [];
+      const result = [];
       schema[name].forEach(function(currentType) {
-        var newIndex = result.length;
+        let newIndex = result.length;
         result.forEach(function(previousType, previousIndex) {
           if (previousType.tag === currentType.tag && previousType.kind === currentType.kind && previousType.multi === currentType.multi) {
             newIndex = previousIndex;
@@ -69632,7 +69933,7 @@ var require_schema = __commonJS({
       return result;
     }
     function compileMap() {
-      var result = {
+      const result = {
         scalar: {},
         sequence: {},
         mapping: {},
@@ -69643,7 +69944,7 @@ var require_schema = __commonJS({
           mapping: [],
           fallback: []
         }
-      }, index, length;
+      };
       function collectType(type) {
         if (type.multi) {
           result.multi[type.kind].push(type);
@@ -69652,7 +69953,7 @@ var require_schema = __commonJS({
           result[type.kind][type.tag] = result["fallback"][type.tag] = type;
         }
       }
-      for (index = 0, length = arguments.length; index < length; index += 1) {
+      for (let index = 0, length = arguments.length; index < length; index += 1) {
         arguments[index].forEach(collectType);
       }
       return result;
@@ -69661,8 +69962,8 @@ var require_schema = __commonJS({
       return this.extend(definition);
     }
     Schema.prototype.extend = function extend(definition) {
-      var implicit = [];
-      var explicit = [];
+      let implicit = [];
+      let explicit = [];
       if (definition instanceof Type) {
         explicit.push(definition);
       } else if (Array.isArray(definition)) {
@@ -69689,7 +69990,7 @@ var require_schema = __commonJS({
           throw new YAMLException("Specified list of YAML types (or a single Type object) contains a non-Type object.");
         }
       });
-      var result = Object.create(Schema.prototype);
+      const result = Object.create(Schema.prototype);
       result.implicit = (this.implicit || []).concat(implicit);
       result.explicit = (this.explicit || []).concat(explicit);
       result.compiledImplicit = compileList(result, "implicit");
@@ -69765,7 +70066,7 @@ var require_null = __commonJS({
     var Type = require_type();
     function resolveYamlNull(data) {
       if (data === null) return true;
-      var max = data.length;
+      const max = data.length;
       return max === 1 && data === "~" || max === 4 && (data === "null" || data === "Null" || data === "NULL");
     }
     function constructYamlNull() {
@@ -69808,7 +70109,7 @@ var require_bool = __commonJS({
     var Type = require_type();
     function resolveYamlBoolean(data) {
       if (data === null) return false;
-      var max = data.length;
+      const max = data.length;
       return max === 4 && (data === "true" || data === "True" || data === "TRUE") || max === 5 && (data === "false" || data === "False" || data === "FALSE");
     }
     function constructYamlBoolean(data) {
@@ -69845,19 +70146,21 @@ var require_int = __commonJS({
     var common = require_common4();
     var Type = require_type();
     function isHexCode(c) {
-      return 48 <= c && c <= 57 || 65 <= c && c <= 70 || 97 <= c && c <= 102;
+      return c >= 48 && c <= 57 || c >= 65 && c <= 70 || c >= 97 && c <= 102;
     }
     function isOctCode(c) {
-      return 48 <= c && c <= 55;
+      return c >= 48 && c <= 55;
     }
     function isDecCode(c) {
-      return 48 <= c && c <= 57;
+      return c >= 48 && c <= 57;
     }
     function resolveYamlInteger(data) {
       if (data === null) return false;
-      var max = data.length, index = 0, hasDigits = false, ch;
+      const max = data.length;
+      let index = 0;
+      let hasDigits = false;
       if (!max) return false;
-      ch = data[index];
+      let ch = data[index];
       if (ch === "-" || ch === "+") {
         ch = data[++index];
       }
@@ -69868,51 +70171,41 @@ var require_int = __commonJS({
           index++;
           for (; index < max; index++) {
             ch = data[index];
-            if (ch === "_") continue;
             if (ch !== "0" && ch !== "1") return false;
             hasDigits = true;
           }
-          return hasDigits && ch !== "_";
+          return hasDigits && isFinite(parseYamlInteger(data));
         }
         if (ch === "x") {
           index++;
           for (; index < max; index++) {
-            ch = data[index];
-            if (ch === "_") continue;
             if (!isHexCode(data.charCodeAt(index))) return false;
             hasDigits = true;
           }
-          return hasDigits && ch !== "_";
+          return hasDigits && isFinite(parseYamlInteger(data));
         }
         if (ch === "o") {
           index++;
           for (; index < max; index++) {
-            ch = data[index];
-            if (ch === "_") continue;
             if (!isOctCode(data.charCodeAt(index))) return false;
             hasDigits = true;
           }
-          return hasDigits && ch !== "_";
+          return hasDigits && isFinite(parseYamlInteger(data));
         }
       }
-      if (ch === "_") return false;
       for (; index < max; index++) {
-        ch = data[index];
-        if (ch === "_") continue;
         if (!isDecCode(data.charCodeAt(index))) {
           return false;
         }
         hasDigits = true;
       }
-      if (!hasDigits || ch === "_") return false;
-      return true;
+      if (!hasDigits) return false;
+      return isFinite(parseYamlInteger(data));
     }
-    function constructYamlInteger(data) {
-      var value = data, sign = 1, ch;
-      if (value.indexOf("_") !== -1) {
-        value = value.replace(/_/g, "");
-      }
-      ch = value[0];
+    function parseYamlInteger(data) {
+      let value = data;
+      let sign = 1;
+      let ch = value[0];
       if (ch === "-" || ch === "+") {
         if (ch === "-") sign = -1;
         value = value.slice(1);
@@ -69925,6 +70218,9 @@ var require_int = __commonJS({
         if (value[1] === "o") return sign * parseInt(value.slice(2), 8);
       }
       return sign * parseInt(value, 10);
+    }
+    function constructYamlInteger(data) {
+      return parseYamlInteger(data);
     }
     function isInteger(object) {
       return Object.prototype.toString.call(object) === "[object Number]" && (object % 1 === 0 && !common.isNegativeZero(object));
@@ -69944,7 +70240,6 @@ var require_int = __commonJS({
         decimal: function(obj) {
           return obj.toString(10);
         },
-        /* eslint-disable max-len */
         hexadecimal: function(obj) {
           return obj >= 0 ? "0x" + obj.toString(16).toUpperCase() : "-0x" + obj.toString(16).toUpperCase().slice(1);
         }
@@ -69968,21 +70263,24 @@ var require_float = __commonJS({
     var Type = require_type();
     var YAML_FLOAT_PATTERN = new RegExp(
       // 2.5e4, 2.5 and integers
-      "^(?:[-+]?(?:[0-9][0-9_]*)(?:\\.[0-9_]*)?(?:[eE][-+]?[0-9]+)?|\\.[0-9_]+(?:[eE][-+]?[0-9]+)?|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$"
+      "^(?:[-+]?(?:[0-9]+)(?:\\.[0-9]*)?(?:[eE][-+]?[0-9]+)?|\\.[0-9]+(?:[eE][-+]?[0-9]+)?|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$"
+    );
+    var YAML_FLOAT_SPECIAL_PATTERN = new RegExp(
+      "^(?:[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$"
     );
     function resolveYamlFloat(data) {
       if (data === null) return false;
-      if (!YAML_FLOAT_PATTERN.test(data) || // Quick hack to not allow integers end with `_`
-      // Probably should update regexp & check speed
-      data[data.length - 1] === "_") {
+      if (!YAML_FLOAT_PATTERN.test(data)) {
         return false;
       }
-      return true;
+      if (isFinite(parseFloat(data, 10))) {
+        return true;
+      }
+      return YAML_FLOAT_SPECIAL_PATTERN.test(data);
     }
     function constructYamlFloat(data) {
-      var value, sign;
-      value = data.replace(/_/g, "").toLowerCase();
-      sign = value[0] === "-" ? -1 : 1;
+      let value = data.toLowerCase();
+      const sign = value[0] === "-" ? -1 : 1;
       if ("+-".indexOf(value[0]) >= 0) {
         value = value.slice(1);
       }
@@ -69995,7 +70293,6 @@ var require_float = __commonJS({
     }
     var SCIENTIFIC_WITHOUT_DOT = /^[-+]?[0-9]+e/;
     function representYamlFloat(object, style) {
-      var res;
       if (isNaN(object)) {
         switch (style) {
           case "lowercase":
@@ -70026,7 +70323,7 @@ var require_float = __commonJS({
       } else if (common.isNegativeZero(object)) {
         return "-0.0";
       }
-      res = object.toString(10);
+      const res = object.toString(10);
       return SCIENTIFIC_WITHOUT_DOT.test(res) ? res.replace("e", ".e") : res;
     }
     function isFloat(object) {
@@ -70084,19 +70381,20 @@ var require_timestamp = __commonJS({
       return false;
     }
     function constructYamlTimestamp(data) {
-      var match, year, month, day, hour, minute, second, fraction = 0, delta = null, tz_hour, tz_minute, date;
-      match = YAML_DATE_REGEXP.exec(data);
+      let fraction = 0;
+      let delta = null;
+      let match = YAML_DATE_REGEXP.exec(data);
       if (match === null) match = YAML_TIMESTAMP_REGEXP.exec(data);
       if (match === null) throw new Error("Date resolve error");
-      year = +match[1];
-      month = +match[2] - 1;
-      day = +match[3];
+      const year = +match[1];
+      const month = +match[2] - 1;
+      const day = +match[3];
       if (!match[4]) {
         return new Date(Date.UTC(year, month, day));
       }
-      hour = +match[4];
-      minute = +match[5];
-      second = +match[6];
+      const hour = +match[4];
+      const minute = +match[5];
+      const second = +match[6];
       if (match[7]) {
         fraction = match[7].slice(0, 3);
         while (fraction.length < 3) {
@@ -70105,12 +70403,12 @@ var require_timestamp = __commonJS({
         fraction = +fraction;
       }
       if (match[9]) {
-        tz_hour = +match[10];
-        tz_minute = +(match[11] || 0);
-        delta = (tz_hour * 60 + tz_minute) * 6e4;
+        const tzHour = +match[10];
+        const tzMinute = +(match[11] || 0);
+        delta = (tzHour * 60 + tzMinute) * 6e4;
         if (match[9] === "-") delta = -delta;
       }
-      date = new Date(Date.UTC(year, month, day, hour, minute, second, fraction));
+      const date = new Date(Date.UTC(year, month, day, hour, minute, second, fraction));
       if (delta) date.setTime(date.getTime() - delta);
       return date;
     }
@@ -70150,9 +70448,11 @@ var require_binary = __commonJS({
     var BASE64_MAP = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=\n\r";
     function resolveYamlBinary(data) {
       if (data === null) return false;
-      var code, idx, bitlen = 0, max = data.length, map = BASE64_MAP;
-      for (idx = 0; idx < max; idx++) {
-        code = map.indexOf(data.charAt(idx));
+      let bitlen = 0;
+      const max = data.length;
+      const map = BASE64_MAP;
+      for (let idx = 0; idx < max; idx++) {
+        const code = map.indexOf(data.charAt(idx));
         if (code > 64) continue;
         if (code < 0) return false;
         bitlen += 6;
@@ -70160,8 +70460,12 @@ var require_binary = __commonJS({
       return bitlen % 8 === 0;
     }
     function constructYamlBinary(data) {
-      var idx, tailbits, input = data.replace(/[\r\n=]/g, ""), max = input.length, map = BASE64_MAP, bits = 0, result = [];
-      for (idx = 0; idx < max; idx++) {
+      const input = data.replace(/[\r\n=]/g, "");
+      const max = input.length;
+      const map = BASE64_MAP;
+      let bits = 0;
+      const result = [];
+      for (let idx = 0; idx < max; idx++) {
         if (idx % 4 === 0 && idx) {
           result.push(bits >> 16 & 255);
           result.push(bits >> 8 & 255);
@@ -70169,7 +70473,7 @@ var require_binary = __commonJS({
         }
         bits = bits << 6 | map.indexOf(input.charAt(idx));
       }
-      tailbits = max % 4 * 6;
+      const tailbits = max % 4 * 6;
       if (tailbits === 0) {
         result.push(bits >> 16 & 255);
         result.push(bits >> 8 & 255);
@@ -70183,8 +70487,11 @@ var require_binary = __commonJS({
       return new Uint8Array(result);
     }
     function representYamlBinary(object) {
-      var result = "", bits = 0, idx, tail, max = object.length, map = BASE64_MAP;
-      for (idx = 0; idx < max; idx++) {
+      let result = "";
+      let bits = 0;
+      const max = object.length;
+      const map = BASE64_MAP;
+      for (let idx = 0; idx < max; idx++) {
         if (idx % 3 === 0 && idx) {
           result += map[bits >> 18 & 63];
           result += map[bits >> 12 & 63];
@@ -70193,7 +70500,7 @@ var require_binary = __commonJS({
         }
         bits = (bits << 8) + object[idx];
       }
-      tail = max % 3;
+      const tail = max % 3;
       if (tail === 0) {
         result += map[bits >> 18 & 63];
         result += map[bits >> 12 & 63];
@@ -70234,11 +70541,13 @@ var require_omap = __commonJS({
     var _toString = Object.prototype.toString;
     function resolveYamlOmap(data) {
       if (data === null) return true;
-      var objectKeys = [], index, length, pair, pairKey, pairHasKey, object = data;
-      for (index = 0, length = object.length; index < length; index += 1) {
-        pair = object[index];
-        pairHasKey = false;
+      const objectKeys = [];
+      const object = data;
+      for (let index = 0, length = object.length; index < length; index += 1) {
+        const pair = object[index];
+        let pairHasKey = false;
         if (_toString.call(pair) !== "[object Object]") return false;
+        let pairKey;
         for (pairKey in pair) {
           if (_hasOwnProperty.call(pair, pairKey)) {
             if (!pairHasKey) pairHasKey = true;
@@ -70270,12 +70579,12 @@ var require_pairs = __commonJS({
     var _toString = Object.prototype.toString;
     function resolveYamlPairs(data) {
       if (data === null) return true;
-      var index, length, pair, keys, result, object = data;
-      result = new Array(object.length);
-      for (index = 0, length = object.length; index < length; index += 1) {
-        pair = object[index];
+      const object = data;
+      const result = new Array(object.length);
+      for (let index = 0, length = object.length; index < length; index += 1) {
+        const pair = object[index];
         if (_toString.call(pair) !== "[object Object]") return false;
-        keys = Object.keys(pair);
+        const keys = Object.keys(pair);
         if (keys.length !== 1) return false;
         result[index] = [keys[0], pair[keys[0]]];
       }
@@ -70283,11 +70592,11 @@ var require_pairs = __commonJS({
     }
     function constructYamlPairs(data) {
       if (data === null) return [];
-      var index, length, pair, keys, result, object = data;
-      result = new Array(object.length);
-      for (index = 0, length = object.length; index < length; index += 1) {
-        pair = object[index];
-        keys = Object.keys(pair);
+      const object = data;
+      const result = new Array(object.length);
+      for (let index = 0, length = object.length; index < length; index += 1) {
+        const pair = object[index];
+        const keys = Object.keys(pair);
         result[index] = [keys[0], pair[keys[0]]];
       }
       return result;
@@ -70308,8 +70617,8 @@ var require_set = __commonJS({
     var _hasOwnProperty = Object.prototype.hasOwnProperty;
     function resolveYamlSet(data) {
       if (data === null) return true;
-      var key, object = data;
-      for (key in object) {
+      const object = data;
+      for (const key in object) {
         if (_hasOwnProperty.call(object, key)) {
           if (object[key] !== null) return false;
         }
@@ -70364,31 +70673,30 @@ var require_loader = __commonJS({
     var CHOMPING_KEEP = 3;
     var PATTERN_NON_PRINTABLE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/;
     var PATTERN_NON_ASCII_LINE_BREAKS = /[\x85\u2028\u2029]/;
-    var PATTERN_FLOW_INDICATORS = /[,\[\]\{\}]/;
-    var PATTERN_TAG_HANDLE = /^(?:!|!!|![a-z\-]+!)$/i;
-    var PATTERN_TAG_URI = /^(?:!|[^,\[\]\{\}])(?:%[0-9a-f]{2}|[0-9a-z\-#;\/\?:@&=\+\$,_\.!~\*'\(\)\[\]])*$/i;
+    var PATTERN_FLOW_INDICATORS = /[,\[\]{}]/;
+    var PATTERN_TAG_HANDLE = /^(?:!|!!|![0-9A-Za-z-]+!)$/;
+    var PATTERN_TAG_URI = /^(?:!|[^,\[\]{}])(?:%[0-9a-f]{2}|[0-9a-z\-#;/?:@&=+$,_.!~*'()\[\]])*$/i;
     function _class(obj) {
       return Object.prototype.toString.call(obj);
     }
-    function is_EOL(c) {
+    function isEol(c) {
       return c === 10 || c === 13;
     }
-    function is_WHITE_SPACE(c) {
+    function isWhiteSpace(c) {
       return c === 9 || c === 32;
     }
-    function is_WS_OR_EOL(c) {
+    function isWsOrEol(c) {
       return c === 9 || c === 32 || c === 10 || c === 13;
     }
-    function is_FLOW_INDICATOR(c) {
+    function isFlowIndicator(c) {
       return c === 44 || c === 91 || c === 93 || c === 123 || c === 125;
     }
     function fromHexCode(c) {
-      var lc;
-      if (48 <= c && c <= 57) {
+      if (c >= 48 && c <= 57) {
         return c - 48;
       }
-      lc = c | 32;
-      if (97 <= lc && lc <= 102) {
+      const lc = c | 32;
+      if (lc >= 97 && lc <= 102) {
         return lc - 97 + 10;
       }
       return -1;
@@ -70406,13 +70714,52 @@ var require_loader = __commonJS({
       return 0;
     }
     function fromDecimalCode(c) {
-      if (48 <= c && c <= 57) {
+      if (c >= 48 && c <= 57) {
         return c - 48;
       }
       return -1;
     }
     function simpleEscapeSequence(c) {
-      return c === 48 ? "\0" : c === 97 ? "\x07" : c === 98 ? "\b" : c === 116 ? "	" : c === 9 ? "	" : c === 110 ? "\n" : c === 118 ? "\v" : c === 102 ? "\f" : c === 114 ? "\r" : c === 101 ? "\x1B" : c === 32 ? " " : c === 34 ? '"' : c === 47 ? "/" : c === 92 ? "\\" : c === 78 ? "\x85" : c === 95 ? "\xA0" : c === 76 ? "\u2028" : c === 80 ? "\u2029" : "";
+      switch (c) {
+        case 48:
+          return "\0";
+        case 97:
+          return "\x07";
+        case 98:
+          return "\b";
+        case 116:
+          return "	";
+        case 9:
+          return "	";
+        case 110:
+          return "\n";
+        case 118:
+          return "\v";
+        case 102:
+          return "\f";
+        case 114:
+          return "\r";
+        case 101:
+          return "\x1B";
+        case 32:
+          return " ";
+        case 34:
+          return '"';
+        case 47:
+          return "/";
+        case 92:
+          return "\\";
+        case 78:
+          return "\x85";
+        case 95:
+          return "\xA0";
+        case 76:
+          return "\u2028";
+        case 80:
+          return "\u2029";
+        default:
+          return "";
+      }
     }
     function charFromCodepoint(c) {
       if (c <= 65535) {
@@ -70437,11 +70784,10 @@ var require_loader = __commonJS({
     }
     var simpleEscapeCheck = new Array(256);
     var simpleEscapeMap = new Array(256);
-    for (i = 0; i < 256; i++) {
+    for (let i = 0; i < 256; i++) {
       simpleEscapeCheck[i] = simpleEscapeSequence(i) ? 1 : 0;
       simpleEscapeMap[i] = simpleEscapeSequence(i);
     }
-    var i;
     function State(input, options2) {
       this.input = input;
       this.filename = options2["filename"] || null;
@@ -70450,6 +70796,8 @@ var require_loader = __commonJS({
       this.legacy = options2["legacy"] || false;
       this.json = options2["json"] || false;
       this.listener = options2["listener"] || null;
+      this.maxDepth = typeof options2["maxDepth"] === "number" ? options2["maxDepth"] : 100;
+      this.maxTotalMergeKeys = typeof options2["maxTotalMergeKeys"] === "number" ? options2["maxTotalMergeKeys"] : 1e4;
       this.implicitTypes = this.schema.compiledImplicit;
       this.typeMap = this.schema.compiledTypeMap;
       this.length = input.length;
@@ -70457,11 +70805,14 @@ var require_loader = __commonJS({
       this.line = 0;
       this.lineStart = 0;
       this.lineIndent = 0;
+      this.depth = 0;
+      this.totalMergeKeys = 0;
       this.firstTabInLine = -1;
       this.documents = [];
+      this.anchorMapTransactions = [];
     }
     function generateError(state, message) {
-      var mark = {
+      const mark = {
         name: state.filename,
         buffer: state.input.slice(0, -1),
         // omit trailing \0
@@ -70480,21 +70831,85 @@ var require_loader = __commonJS({
         state.onWarning.call(null, generateError(state, message));
       }
     }
+    function storeAnchor(state, name, value) {
+      const transactions = state.anchorMapTransactions;
+      if (transactions.length !== 0) {
+        const transaction = transactions[transactions.length - 1];
+        if (!_hasOwnProperty.call(transaction, name)) {
+          transaction[name] = {
+            existed: _hasOwnProperty.call(state.anchorMap, name),
+            value: state.anchorMap[name]
+          };
+        }
+      }
+      state.anchorMap[name] = value;
+    }
+    function beginAnchorTransaction(state) {
+      state.anchorMapTransactions.push(/* @__PURE__ */ Object.create(null));
+    }
+    function commitAnchorTransaction(state) {
+      const transaction = state.anchorMapTransactions.pop();
+      const transactions = state.anchorMapTransactions;
+      if (transactions.length === 0) return;
+      const parent = transactions[transactions.length - 1];
+      const names = Object.keys(transaction);
+      for (let index = 0, length = names.length; index < length; index += 1) {
+        const name = names[index];
+        if (!_hasOwnProperty.call(parent, name)) {
+          parent[name] = transaction[name];
+        }
+      }
+    }
+    function rollbackAnchorTransaction(state) {
+      const transaction = state.anchorMapTransactions.pop();
+      const names = Object.keys(transaction);
+      for (let index = names.length - 1; index >= 0; index -= 1) {
+        const entry = transaction[names[index]];
+        if (entry.existed) {
+          state.anchorMap[names[index]] = entry.value;
+        } else {
+          delete state.anchorMap[names[index]];
+        }
+      }
+    }
+    function snapshotState(state) {
+      return {
+        position: state.position,
+        line: state.line,
+        lineStart: state.lineStart,
+        lineIndent: state.lineIndent,
+        firstTabInLine: state.firstTabInLine,
+        tag: state.tag,
+        anchor: state.anchor,
+        kind: state.kind,
+        result: state.result
+      };
+    }
+    function restoreState(state, snapshot) {
+      state.position = snapshot.position;
+      state.line = snapshot.line;
+      state.lineStart = snapshot.lineStart;
+      state.lineIndent = snapshot.lineIndent;
+      state.firstTabInLine = snapshot.firstTabInLine;
+      state.tag = snapshot.tag;
+      state.anchor = snapshot.anchor;
+      state.kind = snapshot.kind;
+      state.result = snapshot.result;
+    }
     var directiveHandlers = {
       YAML: function handleYamlDirective(state, name, args) {
-        var match, major, minor;
         if (state.version !== null) {
           throwError(state, "duplication of %YAML directive");
         }
         if (args.length !== 1) {
           throwError(state, "YAML directive accepts exactly one argument");
         }
-        match = /^([0-9]+)\.([0-9]+)$/.exec(args[0]);
+        const match = /^([0-9]+)\.([0-9]+)$/.exec(args[0]);
         if (match === null) {
           throwError(state, "ill-formed argument of the YAML directive");
         }
-        major = parseInt(match[1], 10);
-        minor = parseInt(match[2], 10);
+        const major = parseInt(match[1], 10);
+        const minor = parseInt(match[2], 10);
         if (major !== 1) {
           throwError(state, "unacceptable YAML version of the document");
         }
@@ -70505,11 +70920,11 @@ var require_loader = __commonJS({
         }
       },
       TAG: function handleTagDirective(state, name, args) {
-        var handle, prefix;
+        let prefix;
         if (args.length !== 2) {
           throwError(state, "TAG directive accepts exactly two arguments");
         }
-        handle = args[0];
+        const handle = args[0];
         prefix = args[1];
         if (!PATTERN_TAG_HANDLE.test(handle)) {
           throwError(state, "ill-formed tag handle (first argument) of the TAG directive");
@@ -70529,13 +70944,12 @@ var require_loader = __commonJS({
       }
     };
     function captureSegment(state, start, end, checkJson) {
-      var _position, _length, _character, _result;
       if (start < end) {
-        _result = state.input.slice(start, end);
+        const _result = state.input.slice(start, end);
         if (checkJson) {
-          for (_position = 0, _length = _result.length; _position < _length; _position += 1) {
-            _character = _result.charCodeAt(_position);
-            if (!(_character === 9 || 32 <= _character && _character <= 1114111)) {
+          for (let _position = 0, _length = _result.length; _position < _length; _position += 1) {
+            const _character = _result.charCodeAt(_position);
+            if (!(_character === 9 || _character >= 32 && _character <= 1114111)) {
               throwError(state, "expected valid JSON character");
             }
           }
@@ -70546,13 +70960,15 @@ var require_loader = __commonJS({
       }
     }
     function mergeMappings(state, destination, source, overridableKeys) {
-      var sourceKeys, key, index, quantity;
       if (!common.isObject(source)) {
         throwError(state, "cannot merge mappings; the provided source object is unacceptable");
       }
-      sourceKeys = Object.keys(source);
-      for (index = 0, quantity = sourceKeys.length; index < quantity; index += 1) {
-        key = sourceKeys[index];
+      const sourceKeys = Object.keys(source);
+      for (let index = 0, quantity = sourceKeys.length; index < quantity; index += 1) {
+        const key = sourceKeys[index];
+        if (state.maxTotalMergeKeys !== -1 && ++state.totalMergeKeys > state.maxTotalMergeKeys) {
+          throwError(state, "merge keys exceeded maxTotalMergeKeys (" + state.maxTotalMergeKeys + ")");
+        }
         if (!_hasOwnProperty.call(destination, key)) {
           setProperty(destination, key, source[key]);
           overridableKeys[key] = true;
@@ -70560,10 +70976,9 @@ var require_loader = __commonJS({
       }
     }
     function storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode, startLine, startLineStart, startPos) {
-      var index, quantity;
       if (Array.isArray(keyNode)) {
         keyNode = Array.prototype.slice.call(keyNode);
-        for (index = 0, quantity = keyNode.length; index < quantity; index += 1) {
+        for (let index = 0, quantity = keyNode.length; index < quantity; index += 1) {
           if (Array.isArray(keyNode[index])) {
             throwError(state, "nested arrays are not supported inside keys");
           }
@@ -70581,7 +70996,7 @@ var require_loader = __commonJS({
       }
       if (keyTag === "tag:yaml.org,2002:merge") {
         if (Array.isArray(valueNode)) {
-          for (index = 0, quantity = valueNode.length; index < quantity; index += 1) {
+          for (let index = 0, quantity = valueNode.length; index < quantity; index += 1) {
             mergeMappings(state, _result, valueNode[index], overridableKeys);
           }
         } else {
@@ -70600,8 +71015,7 @@ var require_loader = __commonJS({
       return _result;
     }
     function readLineBreak(state) {
-      var ch;
-      ch = state.input.charCodeAt(state.position);
+      const ch = state.input.charCodeAt(state.position);
       if (ch === 10) {
         state.position++;
       } else if (ch === 13) {
@@ -70617,9 +71031,10 @@ var require_loader = __commonJS({
       state.firstTabInLine = -1;
     }
     function skipSeparationSpace(state, allowComments, checkIndent) {
-      var lineBreaks = 0, ch = state.input.charCodeAt(state.position);
+      let lineBreaks = 0;
+      let ch = state.input.charCodeAt(state.position);
       while (ch !== 0) {
-        while (is_WHITE_SPACE(ch)) {
+        while (isWhiteSpace(ch)) {
           if (ch === 9 && state.firstTabInLine === -1) {
             state.firstTabInLine = state.position;
           }
@@ -70630,7 +71045,7 @@ var require_loader = __commonJS({
             ch = state.input.charCodeAt(++state.position);
           } while (ch !== 10 && ch !== 13 && ch !== 0);
         }
-        if (is_EOL(ch)) {
+        if (isEol(ch)) {
           readLineBreak(state);
           ch = state.input.charCodeAt(state.position);
           lineBreaks++;
@@ -70649,12 +71064,12 @@ var require_loader = __commonJS({
       return lineBreaks;
     }
     function testDocumentSeparator(state) {
-      var _position = state.position, ch;
-      ch = state.input.charCodeAt(_position);
+      let _position = state.position;
+      let ch = state.input.charCodeAt(_position);
       if ((ch === 45 || ch === 46) && ch === state.input.charCodeAt(_position + 1) && ch === state.input.charCodeAt(_position + 2)) {
         _position += 3;
         ch = state.input.charCodeAt(_position);
-        if (ch === 0 || is_WS_OR_EOL(ch)) {
+        if (ch === 0 || isWsOrEol(ch)) {
           return true;
         }
       }
@@ -70668,14 +71083,21 @@ var require_loader = __commonJS({
       }
     }
     function readPlainScalar(state, nodeIndent, withinFlowCollection) {
-      var preceding, following, captureStart, captureEnd, hasPendingContent, _line, _lineStart, _lineIndent, _kind = state.kind, _result = state.result, ch;
-      ch = state.input.charCodeAt(state.position);
-      if (is_WS_OR_EOL(ch) || is_FLOW_INDICATOR(ch) || ch === 35 || ch === 38 || ch === 42 || ch === 33 || ch === 124 || ch === 62 || ch === 39 || ch === 34 || ch === 37 || ch === 64 || ch === 96) {
+      let captureStart;
+      let captureEnd;
+      let hasPendingContent;
+      let _line;
+      let _lineStart;
+      let _lineIndent;
+      const _kind = state.kind;
+      const _result = state.result;
+      let ch = state.input.charCodeAt(state.position);
+      if (isWsOrEol(ch) || isFlowIndicator(ch) || ch === 35 || ch === 38 || ch === 42 || ch === 33 || ch === 124 || ch === 62 || ch === 39 || ch === 34 || ch === 37 || ch === 64 || ch === 96) {
         return false;
       }
       if (ch === 63 || ch === 45) {
-        following = state.input.charCodeAt(state.position + 1);
-        if (is_WS_OR_EOL(following) || withinFlowCollection && is_FLOW_INDICATOR(following)) {
+        const following = state.input.charCodeAt(state.position + 1);
+        if (isWsOrEol(following) || withinFlowCollection && isFlowIndicator(following)) {
           return false;
         }
       }
@@ -70685,18 +71107,18 @@ var require_loader = __commonJS({
       hasPendingContent = false;
       while (ch !== 0) {
         if (ch === 58) {
-          following = state.input.charCodeAt(state.position + 1);
-          if (is_WS_OR_EOL(following) || withinFlowCollection && is_FLOW_INDICATOR(following)) {
+          const following = state.input.charCodeAt(state.position + 1);
+          if (isWsOrEol(following) || withinFlowCollection && isFlowIndicator(following)) {
             break;
           }
         } else if (ch === 35) {
-          preceding = state.input.charCodeAt(state.position - 1);
-          if (is_WS_OR_EOL(preceding)) {
+          const preceding = state.input.charCodeAt(state.position - 1);
+          if (isWsOrEol(preceding)) {
             break;
           }
-        } else if (state.position === state.lineStart && testDocumentSeparator(state) || withinFlowCollection && is_FLOW_INDICATOR(ch)) {
+        } else if (state.position === state.lineStart && testDocumentSeparator(state) || withinFlowCollection && isFlowIndicator(ch)) {
           break;
-        } else if (is_EOL(ch)) {
+        } else if (isEol(ch)) {
           _line = state.line;
           _lineStart = state.lineStart;
           _lineIndent = state.lineIndent;
@@ -70719,7 +71141,7 @@ var require_loader = __commonJS({
           captureStart = captureEnd = state.position;
           hasPendingContent = false;
         }
-        if (!is_WHITE_SPACE(ch)) {
+        if (!isWhiteSpace(ch)) {
           captureEnd = state.position + 1;
         }
         ch = state.input.charCodeAt(++state.position);
@@ -70733,8 +71155,9 @@ var require_loader = __commonJS({
       return false;
     }
     function readSingleQuotedScalar(state, nodeIndent) {
-      var ch, captureStart, captureEnd;
-      ch = state.input.charCodeAt(state.position);
+      let captureStart;
+      let captureEnd;
+      let ch = state.input.charCodeAt(state.position);
       if (ch !== 39) {
         return false;
       }
@@ -70753,7 +71176,7 @@ var require_loader = __commonJS({
           } else {
             return true;
           }
-        } else if (is_EOL(ch)) {
+        } else if (isEol(ch)) {
           captureSegment(state, captureStart, captureEnd, true);
           writeFoldedLines(state, skipSeparationSpace(state, false, nodeIndent));
           captureStart = captureEnd = state.position;
@@ -70761,14 +71184,18 @@ var require_loader = __commonJS({
           throwError(state, "unexpected end of the document within a single quoted scalar");
         } else {
           state.position++;
-          captureEnd = state.position;
+          if (!isWhiteSpace(ch)) {
+            captureEnd = state.position;
+          }
         }
       }
       throwError(state, "unexpected end of the stream within a single quoted scalar");
     }
     function readDoubleQuotedScalar(state, nodeIndent) {
-      var captureStart, captureEnd, hexLength, hexResult, tmp, ch;
-      ch = state.input.charCodeAt(state.position);
+      let captureStart;
+      let captureEnd;
+      let tmp;
+      let ch = state.input.charCodeAt(state.position);
       if (ch !== 34) {
         return false;
       }
@@ -70784,14 +71211,14 @@ var require_loader = __commonJS({
         } else if (ch === 92) {
           captureSegment(state, captureStart, state.position, true);
           ch = state.input.charCodeAt(++state.position);
-          if (is_EOL(ch)) {
+          if (isEol(ch)) {
             skipSeparationSpace(state, false, nodeIndent);
           } else if (ch < 256 && simpleEscapeCheck[ch]) {
             state.result += simpleEscapeMap[ch];
             state.position++;
           } else if ((tmp = escapedHexLen(ch)) > 0) {
-            hexLength = tmp;
-            hexResult = 0;
+            let hexLength = tmp;
+            let hexResult = 0;
             for (; hexLength > 0; hexLength--) {
               ch = state.input.charCodeAt(++state.position);
               if ((tmp = fromHexCode(ch)) >= 0) {
@@ -70806,7 +71233,7 @@ var require_loader = __commonJS({
             throwError(state, "unknown escape sequence");
           }
           captureStart = captureEnd = state.position;
-        } else if (is_EOL(ch)) {
+        } else if (isEol(ch)) {
           captureSegment(state, captureStart, captureEnd, true);
           writeFoldedLines(state, skipSeparationSpace(state, false, nodeIndent));
           captureStart = captureEnd = state.position;
@@ -70814,14 +71241,30 @@ var require_loader = __commonJS({
           throwError(state, "unexpected end of the document within a double quoted scalar");
         } else {
           state.position++;
-          captureEnd = state.position;
+          if (!isWhiteSpace(ch)) {
+            captureEnd = state.position;
+          }
         }
       }
       throwError(state, "unexpected end of the stream within a double quoted scalar");
     }
     function readFlowCollection(state, nodeIndent) {
-      var readNext = true, _line, _lineStart, _pos, _tag = state.tag, _result, _anchor = state.anchor, following, terminator, isPair, isExplicitPair, isMapping, overridableKeys = /* @__PURE__ */ Object.create(null), keyNode, keyTag, valueNode, ch;
-      ch = state.input.charCodeAt(state.position);
+      let readNext = true;
+      let _line;
+      let _lineStart;
+      let _pos;
+      const _tag = state.tag;
+      let _result;
+      const _anchor = state.anchor;
+      let terminator;
+      let isPair;
+      let isExplicitPair;
+      let isMapping;
+      const overridableKeys = /* @__PURE__ */ Object.create(null);
+      let keyNode;
+      let keyTag;
+      let valueNode;
+      let ch = state.input.charCodeAt(state.position);
       if (ch === 91) {
         terminator = 93;
         isMapping = false;
@@ -70834,7 +71277,7 @@ var require_loader = __commonJS({
         return false;
       }
       if (state.anchor !== null) {
-        state.anchorMap[state.anchor] = _result;
+        storeAnchor(state, state.anchor, _result);
       }
       ch = state.input.charCodeAt(++state.position);
       while (ch !== 0) {
@@ -70855,8 +71298,8 @@ var require_loader = __commonJS({
         keyTag = keyNode = valueNode = null;
         isPair = isExplicitPair = false;
         if (ch === 63) {
-          following = state.input.charCodeAt(state.position + 1);
-          if (is_WS_OR_EOL(following)) {
+          const following = state.input.charCodeAt(state.position + 1);
+          if (isWsOrEol(following)) {
             isPair = isExplicitPair = true;
             state.position++;
             skipSeparationSpace(state, true, nodeIndent);
@@ -70896,8 +71339,15 @@ var require_loader = __commonJS({
       throwError(state, "unexpected end of the stream within a flow collection");
     }
     function readBlockScalar(state, nodeIndent) {
-      var captureStart, folding, chomping = CHOMPING_CLIP, didReadContent = false, detectedIndent = false, textIndent = nodeIndent, emptyLines = 0, atMoreIndented = false, tmp, ch;
-      ch = state.input.charCodeAt(state.position);
+      let folding;
+      let chomping = CHOMPING_CLIP;
+      let didReadContent = false;
+      let detectedIndent = false;
+      let textIndent = nodeIndent;
+      let emptyLines = 0;
+      let atMoreIndented = false;
+      let tmp;
+      let ch = state.input.charCodeAt(state.position);
       if (ch === 124) {
         folding = false;
       } else if (ch === 62) {
@@ -70928,14 +71378,14 @@ var require_loader = __commonJS({
           break;
         }
       }
-      if (is_WHITE_SPACE(ch)) {
+      if (isWhiteSpace(ch)) {
         do {
           ch = state.input.charCodeAt(++state.position);
-        } while (is_WHITE_SPACE(ch));
+        } while (isWhiteSpace(ch));
         if (ch === 35) {
           do {
             ch = state.input.charCodeAt(++state.position);
-          } while (!is_EOL(ch) && ch !== 0);
+          } while (!isEol(ch) && ch !== 0);
         }
       }
       while (ch !== 0) {
@@ -70949,9 +71399,12 @@ var require_loader = __commonJS({
         if (!detectedIndent && state.lineIndent > textIndent) {
           textIndent = state.lineIndent;
         }
-        if (is_EOL(ch)) {
+        if (isEol(ch)) {
           emptyLines++;
           continue;
+        }
+        if (!detectedIndent && textIndent === 0) {
+          throwError(state, "missing indentation for block scalar");
         }
         if (state.lineIndent < textIndent) {
           if (chomping === CHOMPING_KEEP) {
@@ -70964,7 +71417,7 @@ var require_loader = __commonJS({
           break;
         }
         if (folding) {
-          if (is_WHITE_SPACE(ch)) {
+          if (isWhiteSpace(ch)) {
             atMoreIndented = true;
             state.result += common.repeat("\n", didReadContent ? 1 + emptyLines : emptyLines);
           } else if (atMoreIndented) {
@@ -70983,8 +71436,8 @@ var require_loader = __commonJS({
         didReadContent = true;
         detectedIndent = true;
         emptyLines = 0;
-        captureStart = state.position;
-        while (!is_EOL(ch) && ch !== 0) {
+        const captureStart = state.position;
+        while (!isEol(ch) && ch !== 0) {
           ch = state.input.charCodeAt(++state.position);
         }
         captureSegment(state, captureStart, state.position, false);
@@ -70992,12 +71445,15 @@ var require_loader = __commonJS({
       return true;
     }
     function readBlockSequence(state, nodeIndent) {
-      var _line, _tag = state.tag, _anchor = state.anchor, _result = [], following, detected = false, ch;
+      const _tag = state.tag;
+      const _anchor = state.anchor;
+      const _result = [];
+      let detected = false;
       if (state.firstTabInLine !== -1) return false;
       if (state.anchor !== null) {
-        state.anchorMap[state.anchor] = _result;
+        storeAnchor(state, state.anchor, _result);
       }
-      ch = state.input.charCodeAt(state.position);
+      let ch = state.input.charCodeAt(state.position);
       while (ch !== 0) {
         if (state.firstTabInLine !== -1) {
           state.position = state.firstTabInLine;
@@ -71006,8 +71462,8 @@ var require_loader = __commonJS({
         if (ch !== 45) {
           break;
         }
-        following = state.input.charCodeAt(state.position + 1);
-        if (!is_WS_OR_EOL(following)) {
+        const following = state.input.charCodeAt(state.position + 1);
+        if (!isWsOrEol(following)) {
           break;
         }
         detected = true;
@@ -71019,7 +71475,7 @@ var require_loader = __commonJS({
             continue;
           }
         }
-        _line = state.line;
+        const _line = state.line;
         composeNode(state, nodeIndent, CONTEXT_BLOCK_IN, false, true);
         _result.push(state.result);
         skipSeparationSpace(state, true, -1);
@@ -71040,20 +71496,32 @@ var require_loader = __commonJS({
       return false;
     }
     function readBlockMapping(state, nodeIndent, flowIndent) {
-      var following, allowCompact, _line, _keyLine, _keyLineStart, _keyPos, _tag = state.tag, _anchor = state.anchor, _result = {}, overridableKeys = /* @__PURE__ */ Object.create(null), keyTag = null, keyNode = null, valueNode = null, atExplicitKey = false, detected = false, ch;
+      let allowCompact;
+      let _keyLine;
+      let _keyLineStart;
+      let _keyPos;
+      const _tag = state.tag;
+      const _anchor = state.anchor;
+      const _result = {};
+      const overridableKeys = /* @__PURE__ */ Object.create(null);
+      let keyTag = null;
+      let keyNode = null;
+      let valueNode = null;
+      let atExplicitKey = false;
+      let detected = false;
       if (state.firstTabInLine !== -1) return false;
       if (state.anchor !== null) {
-        state.anchorMap[state.anchor] = _result;
+        storeAnchor(state, state.anchor, _result);
       }
-      ch = state.input.charCodeAt(state.position);
+      let ch = state.input.charCodeAt(state.position);
       while (ch !== 0) {
         if (!atExplicitKey && state.firstTabInLine !== -1) {
           state.position = state.firstTabInLine;
           throwError(state, "tab characters must not be used in indentation");
         }
-        following = state.input.charCodeAt(state.position + 1);
-        _line = state.line;
-        if ((ch === 63 || ch === 58) && is_WS_OR_EOL(following)) {
+        const following = state.input.charCodeAt(state.position + 1);
+        const _line = state.line;
+        if ((ch === 63 || ch === 58) && isWsOrEol(following)) {
           if (ch === 63) {
             if (atExplicitKey) {
               storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null, _keyLine, _keyLineStart, _keyPos);
@@ -71079,12 +71547,12 @@ var require_loader = __commonJS({
           }
           if (state.line === _line) {
             ch = state.input.charCodeAt(state.position);
-            while (is_WHITE_SPACE(ch)) {
+            while (isWhiteSpace(ch)) {
               ch = state.input.charCodeAt(++state.position);
             }
             if (ch === 58) {
               ch = state.input.charCodeAt(++state.position);
-              if (!is_WS_OR_EOL(ch)) {
+              if (!isWsOrEol(ch)) {
                 throwError(state, "a whitespace character is expected after the key-value separator within a block mapping");
               }
               if (atExplicitKey) {
@@ -71149,8 +71617,11 @@ var require_loader = __commonJS({
       return detected;
     }
     function readTagProperty(state) {
-      var _position, isVerbatim = false, isNamed = false, tagHandle, tagName, ch;
-      ch = state.input.charCodeAt(state.position);
+      let isVerbatim = false;
+      let isNamed = false;
+      let tagHandle;
+      let tagName;
+      let ch = state.input.charCodeAt(state.position);
       if (ch !== 33) return false;
       if (state.tag !== null) {
         throwError(state, "duplication of a tag property");
@@ -71166,7 +71637,7 @@ var require_loader = __commonJS({
       } else {
         tagHandle = "!";
       }
-      _position = state.position;
+      let _position = state.position;
       if (isVerbatim) {
         do {
           ch = state.input.charCodeAt(++state.position);
@@ -71178,7 +71649,7 @@ var require_loader = __commonJS({
           throwError(state, "unexpected end of the stream within a verbatim tag");
         }
       } else {
-        while (ch !== 0 && !is_WS_OR_EOL(ch)) {
+        while (ch !== 0 && !isWsOrEol(ch)) {
           if (ch === 33) {
             if (!isNamed) {
               tagHandle = state.input.slice(_position - 1, state.position + 1);
@@ -71220,15 +71691,14 @@ var require_loader = __commonJS({
       return true;
     }
     function readAnchorProperty(state) {
-      var _position, ch;
-      ch = state.input.charCodeAt(state.position);
+      let ch = state.input.charCodeAt(state.position);
       if (ch !== 38) return false;
       if (state.anchor !== null) {
         throwError(state, "duplication of an anchor property");
       }
       ch = state.input.charCodeAt(++state.position);
-      _position = state.position;
-      while (ch !== 0 && !is_WS_OR_EOL(ch) && !is_FLOW_INDICATOR(ch)) {
+      const _position = state.position;
+      while (ch !== 0 && !isWsOrEol(ch) && !isFlowIndicator(ch)) {
         ch = state.input.charCodeAt(++state.position);
       }
       if (state.position === _position) {
@@ -71238,18 +71708,17 @@ var require_loader = __commonJS({
       return true;
     }
     function readAlias(state) {
-      var _position, alias, ch;
-      ch = state.input.charCodeAt(state.position);
+      let ch = state.input.charCodeAt(state.position);
       if (ch !== 42) return false;
       ch = state.input.charCodeAt(++state.position);
-      _position = state.position;
-      while (ch !== 0 && !is_WS_OR_EOL(ch) && !is_FLOW_INDICATOR(ch)) {
+      const _position = state.position;
+      while (ch !== 0 && !isWsOrEol(ch) && !isFlowIndicator(ch)) {
         ch = state.input.charCodeAt(++state.position);
       }
       if (state.position === _position) {
         throwError(state, "name of an alias node must contain at least one character");
       }
-      alias = state.input.slice(_position, state.position);
+      const alias = state.input.slice(_position, state.position);
       if (!_hasOwnProperty.call(state.anchorMap, alias)) {
         throwError(state, 'unidentified alias "' + alias + '"');
       }
@@ -71257,8 +71726,36 @@ var require_loader = __commonJS({
       skipSeparationSpace(state, true, -1);
       return true;
     }
+    function tryReadBlockMappingFromProperty(state, propertyStart, nodeIndent, flowIndent) {
+      const fallbackState = snapshotState(state);
+      beginAnchorTransaction(state);
+      restoreState(state, propertyStart);
+      state.tag = null;
+      state.anchor = null;
+      state.kind = null;
+      state.result = null;
+      if (readBlockMapping(state, nodeIndent, flowIndent) && state.kind === "mapping") {
+        commitAnchorTransaction(state);
+        return true;
+      }
+      rollbackAnchorTransaction(state);
+      restoreState(state, fallbackState);
+      return false;
+    }
     function composeNode(state, parentIndent, nodeContext, allowToSeek, allowCompact) {
-      var allowBlockStyles, allowBlockScalars, allowBlockCollections, indentStatus = 1, atNewLine = false, hasContent = false, typeIndex, typeQuantity, typeList, type, flowIndent, blockIndent;
+      let allowBlockScalars;
+      let allowBlockCollections;
+      let indentStatus = 1;
+      let atNewLine = false;
+      let hasContent = false;
+      let propertyStart = null;
+      let type;
+      let flowIndent;
+      let blockIndent;
+      if (state.depth >= state.maxDepth) {
+        throwError(state, "nesting exceeded maxDepth (" + state.maxDepth + ")");
+      }
+      state.depth += 1;
       if (state.listener !== null) {
         state.listener("open", state);
       }
@@ -71266,7 +71763,7 @@ var require_loader = __commonJS({
       state.anchor = null;
       state.kind = null;
       state.result = null;
-      allowBlockStyles = allowBlockScalars = allowBlockCollections = CONTEXT_BLOCK_OUT === nodeContext || CONTEXT_BLOCK_IN === nodeContext;
+      const allowBlockStyles = allowBlockScalars = allowBlockCollections = CONTEXT_BLOCK_OUT === nodeContext || CONTEXT_BLOCK_IN === nodeContext;
       if (allowToSeek) {
         if (skipSeparationSpace(state, true, -1)) {
           atNewLine = true;
@@ -71280,7 +71777,18 @@ var require_loader = __commonJS({
         }
       }
       if (indentStatus === 1) {
-        while (readTagProperty(state) || readAnchorProperty(state)) {
+        while (true) {
+          const ch = state.input.charCodeAt(state.position);
+          const propertyState = snapshotState(state);
+          if (atNewLine && (ch === 33 && state.tag !== null || ch === 38 && state.anchor !== null)) {
+            break;
+          }
+          if (!readTagProperty(state) && !readAnchorProperty(state)) {
+            break;
+          }
+          if (propertyStart === null) {
+            propertyStart = propertyState;
+          }
           if (skipSeparationSpace(state, true, -1)) {
             atNewLine = true;
             allowBlockCollections = allowBlockStyles;
@@ -71310,7 +71818,15 @@ var require_loader = __commonJS({
           if (allowBlockCollections && (readBlockSequence(state, blockIndent) || readBlockMapping(state, blockIndent, flowIndent)) || readFlowCollection(state, flowIndent)) {
             hasContent = true;
           } else {
-            if (allowBlockScalars && readBlockScalar(state, flowIndent) || readSingleQuotedScalar(state, flowIndent) || readDoubleQuotedScalar(state, flowIndent)) {
+            const ch = state.input.charCodeAt(state.position);
+            if (propertyStart !== null && allowBlockStyles && !allowBlockCollections && ch !== 124 && ch !== 62 && tryReadBlockMappingFromProperty(
+              state,
+              propertyStart,
+              propertyStart.position - propertyStart.lineStart,
+              flowIndent
+            )) {
+              hasContent = true;
+            } else if (allowBlockScalars && readBlockScalar(state, flowIndent) || readSingleQuotedScalar(state, flowIndent) || readDoubleQuotedScalar(state, flowIndent)) {
               hasContent = true;
             } else if (readAlias(state)) {
               hasContent = true;
@@ -71324,7 +71840,7 @@ var require_loader = __commonJS({
               }
             }
             if (state.anchor !== null) {
-              state.anchorMap[state.anchor] = state.result;
+              storeAnchor(state, state.anchor, state.result);
             }
           }
         } else if (indentStatus === 0) {
@@ -71333,19 +71849,19 @@ var require_loader = __commonJS({
       }
       if (state.tag === null) {
         if (state.anchor !== null) {
-          state.anchorMap[state.anchor] = state.result;
+          storeAnchor(state, state.anchor, state.result);
         }
       } else if (state.tag === "?") {
         if (state.result !== null && state.kind !== "scalar") {
           throwError(state, 'unacceptable node kind for !<?> tag; it should be "scalar", not "' + state.kind + '"');
         }
-        for (typeIndex = 0, typeQuantity = state.implicitTypes.length; typeIndex < typeQuantity; typeIndex += 1) {
+        for (let typeIndex = 0, typeQuantity = state.implicitTypes.length; typeIndex < typeQuantity; typeIndex += 1) {
           type = state.implicitTypes[typeIndex];
           if (type.resolve(state.result)) {
             state.result = type.construct(state.result);
             state.tag = type.tag;
             if (state.anchor !== null) {
-              state.anchorMap[state.anchor] = state.result;
+              storeAnchor(state, state.anchor, state.result);
             }
             break;
           }
@@ -71355,8 +71871,8 @@ var require_loader = __commonJS({
           type = state.typeMap[state.kind || "fallback"][state.tag];
         } else {
           type = null;
-          typeList = state.typeMap.multi[state.kind || "fallback"];
-          for (typeIndex = 0, typeQuantity = typeList.length; typeIndex < typeQuantity; typeIndex += 1) {
+          const typeList = state.typeMap.multi[state.kind || "fallback"];
+          for (let typeIndex = 0, typeQuantity = typeList.length; typeIndex < typeQuantity; typeIndex += 1) {
             if (state.tag.slice(0, typeList[typeIndex].tag.length) === typeList[typeIndex].tag) {
               type = typeList[typeIndex];
               break;
@@ -71374,17 +71890,20 @@ var require_loader = __commonJS({
         } else {
           state.result = type.construct(state.result, state.tag);
           if (state.anchor !== null) {
-            state.anchorMap[state.anchor] = state.result;
+            storeAnchor(state, state.anchor, state.result);
           }
         }
       }
       if (state.listener !== null) {
         state.listener("close", state);
       }
+      state.depth -= 1;
       return state.tag !== null || state.anchor !== null || hasContent;
     }
     function readDocument(state) {
-      var documentStart = state.position, _position, directiveName, directiveArgs, hasDirectives = false, ch;
+      const documentStart = state.position;
+      let hasDirectives = false;
+      let ch;
       state.version = null;
       state.checkLineBreaks = state.legacy;
       state.tagMap = /* @__PURE__ */ Object.create(null);
@@ -71397,28 +71916,28 @@ var require_loader = __commonJS({
         }
         hasDirectives = true;
         ch = state.input.charCodeAt(++state.position);
-        _position = state.position;
-        while (ch !== 0 && !is_WS_OR_EOL(ch)) {
+        let _position = state.position;
+        while (ch !== 0 && !isWsOrEol(ch)) {
           ch = state.input.charCodeAt(++state.position);
         }
-        directiveName = state.input.slice(_position, state.position);
-        directiveArgs = [];
+        const directiveName = state.input.slice(_position, state.position);
+        const directiveArgs = [];
         if (directiveName.length < 1) {
           throwError(state, "directive name must not be less than one character in length");
         }
         while (ch !== 0) {
-          while (is_WHITE_SPACE(ch)) {
+          while (isWhiteSpace(ch)) {
             ch = state.input.charCodeAt(++state.position);
           }
           if (ch === 35) {
             do {
               ch = state.input.charCodeAt(++state.position);
-            } while (ch !== 0 && !is_EOL(ch));
+            } while (ch !== 0 && !isEol(ch));
             break;
           }
-          if (is_EOL(ch)) break;
+          if (isEol(ch)) break;
           _position = state.position;
-          while (ch !== 0 && !is_WS_OR_EOL(ch)) {
+          while (ch !== 0 && !isWsOrEol(ch)) {
             ch = state.input.charCodeAt(++state.position);
           }
           directiveArgs.push(state.input.slice(_position, state.position));
@@ -71452,8 +71971,6 @@ var require_loader = __commonJS({
       }
       if (state.position < state.length - 1) {
         throwError(state, "end of the stream or a document separator is expected");
-      } else {
-        return;
       }
     }
     function loadDocuments(input, options2) {
@@ -71467,8 +71984,8 @@ var require_loader = __commonJS({
           input = input.slice(1);
         }
       }
-      var state = new State(input, options2);
-      var nullpos = input.indexOf("\0");
+      const state = new State(input, options2);
+      const nullpos = input.indexOf("\0");
       if (nullpos !== -1) {
         state.position = nullpos;
         throwError(state, "null byte is not allowed in input");
@@ -71488,16 +72005,16 @@ var require_loader = __commonJS({
         options2 = iterator;
         iterator = null;
       }
-      var documents = loadDocuments(input, options2);
+      const documents = loadDocuments(input, options2);
       if (typeof iterator !== "function") {
         return documents;
       }
-      for (var index = 0, length = documents.length; index < length; index += 1) {
+      for (let index = 0, length = documents.length; index < length; index += 1) {
         iterator(documents[index]);
       }
     }
     function load(input, options2) {
-      var documents = loadDocuments(input, options2);
+      const documents = loadDocuments(input, options2);
       if (documents.length === 0) {
         return void 0;
       } else if (documents.length === 1) {
@@ -71580,17 +72097,16 @@ var require_dumper = __commonJS({
     ];
     var DEPRECATED_BASE60_SYNTAX = /^[-+]?[0-9_]+(?::[0-9_]+)+(?:\.[0-9_]*)?$/;
     function compileStyleMap(schema, map) {
-      var result, keys, index, length, tag, style, type;
       if (map === null) return {};
-      result = {};
-      keys = Object.keys(map);
-      for (index = 0, length = keys.length; index < length; index += 1) {
-        tag = keys[index];
-        style = String(map[tag]);
+      const result = {};
+      const keys = Object.keys(map);
+      for (let index = 0, length = keys.length; index < length; index += 1) {
+        let tag = keys[index];
+        let style = String(map[tag]);
         if (tag.slice(0, 2) === "!!") {
           tag = "tag:yaml.org,2002:" + tag.slice(2);
         }
-        type = schema.compiledTypeMap["fallback"][tag];
+        const type = schema.compiledTypeMap["fallback"][tag];
         if (type && _hasOwnProperty.call(type.styleAliases, style)) {
           style = type.styleAliases[style];
         }
@@ -71599,8 +72115,9 @@ var require_dumper = __commonJS({
       return result;
     }
     function encodeHex(character) {
-      var string, handle, length;
-      string = character.toString(16).toUpperCase();
+      let handle;
+      let length;
+      const string = character.toString(16).toUpperCase();
       if (character <= 255) {
         handle = "x";
         length = 2;
@@ -71640,9 +72157,13 @@ var require_dumper = __commonJS({
       this.usedDuplicates = null;
     }
     function indentString(string, spaces) {
-      var ind = common.repeat(" ", spaces), position = 0, next = -1, result = "", line, length = string.length;
+      const ind = common.repeat(" ", spaces);
+      let position = 0;
+      let result = "";
+      const length = string.length;
       while (position < length) {
-        next = string.indexOf("\n", position);
+        let line;
+        const next = string.indexOf("\n", position);
         if (next === -1) {
           line = string.slice(position);
           position = length;
@@ -71659,9 +72180,8 @@ var require_dumper = __commonJS({
       return "\n" + common.repeat(" ", state.indent * level);
     }
     function testImplicitResolving(state, str) {
-      var index, length, type;
-      for (index = 0, length = state.implicitTypes.length; index < length; index += 1) {
-        type = state.implicitTypes[index];
+      for (let index = 0, length = state.implicitTypes.length; index < length; index += 1) {
+        const type = state.implicitTypes[index];
         if (type.resolve(str)) {
           return true;
         }
@@ -71672,30 +72192,39 @@ var require_dumper = __commonJS({
       return c === CHAR_SPACE || c === CHAR_TAB;
     }
     function isPrintable(c) {
-      return 32 <= c && c <= 126 || 161 <= c && c <= 55295 && c !== 8232 && c !== 8233 || 57344 <= c && c <= 65533 && c !== CHAR_BOM || 65536 <= c && c <= 1114111;
+      return c >= 32 && c <= 126 || c >= 161 && c <= 55295 && c !== 8232 && c !== 8233 || c >= 57344 && c <= 65533 && c !== CHAR_BOM || c >= 65536 && c <= 1114111;
     }
     function isNsCharOrWhitespace(c) {
-      return isPrintable(c) && c !== CHAR_BOM && c !== CHAR_CARRIAGE_RETURN && c !== CHAR_LINE_FEED;
+      return isPrintable(c) && c !== CHAR_BOM && // - b-char
+      c !== CHAR_CARRIAGE_RETURN && c !== CHAR_LINE_FEED;
     }
     function isPlainSafe(c, prev, inblock) {
-      var cIsNsCharOrWhitespace = isNsCharOrWhitespace(c);
-      var cIsNsChar = cIsNsCharOrWhitespace && !isWhitespace(c);
+      const cIsNsCharOrWhitespace = isNsCharOrWhitespace(c);
+      const cIsNsChar = cIsNsCharOrWhitespace && !isWhitespace(c);
       return (
         // ns-plain-safe
-        (inblock ? (
-          // c = flow-in
-          cIsNsCharOrWhitespace
-        ) : cIsNsCharOrWhitespace && c !== CHAR_COMMA && c !== CHAR_LEFT_SQUARE_BRACKET && c !== CHAR_RIGHT_SQUARE_BRACKET && c !== CHAR_LEFT_CURLY_BRACKET && c !== CHAR_RIGHT_CURLY_BRACKET) && c !== CHAR_SHARP && !(prev === CHAR_COLON && !cIsNsChar) || isNsCharOrWhitespace(prev) && !isWhitespace(prev) && c === CHAR_SHARP || prev === CHAR_COLON && cIsNsChar
+        (inblock ? cIsNsCharOrWhitespace : cIsNsCharOrWhitespace && // - c-flow-indicator
+        c !== CHAR_COMMA && c !== CHAR_LEFT_SQUARE_BRACKET && c !== CHAR_RIGHT_SQUARE_BRACKET && c !== CHAR_LEFT_CURLY_BRACKET && c !== CHAR_RIGHT_CURLY_BRACKET) && // ns-plain-char
+        c !== CHAR_SHARP && // false on '#'
+        !(prev === CHAR_COLON && !cIsNsChar) || // false on ': '
+        isNsCharOrWhitespace(prev) && !isWhitespace(prev) && c === CHAR_SHARP || // change to true on '[^ ]#'
+        prev === CHAR_COLON && cIsNsChar
       );
     }
     function isPlainSafeFirst(c) {
-      return isPrintable(c) && c !== CHAR_BOM && !isWhitespace(c) && c !== CHAR_MINUS && c !== CHAR_QUESTION && c !== CHAR_COLON && c !== CHAR_COMMA && c !== CHAR_LEFT_SQUARE_BRACKET && c !== CHAR_RIGHT_SQUARE_BRACKET && c !== CHAR_LEFT_CURLY_BRACKET && c !== CHAR_RIGHT_CURLY_BRACKET && c !== CHAR_SHARP && c !== CHAR_AMPERSAND && c !== CHAR_ASTERISK && c !== CHAR_EXCLAMATION && c !== CHAR_VERTICAL_LINE && c !== CHAR_EQUALS && c !== CHAR_GREATER_THAN && c !== CHAR_SINGLE_QUOTE && c !== CHAR_DOUBLE_QUOTE && c !== CHAR_PERCENT && c !== CHAR_COMMERCIAL_AT && c !== CHAR_GRAVE_ACCENT;
+      return isPrintable(c) && c !== CHAR_BOM && !isWhitespace(c) && // - s-white
+      // - (c-indicator ::=
+      // “-” | “?” | “:” | “,” | “[” | “]” | “{” | “}”
+      c !== CHAR_MINUS && c !== CHAR_QUESTION && c !== CHAR_COLON && c !== CHAR_COMMA && c !== CHAR_LEFT_SQUARE_BRACKET && c !== CHAR_RIGHT_SQUARE_BRACKET && c !== CHAR_LEFT_CURLY_BRACKET && c !== CHAR_RIGHT_CURLY_BRACKET && // | “#” | “&” | “*” | “!” | “|” | “=” | “>” | “'” | “"”
+      c !== CHAR_SHARP && c !== CHAR_AMPERSAND && c !== CHAR_ASTERISK && c !== CHAR_EXCLAMATION && c !== CHAR_VERTICAL_LINE && c !== CHAR_EQUALS && c !== CHAR_GREATER_THAN && c !== CHAR_SINGLE_QUOTE && c !== CHAR_DOUBLE_QUOTE && // | “%” | “@” | “`”)
+      c !== CHAR_PERCENT && c !== CHAR_COMMERCIAL_AT && c !== CHAR_GRAVE_ACCENT;
     }
     function isPlainSafeLast(c) {
       return !isWhitespace(c) && c !== CHAR_COLON;
     }
     function codePointAt(string, pos) {
-      var first = string.charCodeAt(pos), second;
+      const first = string.charCodeAt(pos);
+      let second;
       if (first >= 55296 && first <= 56319 && pos + 1 < string.length) {
         second = string.charCodeAt(pos + 1);
         if (second >= 56320 && second <= 57343) {
@@ -71705,7 +72234,7 @@ var require_dumper = __commonJS({
       return first;
     }
     function needIndentIndicator(string) {
-      var leadingSpaceRe = /^\n* /;
+      const leadingSpaceRe = /^\n* /;
       return leadingSpaceRe.test(string);
     }
     var STYLE_PLAIN = 1;
@@ -71714,14 +72243,14 @@ var require_dumper = __commonJS({
     var STYLE_FOLDED = 4;
     var STYLE_DOUBLE = 5;
     function chooseScalarStyle(string, singleLineOnly, indentPerLevel, lineWidth, testAmbiguousType, quotingType, forceQuotes, inblock) {
-      var i;
-      var char = 0;
-      var prevChar = null;
-      var hasLineBreak = false;
-      var hasFoldableLine = false;
-      var shouldTrackWidth = lineWidth !== -1;
-      var previousLineBreak = -1;
-      var plain = isPlainSafeFirst(codePointAt(string, 0)) && isPlainSafeLast(codePointAt(string, string.length - 1));
+      let i;
+      let char = 0;
+      let prevChar = null;
+      let hasLineBreak = false;
+      let hasFoldableLine = false;
+      const shouldTrackWidth = lineWidth !== -1;
+      let previousLineBreak = -1;
+      let plain = isPlainSafeFirst(codePointAt(string, 0)) && isPlainSafeLast(codePointAt(string, string.length - 1));
       if (singleLineOnly || forceQuotes) {
         for (i = 0; i < string.length; char >= 65536 ? i += 2 : i++) {
           char = codePointAt(string, i);
@@ -71773,9 +72302,10 @@ var require_dumper = __commonJS({
             return state.quotingType === QUOTING_TYPE_DOUBLE ? '"' + string + '"' : "'" + string + "'";
           }
         }
-        var indent = state.indent * Math.max(1, level);
-        var lineWidth = state.lineWidth === -1 ? -1 : Math.max(Math.min(state.lineWidth, 40), state.lineWidth - indent);
-        var singleLineOnly = iskey || state.flowLevel > -1 && level >= state.flowLevel;
+        const indent = state.indent * Math.max(1, level);
+        const lineWidth = state.lineWidth === -1 ? -1 : Math.max(Math.min(state.lineWidth, 40), state.lineWidth - indent);
+        const singleLineOnly = iskey || // No block styles in flow mode.
+        state.flowLevel > -1 && level >= state.flowLevel;
         function testAmbiguity(string2) {
           return testImplicitResolving(state, string2);
         }
@@ -71805,28 +72335,29 @@ var require_dumper = __commonJS({
       })();
     }
     function blockHeader(string, indentPerLevel) {
-      var indentIndicator = needIndentIndicator(string) ? String(indentPerLevel) : "";
-      var clip = string[string.length - 1] === "\n";
-      var keep = clip && (string[string.length - 2] === "\n" || string === "\n");
-      var chomp = keep ? "+" : clip ? "" : "-";
+      const indentIndicator = needIndentIndicator(string) ? String(indentPerLevel) : "";
+      const clip = string[string.length - 1] === "\n";
+      const keep = clip && (string[string.length - 2] === "\n" || string === "\n");
+      const chomp = keep ? "+" : clip ? "" : "-";
       return indentIndicator + chomp + "\n";
     }
     function dropEndingNewline(string) {
       return string[string.length - 1] === "\n" ? string.slice(0, -1) : string;
     }
     function foldString(string, width) {
-      var lineRe = /(\n+)([^\n]*)/g;
-      var result = (function() {
-        var nextLF = string.indexOf("\n");
+      const lineRe = /(\n+)([^\n]*)/g;
+      let result = (function() {
+        let nextLF = string.indexOf("\n");
         nextLF = nextLF !== -1 ? nextLF : string.length;
         lineRe.lastIndex = nextLF;
         return foldLine(string.slice(0, nextLF), width);
       })();
-      var prevMoreIndented = string[0] === "\n" || string[0] === " ";
-      var moreIndented;
-      var match;
+      let prevMoreIndented = string[0] === "\n" || string[0] === " ";
+      let moreIndented;
+      let match;
       while (match = lineRe.exec(string)) {
-        var prefix = match[1], line = match[2];
+        const prefix = match[1];
+        const line = match[2];
         moreIndented = line[0] === " ";
         result += prefix + (!prevMoreIndented && !moreIndented && line !== "" ? "\n" : "") + foldLine(line, width);
         prevMoreIndented = moreIndented;
@@ -71835,10 +72366,13 @@ var require_dumper = __commonJS({
     }
     function foldLine(line, width) {
       if (line === "" || line[0] === " ") return line;
-      var breakRe = / [^ ]/g;
-      var match;
-      var start = 0, end, curr = 0, next = 0;
-      var result = "";
+      const breakRe = / [^ ]/g;
+      let match;
+      let start = 0;
+      let end;
+      let curr = 0;
+      let next = 0;
+      let result = "";
       while (match = breakRe.exec(line)) {
         next = match.index;
         if (next - start > width) {
@@ -71857,12 +72391,11 @@ var require_dumper = __commonJS({
       return result.slice(1);
     }
     function escapeString(string) {
-      var result = "";
-      var char = 0;
-      var escapeSeq;
-      for (var i = 0; i < string.length; char >= 65536 ? i += 2 : i++) {
+      let result = "";
+      let char = 0;
+      for (let i = 0; i < string.length; char >= 65536 ? i += 2 : i++) {
         char = codePointAt(string, i);
-        escapeSeq = ESCAPE_SEQUENCES[char];
+        const escapeSeq = ESCAPE_SEQUENCES[char];
         if (!escapeSeq && isPrintable(char)) {
           result += string[i];
           if (char >= 65536) result += string[i + 1];
@@ -71873,9 +72406,10 @@ var require_dumper = __commonJS({
       return result;
     }
     function writeFlowSequence(state, level, object) {
-      var _result = "", _tag = state.tag, index, length, value;
-      for (index = 0, length = object.length; index < length; index += 1) {
-        value = object[index];
+      let _result = "";
+      const _tag = state.tag;
+      for (let index = 0, length = object.length; index < length; index += 1) {
+        let value = object[index];
         if (state.replacer) {
           value = state.replacer.call(object, String(index), value);
         }
@@ -71888,9 +72422,10 @@ var require_dumper = __commonJS({
       state.dump = "[" + _result + "]";
     }
     function writeBlockSequence(state, level, object, compact) {
-      var _result = "", _tag = state.tag, index, length, value;
-      for (index = 0, length = object.length; index < length; index += 1) {
-        value = object[index];
+      let _result = "";
+      const _tag = state.tag;
+      for (let index = 0, length = object.length; index < length; index += 1) {
+        let value = object[index];
         if (state.replacer) {
           value = state.replacer.call(object, String(index), value);
         }
@@ -71910,13 +72445,15 @@ var require_dumper = __commonJS({
       state.dump = _result || "[]";
     }
     function writeFlowMapping(state, level, object) {
-      var _result = "", _tag = state.tag, objectKeyList = Object.keys(object), index, length, objectKey, objectValue, pairBuffer;
-      for (index = 0, length = objectKeyList.length; index < length; index += 1) {
-        pairBuffer = "";
+      let _result = "";
+      const _tag = state.tag;
+      const objectKeyList = Object.keys(object);
+      for (let index = 0, length = objectKeyList.length; index < length; index += 1) {
+        let pairBuffer = "";
         if (_result !== "") pairBuffer += ", ";
         if (state.condenseFlow) pairBuffer += '"';
-        objectKey = objectKeyList[index];
-        objectValue = object[objectKey];
+        const objectKey = objectKeyList[index];
+        let objectValue = object[objectKey];
         if (state.replacer) {
           objectValue = state.replacer.call(object, objectKey, objectValue);
         }
@@ -71935,7 +72472,9 @@ var require_dumper = __commonJS({
       state.dump = "{" + _result + "}";
     }
     function writeBlockMapping(state, level, object, compact) {
-      var _result = "", _tag = state.tag, objectKeyList = Object.keys(object), index, length, objectKey, objectValue, explicitPair, pairBuffer;
+      let _result = "";
+      const _tag = state.tag;
+      const objectKeyList = Object.keys(object);
       if (state.sortKeys === true) {
         objectKeyList.sort();
       } else if (typeof state.sortKeys === "function") {
@@ -71943,20 +72482,20 @@ var require_dumper = __commonJS({
       } else if (state.sortKeys) {
         throw new YAMLException("sortKeys must be a boolean or a function");
       }
-      for (index = 0, length = objectKeyList.length; index < length; index += 1) {
-        pairBuffer = "";
+      for (let index = 0, length = objectKeyList.length; index < length; index += 1) {
+        let pairBuffer = "";
         if (!compact || _result !== "") {
           pairBuffer += generateNextLine(state, level);
         }
-        objectKey = objectKeyList[index];
-        objectValue = object[objectKey];
+        const objectKey = objectKeyList[index];
+        let objectValue = object[objectKey];
         if (state.replacer) {
           objectValue = state.replacer.call(object, objectKey, objectValue);
         }
         if (!writeNode(state, level + 1, objectKey, true, true, true)) {
           continue;
         }
-        explicitPair = state.tag !== null && state.tag !== "?" || state.dump && state.dump.length > 1024;
+        const explicitPair = state.tag !== null && state.tag !== "?" || state.dump && state.dump.length > 1024;
         if (explicitPair) {
           if (state.dump && CHAR_LINE_FEED === state.dump.charCodeAt(0)) {
             pairBuffer += "?";
@@ -71983,10 +72522,9 @@ var require_dumper = __commonJS({
       state.dump = _result || "{}";
     }
     function detectType(state, object, explicit) {
-      var _result, typeList, index, length, type, style;
-      typeList = explicit ? state.explicitTypes : state.implicitTypes;
-      for (index = 0, length = typeList.length; index < length; index += 1) {
-        type = typeList[index];
+      const typeList = explicit ? state.explicitTypes : state.implicitTypes;
+      for (let index = 0, length = typeList.length; index < length; index += 1) {
+        const type = typeList[index];
         if ((type.instanceOf || type.predicate) && (!type.instanceOf || typeof object === "object" && object instanceof type.instanceOf) && (!type.predicate || type.predicate(object))) {
           if (explicit) {
             if (type.multi && type.representName) {
@@ -71998,7 +72536,8 @@ var require_dumper = __commonJS({
             state.tag = "?";
           }
           if (type.represent) {
-            style = state.styleMap[type.tag] || type.defaultStyle;
+            const style = state.styleMap[type.tag] || type.defaultStyle;
+            let _result;
             if (_toString.call(type.represent) === "[object Function]") {
               _result = type.represent(object, style);
             } else if (_hasOwnProperty.call(type.represent, style)) {
@@ -72019,13 +72558,14 @@ var require_dumper = __commonJS({
       if (!detectType(state, object, false)) {
         detectType(state, object, true);
       }
-      var type = _toString.call(state.dump);
-      var inblock = block;
-      var tagStr;
+      const type = _toString.call(state.dump);
+      const inblock = block;
       if (block) {
         block = state.flowLevel < 0 || state.flowLevel > level;
       }
-      var objectOrArray = type === "[object Object]" || type === "[object Array]", duplicateIndex, duplicate;
+      const objectOrArray = type === "[object Object]" || type === "[object Array]";
+      let duplicateIndex;
+      let duplicate;
       if (objectOrArray) {
         duplicateIndex = state.duplicates.indexOf(object);
         duplicate = duplicateIndex !== -1;
@@ -72078,7 +72618,7 @@ var require_dumper = __commonJS({
           throw new YAMLException("unacceptable kind of an object to dump " + type);
         }
         if (state.tag !== null && state.tag !== "?") {
-          tagStr = encodeURI(
+          let tagStr = encodeURI(
             state.tag[0] === "!" ? state.tag.slice(1) : state.tag
           ).replace(/!/g, "%21");
           if (state.tag[0] === "!") {
@@ -72094,17 +72634,18 @@ var require_dumper = __commonJS({
       return true;
     }
     function getDuplicateReferences(object, state) {
-      var objects = [], duplicatesIndexes = [], index, length;
+      const objects = [];
+      const duplicatesIndexes = [];
       inspectNode(object, objects, duplicatesIndexes);
-      for (index = 0, length = duplicatesIndexes.length; index < length; index += 1) {
+      const length = duplicatesIndexes.length;
+      for (let index = 0; index < length; index += 1) {
         state.duplicates.push(objects[duplicatesIndexes[index]]);
       }
       state.usedDuplicates = new Array(length);
     }
     function inspectNode(object, objects, duplicatesIndexes) {
-      var objectKeyList, index, length;
       if (object !== null && typeof object === "object") {
-        index = objects.indexOf(object);
+        const index = objects.indexOf(object);
         if (index !== -1) {
           if (duplicatesIndexes.indexOf(index) === -1) {
             duplicatesIndexes.push(index);
@@ -72112,13 +72653,13 @@ var require_dumper = __commonJS({
         } else {
           objects.push(object);
           if (Array.isArray(object)) {
-            for (index = 0, length = object.length; index < length; index += 1) {
-              inspectNode(object[index], objects, duplicatesIndexes);
+            for (let i = 0, length = object.length; i < length; i += 1) {
+              inspectNode(object[i], objects, duplicatesIndexes);
             }
           } else {
-            objectKeyList = Object.keys(object);
-            for (index = 0, length = objectKeyList.length; index < length; index += 1) {
-              inspectNode(object[objectKeyList[index]], objects, duplicatesIndexes);
+            const objectKeyList = Object.keys(object);
+            for (let i = 0, length = objectKeyList.length; i < length; i += 1) {
+              inspectNode(object[objectKeyList[i]], objects, duplicatesIndexes);
             }
           }
         }
@@ -72126,9 +72667,9 @@ var require_dumper = __commonJS({
     }
     function dump(input, options2) {
       options2 = options2 || {};
-      var state = new State(options2);
+      const state = new State(options2);
       if (!state.noRefs) getDuplicateReferences(input, state);
-      var value = input;
+      let value = input;
       if (state.replacer) {
         value = state.replacer.call({ "": value }, "", value);
       }
@@ -72182,7 +72723,7 @@ var require_js_yaml = __commonJS({
 });
 
 // node_modules/@probot/octokit-plugin-config/dist-node/index.js
-var require_dist_node17 = __commonJS({
+var require_dist_node16 = __commonJS({
   "node_modules/@probot/octokit-plugin-config/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -72408,7 +72949,7 @@ var require_dist_node17 = __commonJS({
 });
 
 // node_modules/@octokit/auth-unauthenticated/dist-node/index.js
-var require_dist_node18 = __commonJS({
+var require_dist_node17 = __commonJS({
   "node_modules/@octokit/auth-unauthenticated/dist-node/index.js"(exports2, module2) {
     "use strict";
     var __defProp2 = Object.defineProperty;
@@ -72500,7 +73041,7 @@ var require_dist_node18 = __commonJS({
 });
 
 // node_modules/octokit-auth-probot/node_modules/@octokit/auth-token/dist-node/index.js
-var require_dist_node19 = __commonJS({
+var require_dist_node18 = __commonJS({
   "node_modules/octokit-auth-probot/node_modules/@octokit/auth-token/dist-node/index.js"(exports2, module2) {
     "use strict";
     var __defProp2 = Object.defineProperty;
@@ -72570,9 +73111,9 @@ var require_dist_node19 = __commonJS({
   }
 });
 
-// node_modules/@octokit/request/node_modules/@octokit/endpoint/dist-node/index.js
-var require_dist_node20 = __commonJS({
-  "node_modules/@octokit/request/node_modules/@octokit/endpoint/dist-node/index.js"(exports2, module2) {
+// node_modules/@octokit/auth-app/node_modules/@octokit/endpoint/dist-node/index.js
+var require_dist_node19 = __commonJS({
+  "node_modules/@octokit/auth-app/node_modules/@octokit/endpoint/dist-node/index.js"(exports2, module2) {
     "use strict";
     var __defProp2 = Object.defineProperty;
     var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
@@ -72895,9 +73436,9 @@ var require_dist_node20 = __commonJS({
   }
 });
 
-// node_modules/@octokit/request/node_modules/@octokit/request-error/dist-node/index.js
-var require_dist_node21 = __commonJS({
-  "node_modules/@octokit/request/node_modules/@octokit/request-error/dist-node/index.js"(exports2) {
+// node_modules/@octokit/auth-app/node_modules/@octokit/request-error/dist-node/index.js
+var require_dist_node20 = __commonJS({
+  "node_modules/@octokit/auth-app/node_modules/@octokit/request-error/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     function _interopDefault(ex) {
@@ -72949,9 +73490,9 @@ var require_dist_node21 = __commonJS({
   }
 });
 
-// node_modules/@octokit/request/dist-node/index.js
-var require_dist_node22 = __commonJS({
-  "node_modules/@octokit/request/dist-node/index.js"(exports2, module2) {
+// node_modules/@octokit/auth-app/node_modules/@octokit/request/dist-node/index.js
+var require_dist_node21 = __commonJS({
+  "node_modules/@octokit/auth-app/node_modules/@octokit/request/dist-node/index.js"(exports2, module2) {
     "use strict";
     var __create2 = Object.create;
     var __defProp2 = Object.defineProperty;
@@ -72985,12 +73526,586 @@ var require_dist_node22 = __commonJS({
       request: () => request
     });
     module2.exports = __toCommonJS2(dist_src_exports);
-    var import_endpoint = require_dist_node20();
+    var import_endpoint = require_dist_node19();
     var import_universal_user_agent = require_dist_node3();
     var VERSION = "6.2.8";
     var import_is_plain_object = require_is_plain_object();
     var import_node_fetch = __toESM2(require_lib6());
-    var import_request_error = require_dist_node21();
+    var import_request_error = require_dist_node20();
+    function getBufferResponse(response) {
+      return response.arrayBuffer();
+    }
+    function fetchWrapper(requestOptions) {
+      const log = requestOptions.request && requestOptions.request.log ? requestOptions.request.log : console;
+      if ((0, import_is_plain_object.isPlainObject)(requestOptions.body) || Array.isArray(requestOptions.body)) {
+        requestOptions.body = JSON.stringify(requestOptions.body);
+      }
+      let headers = {};
+      let status;
+      let url;
+      const fetch2 = requestOptions.request && requestOptions.request.fetch || globalThis.fetch || /* istanbul ignore next */
+      import_node_fetch.default;
+      return fetch2(
+        requestOptions.url,
+        Object.assign(
+          {
+            method: requestOptions.method,
+            body: requestOptions.body,
+            headers: requestOptions.headers,
+            redirect: requestOptions.redirect,
+            // duplex must be set if request.body is ReadableStream or Async Iterables.
+            // See https://fetch.spec.whatwg.org/#dom-requestinit-duplex.
+            ...requestOptions.body && { duplex: "half" }
+          },
+          // `requestOptions.request.agent` type is incompatible
+          // see https://github.com/octokit/types.ts/pull/264
+          requestOptions.request
+        )
+      ).then(async (response) => {
+        url = response.url;
+        status = response.status;
+        for (const keyAndValue of response.headers) {
+          headers[keyAndValue[0]] = keyAndValue[1];
+        }
+        if ("deprecation" in headers) {
+          const matches = headers.link && headers.link.match(/<([^>]+)>; rel="deprecation"/);
+          const deprecationLink = matches && matches.pop();
+          log.warn(
+            `[@octokit/request] "${requestOptions.method} ${requestOptions.url}" is deprecated. It is scheduled to be removed on ${headers.sunset}${deprecationLink ? `. See ${deprecationLink}` : ""}`
+          );
+        }
+        if (status === 204 || status === 205) {
+          return;
+        }
+        if (requestOptions.method === "HEAD") {
+          if (status < 400) {
+            return;
+          }
+          throw new import_request_error.RequestError(response.statusText, status, {
+            response: {
+              url,
+              status,
+              headers,
+              data: void 0
+            },
+            request: requestOptions
+          });
+        }
+        if (status === 304) {
+          throw new import_request_error.RequestError("Not modified", status, {
+            response: {
+              url,
+              status,
+              headers,
+              data: await getResponseData(response)
+            },
+            request: requestOptions
+          });
+        }
+        if (status >= 400) {
+          const data = await getResponseData(response);
+          const error = new import_request_error.RequestError(toErrorMessage(data), status, {
+            response: {
+              url,
+              status,
+              headers,
+              data
+            },
+            request: requestOptions
+          });
+          throw error;
+        }
+        return getResponseData(response);
+      }).then((data) => {
+        return {
+          status,
+          url,
+          headers,
+          data
+        };
+      }).catch((error) => {
+        if (error instanceof import_request_error.RequestError)
+          throw error;
+        else if (error.name === "AbortError")
+          throw error;
+        throw new import_request_error.RequestError(error.message, 500, {
+          request: requestOptions
+        });
+      });
+    }
+    async function getResponseData(response) {
+      const contentType = response.headers.get("content-type");
+      if (/application\/json/.test(contentType)) {
+        return response.json();
+      }
+      if (!contentType || /^text\/|charset=utf-8$/.test(contentType)) {
+        return response.text();
+      }
+      return getBufferResponse(response);
+    }
+    function toErrorMessage(data) {
+      if (typeof data === "string")
+        return data;
+      if ("message" in data) {
+        if (Array.isArray(data.errors)) {
+          return `${data.message}: ${data.errors.map(JSON.stringify).join(", ")}`;
+        }
+        return data.message;
+      }
+      return `Unknown error: ${JSON.stringify(data)}`;
+    }
+    function withDefaults(oldEndpoint, newDefaults) {
+      const endpoint2 = oldEndpoint.defaults(newDefaults);
+      const newApi = function(route, parameters) {
+        const endpointOptions = endpoint2.merge(route, parameters);
+        if (!endpointOptions.request || !endpointOptions.request.hook) {
+          return fetchWrapper(endpoint2.parse(endpointOptions));
+        }
+        const request2 = (route2, parameters2) => {
+          return fetchWrapper(
+            endpoint2.parse(endpoint2.merge(route2, parameters2))
+          );
+        };
+        Object.assign(request2, {
+          endpoint: endpoint2,
+          defaults: withDefaults.bind(null, endpoint2)
+        });
+        return endpointOptions.request.hook(request2, endpointOptions);
+      };
+      return Object.assign(newApi, {
+        endpoint: endpoint2,
+        defaults: withDefaults.bind(null, endpoint2)
+      });
+    }
+    var request = withDefaults(import_endpoint.endpoint, {
+      headers: {
+        "user-agent": `octokit-request.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`
+      }
+    });
+  }
+});
+
+// node_modules/@octokit/auth-oauth-app/node_modules/@octokit/endpoint/dist-node/index.js
+var require_dist_node22 = __commonJS({
+  "node_modules/@octokit/auth-oauth-app/node_modules/@octokit/endpoint/dist-node/index.js"(exports2, module2) {
+    "use strict";
+    var __defProp2 = Object.defineProperty;
+    var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
+    var __getOwnPropNames2 = Object.getOwnPropertyNames;
+    var __hasOwnProp2 = Object.prototype.hasOwnProperty;
+    var __export2 = (target, all) => {
+      for (var name in all)
+        __defProp2(target, name, { get: all[name], enumerable: true });
+    };
+    var __copyProps2 = (to, from, except, desc) => {
+      if (from && typeof from === "object" || typeof from === "function") {
+        for (let key of __getOwnPropNames2(from))
+          if (!__hasOwnProp2.call(to, key) && key !== except)
+            __defProp2(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc2(from, key)) || desc.enumerable });
+      }
+      return to;
+    };
+    var __toCommonJS2 = (mod) => __copyProps2(__defProp2({}, "__esModule", { value: true }), mod);
+    var dist_src_exports = {};
+    __export2(dist_src_exports, {
+      endpoint: () => endpoint
+    });
+    module2.exports = __toCommonJS2(dist_src_exports);
+    function lowercaseKeys(object) {
+      if (!object) {
+        return {};
+      }
+      return Object.keys(object).reduce((newObj, key) => {
+        newObj[key.toLowerCase()] = object[key];
+        return newObj;
+      }, {});
+    }
+    var import_is_plain_object = require_is_plain_object();
+    function mergeDeep(defaults, options2) {
+      const result = Object.assign({}, defaults);
+      Object.keys(options2).forEach((key) => {
+        if ((0, import_is_plain_object.isPlainObject)(options2[key])) {
+          if (!(key in defaults))
+            Object.assign(result, { [key]: options2[key] });
+          else
+            result[key] = mergeDeep(defaults[key], options2[key]);
+        } else {
+          Object.assign(result, { [key]: options2[key] });
+        }
+      });
+      return result;
+    }
+    function removeUndefinedProperties(obj) {
+      for (const key in obj) {
+        if (obj[key] === void 0) {
+          delete obj[key];
+        }
+      }
+      return obj;
+    }
+    function merge(defaults, route, options2) {
+      if (typeof route === "string") {
+        let [method, url] = route.split(" ");
+        options2 = Object.assign(url ? { method, url } : { url: method }, options2);
+      } else {
+        options2 = Object.assign({}, route);
+      }
+      options2.headers = lowercaseKeys(options2.headers);
+      removeUndefinedProperties(options2);
+      removeUndefinedProperties(options2.headers);
+      const mergedOptions = mergeDeep(defaults || {}, options2);
+      if (defaults && defaults.mediaType.previews.length) {
+        mergedOptions.mediaType.previews = defaults.mediaType.previews.filter((preview) => !mergedOptions.mediaType.previews.includes(preview)).concat(mergedOptions.mediaType.previews);
+      }
+      mergedOptions.mediaType.previews = mergedOptions.mediaType.previews.map(
+        (preview) => preview.replace(/-preview/, "")
+      );
+      return mergedOptions;
+    }
+    function addQueryParameters(url, parameters) {
+      const separator = /\?/.test(url) ? "&" : "?";
+      const names = Object.keys(parameters);
+      if (names.length === 0) {
+        return url;
+      }
+      return url + separator + names.map((name) => {
+        if (name === "q") {
+          return "q=" + parameters.q.split("+").map(encodeURIComponent).join("+");
+        }
+        return `${name}=${encodeURIComponent(parameters[name])}`;
+      }).join("&");
+    }
+    var urlVariableRegex = /\{[^}]+\}/g;
+    function removeNonChars(variableName) {
+      return variableName.replace(/^\W+|\W+$/g, "").split(/,/);
+    }
+    function extractUrlVariableNames(url) {
+      const matches = url.match(urlVariableRegex);
+      if (!matches) {
+        return [];
+      }
+      return matches.map(removeNonChars).reduce((a, b) => a.concat(b), []);
+    }
+    function omit(object, keysToOmit) {
+      return Object.keys(object).filter((option) => !keysToOmit.includes(option)).reduce((obj, key) => {
+        obj[key] = object[key];
+        return obj;
+      }, {});
+    }
+    function encodeReserved(str) {
+      return str.split(/(%[0-9A-Fa-f]{2})/g).map(function(part) {
+        if (!/%[0-9A-Fa-f]/.test(part)) {
+          part = encodeURI(part).replace(/%5B/g, "[").replace(/%5D/g, "]");
+        }
+        return part;
+      }).join("");
+    }
+    function encodeUnreserved(str) {
+      return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
+        return "%" + c.charCodeAt(0).toString(16).toUpperCase();
+      });
+    }
+    function encodeValue(operator, value, key) {
+      value = operator === "+" || operator === "#" ? encodeReserved(value) : encodeUnreserved(value);
+      if (key) {
+        return encodeUnreserved(key) + "=" + value;
+      } else {
+        return value;
+      }
+    }
+    function isDefined(value) {
+      return value !== void 0 && value !== null;
+    }
+    function isKeyOperator(operator) {
+      return operator === ";" || operator === "&" || operator === "?";
+    }
+    function getValues(context, operator, key, modifier) {
+      var value = context[key], result = [];
+      if (isDefined(value) && value !== "") {
+        if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+          value = value.toString();
+          if (modifier && modifier !== "*") {
+            value = value.substring(0, parseInt(modifier, 10));
+          }
+          result.push(
+            encodeValue(operator, value, isKeyOperator(operator) ? key : "")
+          );
+        } else {
+          if (modifier === "*") {
+            if (Array.isArray(value)) {
+              value.filter(isDefined).forEach(function(value2) {
+                result.push(
+                  encodeValue(operator, value2, isKeyOperator(operator) ? key : "")
+                );
+              });
+            } else {
+              Object.keys(value).forEach(function(k) {
+                if (isDefined(value[k])) {
+                  result.push(encodeValue(operator, value[k], k));
+                }
+              });
+            }
+          } else {
+            const tmp = [];
+            if (Array.isArray(value)) {
+              value.filter(isDefined).forEach(function(value2) {
+                tmp.push(encodeValue(operator, value2));
+              });
+            } else {
+              Object.keys(value).forEach(function(k) {
+                if (isDefined(value[k])) {
+                  tmp.push(encodeUnreserved(k));
+                  tmp.push(encodeValue(operator, value[k].toString()));
+                }
+              });
+            }
+            if (isKeyOperator(operator)) {
+              result.push(encodeUnreserved(key) + "=" + tmp.join(","));
+            } else if (tmp.length !== 0) {
+              result.push(tmp.join(","));
+            }
+          }
+        }
+      } else {
+        if (operator === ";") {
+          if (isDefined(value)) {
+            result.push(encodeUnreserved(key));
+          }
+        } else if (value === "" && (operator === "&" || operator === "?")) {
+          result.push(encodeUnreserved(key) + "=");
+        } else if (value === "") {
+          result.push("");
+        }
+      }
+      return result;
+    }
+    function parseUrl(template) {
+      return {
+        expand: expand.bind(null, template)
+      };
+    }
+    function expand(template, context) {
+      var operators = ["+", "#", ".", "/", ";", "?", "&"];
+      return template.replace(
+        /\{([^\{\}]+)\}|([^\{\}]+)/g,
+        function(_, expression, literal) {
+          if (expression) {
+            let operator = "";
+            const values = [];
+            if (operators.indexOf(expression.charAt(0)) !== -1) {
+              operator = expression.charAt(0);
+              expression = expression.substr(1);
+            }
+            expression.split(/,/g).forEach(function(variable) {
+              var tmp = /([^:\*]*)(?::(\d+)|(\*))?/.exec(variable);
+              values.push(getValues(context, operator, tmp[1], tmp[2] || tmp[3]));
+            });
+            if (operator && operator !== "+") {
+              var separator = ",";
+              if (operator === "?") {
+                separator = "&";
+              } else if (operator !== "#") {
+                separator = operator;
+              }
+              return (values.length !== 0 ? operator : "") + values.join(separator);
+            } else {
+              return values.join(",");
+            }
+          } else {
+            return encodeReserved(literal);
+          }
+        }
+      );
+    }
+    function parse2(options2) {
+      let method = options2.method.toUpperCase();
+      let url = (options2.url || "/").replace(/:([a-z]\w+)/g, "{$1}");
+      let headers = Object.assign({}, options2.headers);
+      let body;
+      let parameters = omit(options2, [
+        "method",
+        "baseUrl",
+        "url",
+        "headers",
+        "request",
+        "mediaType"
+      ]);
+      const urlVariableNames = extractUrlVariableNames(url);
+      url = parseUrl(url).expand(parameters);
+      if (!/^http/.test(url)) {
+        url = options2.baseUrl + url;
+      }
+      const omittedParameters = Object.keys(options2).filter((option) => urlVariableNames.includes(option)).concat("baseUrl");
+      const remainingParameters = omit(parameters, omittedParameters);
+      const isBinaryRequest = /application\/octet-stream/i.test(headers.accept);
+      if (!isBinaryRequest) {
+        if (options2.mediaType.format) {
+          headers.accept = headers.accept.split(/,/).map(
+            (preview) => preview.replace(
+              /application\/vnd(\.\w+)(\.v3)?(\.\w+)?(\+json)?$/,
+              `application/vnd$1$2.${options2.mediaType.format}`
+            )
+          ).join(",");
+        }
+        if (options2.mediaType.previews.length) {
+          const previewsFromAcceptHeader = headers.accept.match(/[\w-]+(?=-preview)/g) || [];
+          headers.accept = previewsFromAcceptHeader.concat(options2.mediaType.previews).map((preview) => {
+            const format = options2.mediaType.format ? `.${options2.mediaType.format}` : "+json";
+            return `application/vnd.github.${preview}-preview${format}`;
+          }).join(",");
+        }
+      }
+      if (["GET", "HEAD"].includes(method)) {
+        url = addQueryParameters(url, remainingParameters);
+      } else {
+        if ("data" in remainingParameters) {
+          body = remainingParameters.data;
+        } else {
+          if (Object.keys(remainingParameters).length) {
+            body = remainingParameters;
+          }
+        }
+      }
+      if (!headers["content-type"] && typeof body !== "undefined") {
+        headers["content-type"] = "application/json; charset=utf-8";
+      }
+      if (["PATCH", "PUT"].includes(method) && typeof body === "undefined") {
+        body = "";
+      }
+      return Object.assign(
+        { method, url, headers },
+        typeof body !== "undefined" ? { body } : null,
+        options2.request ? { request: options2.request } : null
+      );
+    }
+    function endpointWithDefaults(defaults, route, options2) {
+      return parse2(merge(defaults, route, options2));
+    }
+    function withDefaults(oldDefaults, newDefaults) {
+      const DEFAULTS2 = merge(oldDefaults, newDefaults);
+      const endpoint2 = endpointWithDefaults.bind(null, DEFAULTS2);
+      return Object.assign(endpoint2, {
+        DEFAULTS: DEFAULTS2,
+        defaults: withDefaults.bind(null, DEFAULTS2),
+        merge: merge.bind(null, DEFAULTS2),
+        parse: parse2
+      });
+    }
+    var import_universal_user_agent = require_dist_node3();
+    var VERSION = "7.0.6";
+    var userAgent = `octokit-endpoint.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`;
+    var DEFAULTS = {
+      method: "GET",
+      baseUrl: "https://api.github.com",
+      headers: {
+        accept: "application/vnd.github.v3+json",
+        "user-agent": userAgent
+      },
+      mediaType: {
+        format: "",
+        previews: []
+      }
+    };
+    var endpoint = withDefaults(null, DEFAULTS);
+  }
+});
+
+// node_modules/@octokit/auth-oauth-app/node_modules/@octokit/request-error/dist-node/index.js
+var require_dist_node23 = __commonJS({
+  "node_modules/@octokit/auth-oauth-app/node_modules/@octokit/request-error/dist-node/index.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    function _interopDefault(ex) {
+      return ex && typeof ex === "object" && "default" in ex ? ex["default"] : ex;
+    }
+    var deprecation = require_dist_node5();
+    var once = _interopDefault(require_once());
+    var logOnceCode = once((deprecation2) => console.warn(deprecation2));
+    var logOnceHeaders = once((deprecation2) => console.warn(deprecation2));
+    var RequestError = class extends Error {
+      constructor(message, statusCode, options2) {
+        super(message);
+        if (Error.captureStackTrace) {
+          Error.captureStackTrace(this, this.constructor);
+        }
+        this.name = "HttpError";
+        this.status = statusCode;
+        let headers;
+        if ("headers" in options2 && typeof options2.headers !== "undefined") {
+          headers = options2.headers;
+        }
+        if ("response" in options2) {
+          this.response = options2.response;
+          headers = options2.response.headers;
+        }
+        const requestCopy = Object.assign({}, options2.request);
+        if (options2.request.headers.authorization) {
+          requestCopy.headers = Object.assign({}, options2.request.headers, {
+            authorization: options2.request.headers.authorization.replace(/ .*$/, " [REDACTED]")
+          });
+        }
+        requestCopy.url = requestCopy.url.replace(/\bclient_secret=\w+/g, "client_secret=[REDACTED]").replace(/\baccess_token=\w+/g, "access_token=[REDACTED]");
+        this.request = requestCopy;
+        Object.defineProperty(this, "code", {
+          get() {
+            logOnceCode(new deprecation.Deprecation("[@octokit/request-error] `error.code` is deprecated, use `error.status`."));
+            return statusCode;
+          }
+        });
+        Object.defineProperty(this, "headers", {
+          get() {
+            logOnceHeaders(new deprecation.Deprecation("[@octokit/request-error] `error.headers` is deprecated, use `error.response.headers`."));
+            return headers || {};
+          }
+        });
+      }
+    };
+    exports2.RequestError = RequestError;
+  }
+});
+
+// node_modules/@octokit/auth-oauth-app/node_modules/@octokit/request/dist-node/index.js
+var require_dist_node24 = __commonJS({
+  "node_modules/@octokit/auth-oauth-app/node_modules/@octokit/request/dist-node/index.js"(exports2, module2) {
+    "use strict";
+    var __create2 = Object.create;
+    var __defProp2 = Object.defineProperty;
+    var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
+    var __getOwnPropNames2 = Object.getOwnPropertyNames;
+    var __getProtoOf2 = Object.getPrototypeOf;
+    var __hasOwnProp2 = Object.prototype.hasOwnProperty;
+    var __export2 = (target, all) => {
+      for (var name in all)
+        __defProp2(target, name, { get: all[name], enumerable: true });
+    };
+    var __copyProps2 = (to, from, except, desc) => {
+      if (from && typeof from === "object" || typeof from === "function") {
+        for (let key of __getOwnPropNames2(from))
+          if (!__hasOwnProp2.call(to, key) && key !== except)
+            __defProp2(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc2(from, key)) || desc.enumerable });
+      }
+      return to;
+    };
+    var __toESM2 = (mod, isNodeMode, target) => (target = mod != null ? __create2(__getProtoOf2(mod)) : {}, __copyProps2(
+      // If the importer is in node compatibility mode or this is not an ESM
+      // file that has been converted to a CommonJS file using a Babel-
+      // compatible transform (i.e. "__esModule" has not been set), then set
+      // "default" to the CommonJS "module.exports" for node compatibility.
+      isNodeMode || !mod || !mod.__esModule ? __defProp2(target, "default", { value: mod, enumerable: true }) : target,
+      mod
+    ));
+    var __toCommonJS2 = (mod) => __copyProps2(__defProp2({}, "__esModule", { value: true }), mod);
+    var dist_src_exports = {};
+    __export2(dist_src_exports, {
+      request: () => request
+    });
+    module2.exports = __toCommonJS2(dist_src_exports);
+    var import_endpoint = require_dist_node22();
+    var import_universal_user_agent = require_dist_node3();
+    var VERSION = "6.2.8";
+    var import_is_plain_object = require_is_plain_object();
+    var import_node_fetch = __toESM2(require_lib6());
+    var import_request_error = require_dist_node23();
     function getBufferResponse(response) {
       return response.arrayBuffer();
     }
@@ -73153,8 +74268,1156 @@ var require_btoa_node = __commonJS({
   }
 });
 
+// node_modules/@octokit/auth-oauth-user/node_modules/@octokit/endpoint/dist-node/index.js
+var require_dist_node25 = __commonJS({
+  "node_modules/@octokit/auth-oauth-user/node_modules/@octokit/endpoint/dist-node/index.js"(exports2, module2) {
+    "use strict";
+    var __defProp2 = Object.defineProperty;
+    var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
+    var __getOwnPropNames2 = Object.getOwnPropertyNames;
+    var __hasOwnProp2 = Object.prototype.hasOwnProperty;
+    var __export2 = (target, all) => {
+      for (var name in all)
+        __defProp2(target, name, { get: all[name], enumerable: true });
+    };
+    var __copyProps2 = (to, from, except, desc) => {
+      if (from && typeof from === "object" || typeof from === "function") {
+        for (let key of __getOwnPropNames2(from))
+          if (!__hasOwnProp2.call(to, key) && key !== except)
+            __defProp2(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc2(from, key)) || desc.enumerable });
+      }
+      return to;
+    };
+    var __toCommonJS2 = (mod) => __copyProps2(__defProp2({}, "__esModule", { value: true }), mod);
+    var dist_src_exports = {};
+    __export2(dist_src_exports, {
+      endpoint: () => endpoint
+    });
+    module2.exports = __toCommonJS2(dist_src_exports);
+    function lowercaseKeys(object) {
+      if (!object) {
+        return {};
+      }
+      return Object.keys(object).reduce((newObj, key) => {
+        newObj[key.toLowerCase()] = object[key];
+        return newObj;
+      }, {});
+    }
+    var import_is_plain_object = require_is_plain_object();
+    function mergeDeep(defaults, options2) {
+      const result = Object.assign({}, defaults);
+      Object.keys(options2).forEach((key) => {
+        if ((0, import_is_plain_object.isPlainObject)(options2[key])) {
+          if (!(key in defaults))
+            Object.assign(result, { [key]: options2[key] });
+          else
+            result[key] = mergeDeep(defaults[key], options2[key]);
+        } else {
+          Object.assign(result, { [key]: options2[key] });
+        }
+      });
+      return result;
+    }
+    function removeUndefinedProperties(obj) {
+      for (const key in obj) {
+        if (obj[key] === void 0) {
+          delete obj[key];
+        }
+      }
+      return obj;
+    }
+    function merge(defaults, route, options2) {
+      if (typeof route === "string") {
+        let [method, url] = route.split(" ");
+        options2 = Object.assign(url ? { method, url } : { url: method }, options2);
+      } else {
+        options2 = Object.assign({}, route);
+      }
+      options2.headers = lowercaseKeys(options2.headers);
+      removeUndefinedProperties(options2);
+      removeUndefinedProperties(options2.headers);
+      const mergedOptions = mergeDeep(defaults || {}, options2);
+      if (defaults && defaults.mediaType.previews.length) {
+        mergedOptions.mediaType.previews = defaults.mediaType.previews.filter((preview) => !mergedOptions.mediaType.previews.includes(preview)).concat(mergedOptions.mediaType.previews);
+      }
+      mergedOptions.mediaType.previews = mergedOptions.mediaType.previews.map(
+        (preview) => preview.replace(/-preview/, "")
+      );
+      return mergedOptions;
+    }
+    function addQueryParameters(url, parameters) {
+      const separator = /\?/.test(url) ? "&" : "?";
+      const names = Object.keys(parameters);
+      if (names.length === 0) {
+        return url;
+      }
+      return url + separator + names.map((name) => {
+        if (name === "q") {
+          return "q=" + parameters.q.split("+").map(encodeURIComponent).join("+");
+        }
+        return `${name}=${encodeURIComponent(parameters[name])}`;
+      }).join("&");
+    }
+    var urlVariableRegex = /\{[^}]+\}/g;
+    function removeNonChars(variableName) {
+      return variableName.replace(/^\W+|\W+$/g, "").split(/,/);
+    }
+    function extractUrlVariableNames(url) {
+      const matches = url.match(urlVariableRegex);
+      if (!matches) {
+        return [];
+      }
+      return matches.map(removeNonChars).reduce((a, b) => a.concat(b), []);
+    }
+    function omit(object, keysToOmit) {
+      return Object.keys(object).filter((option) => !keysToOmit.includes(option)).reduce((obj, key) => {
+        obj[key] = object[key];
+        return obj;
+      }, {});
+    }
+    function encodeReserved(str) {
+      return str.split(/(%[0-9A-Fa-f]{2})/g).map(function(part) {
+        if (!/%[0-9A-Fa-f]/.test(part)) {
+          part = encodeURI(part).replace(/%5B/g, "[").replace(/%5D/g, "]");
+        }
+        return part;
+      }).join("");
+    }
+    function encodeUnreserved(str) {
+      return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
+        return "%" + c.charCodeAt(0).toString(16).toUpperCase();
+      });
+    }
+    function encodeValue(operator, value, key) {
+      value = operator === "+" || operator === "#" ? encodeReserved(value) : encodeUnreserved(value);
+      if (key) {
+        return encodeUnreserved(key) + "=" + value;
+      } else {
+        return value;
+      }
+    }
+    function isDefined(value) {
+      return value !== void 0 && value !== null;
+    }
+    function isKeyOperator(operator) {
+      return operator === ";" || operator === "&" || operator === "?";
+    }
+    function getValues(context, operator, key, modifier) {
+      var value = context[key], result = [];
+      if (isDefined(value) && value !== "") {
+        if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+          value = value.toString();
+          if (modifier && modifier !== "*") {
+            value = value.substring(0, parseInt(modifier, 10));
+          }
+          result.push(
+            encodeValue(operator, value, isKeyOperator(operator) ? key : "")
+          );
+        } else {
+          if (modifier === "*") {
+            if (Array.isArray(value)) {
+              value.filter(isDefined).forEach(function(value2) {
+                result.push(
+                  encodeValue(operator, value2, isKeyOperator(operator) ? key : "")
+                );
+              });
+            } else {
+              Object.keys(value).forEach(function(k) {
+                if (isDefined(value[k])) {
+                  result.push(encodeValue(operator, value[k], k));
+                }
+              });
+            }
+          } else {
+            const tmp = [];
+            if (Array.isArray(value)) {
+              value.filter(isDefined).forEach(function(value2) {
+                tmp.push(encodeValue(operator, value2));
+              });
+            } else {
+              Object.keys(value).forEach(function(k) {
+                if (isDefined(value[k])) {
+                  tmp.push(encodeUnreserved(k));
+                  tmp.push(encodeValue(operator, value[k].toString()));
+                }
+              });
+            }
+            if (isKeyOperator(operator)) {
+              result.push(encodeUnreserved(key) + "=" + tmp.join(","));
+            } else if (tmp.length !== 0) {
+              result.push(tmp.join(","));
+            }
+          }
+        }
+      } else {
+        if (operator === ";") {
+          if (isDefined(value)) {
+            result.push(encodeUnreserved(key));
+          }
+        } else if (value === "" && (operator === "&" || operator === "?")) {
+          result.push(encodeUnreserved(key) + "=");
+        } else if (value === "") {
+          result.push("");
+        }
+      }
+      return result;
+    }
+    function parseUrl(template) {
+      return {
+        expand: expand.bind(null, template)
+      };
+    }
+    function expand(template, context) {
+      var operators = ["+", "#", ".", "/", ";", "?", "&"];
+      return template.replace(
+        /\{([^\{\}]+)\}|([^\{\}]+)/g,
+        function(_, expression, literal) {
+          if (expression) {
+            let operator = "";
+            const values = [];
+            if (operators.indexOf(expression.charAt(0)) !== -1) {
+              operator = expression.charAt(0);
+              expression = expression.substr(1);
+            }
+            expression.split(/,/g).forEach(function(variable) {
+              var tmp = /([^:\*]*)(?::(\d+)|(\*))?/.exec(variable);
+              values.push(getValues(context, operator, tmp[1], tmp[2] || tmp[3]));
+            });
+            if (operator && operator !== "+") {
+              var separator = ",";
+              if (operator === "?") {
+                separator = "&";
+              } else if (operator !== "#") {
+                separator = operator;
+              }
+              return (values.length !== 0 ? operator : "") + values.join(separator);
+            } else {
+              return values.join(",");
+            }
+          } else {
+            return encodeReserved(literal);
+          }
+        }
+      );
+    }
+    function parse2(options2) {
+      let method = options2.method.toUpperCase();
+      let url = (options2.url || "/").replace(/:([a-z]\w+)/g, "{$1}");
+      let headers = Object.assign({}, options2.headers);
+      let body;
+      let parameters = omit(options2, [
+        "method",
+        "baseUrl",
+        "url",
+        "headers",
+        "request",
+        "mediaType"
+      ]);
+      const urlVariableNames = extractUrlVariableNames(url);
+      url = parseUrl(url).expand(parameters);
+      if (!/^http/.test(url)) {
+        url = options2.baseUrl + url;
+      }
+      const omittedParameters = Object.keys(options2).filter((option) => urlVariableNames.includes(option)).concat("baseUrl");
+      const remainingParameters = omit(parameters, omittedParameters);
+      const isBinaryRequest = /application\/octet-stream/i.test(headers.accept);
+      if (!isBinaryRequest) {
+        if (options2.mediaType.format) {
+          headers.accept = headers.accept.split(/,/).map(
+            (preview) => preview.replace(
+              /application\/vnd(\.\w+)(\.v3)?(\.\w+)?(\+json)?$/,
+              `application/vnd$1$2.${options2.mediaType.format}`
+            )
+          ).join(",");
+        }
+        if (options2.mediaType.previews.length) {
+          const previewsFromAcceptHeader = headers.accept.match(/[\w-]+(?=-preview)/g) || [];
+          headers.accept = previewsFromAcceptHeader.concat(options2.mediaType.previews).map((preview) => {
+            const format = options2.mediaType.format ? `.${options2.mediaType.format}` : "+json";
+            return `application/vnd.github.${preview}-preview${format}`;
+          }).join(",");
+        }
+      }
+      if (["GET", "HEAD"].includes(method)) {
+        url = addQueryParameters(url, remainingParameters);
+      } else {
+        if ("data" in remainingParameters) {
+          body = remainingParameters.data;
+        } else {
+          if (Object.keys(remainingParameters).length) {
+            body = remainingParameters;
+          }
+        }
+      }
+      if (!headers["content-type"] && typeof body !== "undefined") {
+        headers["content-type"] = "application/json; charset=utf-8";
+      }
+      if (["PATCH", "PUT"].includes(method) && typeof body === "undefined") {
+        body = "";
+      }
+      return Object.assign(
+        { method, url, headers },
+        typeof body !== "undefined" ? { body } : null,
+        options2.request ? { request: options2.request } : null
+      );
+    }
+    function endpointWithDefaults(defaults, route, options2) {
+      return parse2(merge(defaults, route, options2));
+    }
+    function withDefaults(oldDefaults, newDefaults) {
+      const DEFAULTS2 = merge(oldDefaults, newDefaults);
+      const endpoint2 = endpointWithDefaults.bind(null, DEFAULTS2);
+      return Object.assign(endpoint2, {
+        DEFAULTS: DEFAULTS2,
+        defaults: withDefaults.bind(null, DEFAULTS2),
+        merge: merge.bind(null, DEFAULTS2),
+        parse: parse2
+      });
+    }
+    var import_universal_user_agent = require_dist_node3();
+    var VERSION = "7.0.6";
+    var userAgent = `octokit-endpoint.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`;
+    var DEFAULTS = {
+      method: "GET",
+      baseUrl: "https://api.github.com",
+      headers: {
+        accept: "application/vnd.github.v3+json",
+        "user-agent": userAgent
+      },
+      mediaType: {
+        format: "",
+        previews: []
+      }
+    };
+    var endpoint = withDefaults(null, DEFAULTS);
+  }
+});
+
+// node_modules/@octokit/auth-oauth-user/node_modules/@octokit/request-error/dist-node/index.js
+var require_dist_node26 = __commonJS({
+  "node_modules/@octokit/auth-oauth-user/node_modules/@octokit/request-error/dist-node/index.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    function _interopDefault(ex) {
+      return ex && typeof ex === "object" && "default" in ex ? ex["default"] : ex;
+    }
+    var deprecation = require_dist_node5();
+    var once = _interopDefault(require_once());
+    var logOnceCode = once((deprecation2) => console.warn(deprecation2));
+    var logOnceHeaders = once((deprecation2) => console.warn(deprecation2));
+    var RequestError = class extends Error {
+      constructor(message, statusCode, options2) {
+        super(message);
+        if (Error.captureStackTrace) {
+          Error.captureStackTrace(this, this.constructor);
+        }
+        this.name = "HttpError";
+        this.status = statusCode;
+        let headers;
+        if ("headers" in options2 && typeof options2.headers !== "undefined") {
+          headers = options2.headers;
+        }
+        if ("response" in options2) {
+          this.response = options2.response;
+          headers = options2.response.headers;
+        }
+        const requestCopy = Object.assign({}, options2.request);
+        if (options2.request.headers.authorization) {
+          requestCopy.headers = Object.assign({}, options2.request.headers, {
+            authorization: options2.request.headers.authorization.replace(/ .*$/, " [REDACTED]")
+          });
+        }
+        requestCopy.url = requestCopy.url.replace(/\bclient_secret=\w+/g, "client_secret=[REDACTED]").replace(/\baccess_token=\w+/g, "access_token=[REDACTED]");
+        this.request = requestCopy;
+        Object.defineProperty(this, "code", {
+          get() {
+            logOnceCode(new deprecation.Deprecation("[@octokit/request-error] `error.code` is deprecated, use `error.status`."));
+            return statusCode;
+          }
+        });
+        Object.defineProperty(this, "headers", {
+          get() {
+            logOnceHeaders(new deprecation.Deprecation("[@octokit/request-error] `error.headers` is deprecated, use `error.response.headers`."));
+            return headers || {};
+          }
+        });
+      }
+    };
+    exports2.RequestError = RequestError;
+  }
+});
+
+// node_modules/@octokit/auth-oauth-user/node_modules/@octokit/request/dist-node/index.js
+var require_dist_node27 = __commonJS({
+  "node_modules/@octokit/auth-oauth-user/node_modules/@octokit/request/dist-node/index.js"(exports2, module2) {
+    "use strict";
+    var __create2 = Object.create;
+    var __defProp2 = Object.defineProperty;
+    var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
+    var __getOwnPropNames2 = Object.getOwnPropertyNames;
+    var __getProtoOf2 = Object.getPrototypeOf;
+    var __hasOwnProp2 = Object.prototype.hasOwnProperty;
+    var __export2 = (target, all) => {
+      for (var name in all)
+        __defProp2(target, name, { get: all[name], enumerable: true });
+    };
+    var __copyProps2 = (to, from, except, desc) => {
+      if (from && typeof from === "object" || typeof from === "function") {
+        for (let key of __getOwnPropNames2(from))
+          if (!__hasOwnProp2.call(to, key) && key !== except)
+            __defProp2(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc2(from, key)) || desc.enumerable });
+      }
+      return to;
+    };
+    var __toESM2 = (mod, isNodeMode, target) => (target = mod != null ? __create2(__getProtoOf2(mod)) : {}, __copyProps2(
+      // If the importer is in node compatibility mode or this is not an ESM
+      // file that has been converted to a CommonJS file using a Babel-
+      // compatible transform (i.e. "__esModule" has not been set), then set
+      // "default" to the CommonJS "module.exports" for node compatibility.
+      isNodeMode || !mod || !mod.__esModule ? __defProp2(target, "default", { value: mod, enumerable: true }) : target,
+      mod
+    ));
+    var __toCommonJS2 = (mod) => __copyProps2(__defProp2({}, "__esModule", { value: true }), mod);
+    var dist_src_exports = {};
+    __export2(dist_src_exports, {
+      request: () => request
+    });
+    module2.exports = __toCommonJS2(dist_src_exports);
+    var import_endpoint = require_dist_node25();
+    var import_universal_user_agent = require_dist_node3();
+    var VERSION = "6.2.8";
+    var import_is_plain_object = require_is_plain_object();
+    var import_node_fetch = __toESM2(require_lib6());
+    var import_request_error = require_dist_node26();
+    function getBufferResponse(response) {
+      return response.arrayBuffer();
+    }
+    function fetchWrapper(requestOptions) {
+      const log = requestOptions.request && requestOptions.request.log ? requestOptions.request.log : console;
+      if ((0, import_is_plain_object.isPlainObject)(requestOptions.body) || Array.isArray(requestOptions.body)) {
+        requestOptions.body = JSON.stringify(requestOptions.body);
+      }
+      let headers = {};
+      let status;
+      let url;
+      const fetch2 = requestOptions.request && requestOptions.request.fetch || globalThis.fetch || /* istanbul ignore next */
+      import_node_fetch.default;
+      return fetch2(
+        requestOptions.url,
+        Object.assign(
+          {
+            method: requestOptions.method,
+            body: requestOptions.body,
+            headers: requestOptions.headers,
+            redirect: requestOptions.redirect,
+            // duplex must be set if request.body is ReadableStream or Async Iterables.
+            // See https://fetch.spec.whatwg.org/#dom-requestinit-duplex.
+            ...requestOptions.body && { duplex: "half" }
+          },
+          // `requestOptions.request.agent` type is incompatible
+          // see https://github.com/octokit/types.ts/pull/264
+          requestOptions.request
+        )
+      ).then(async (response) => {
+        url = response.url;
+        status = response.status;
+        for (const keyAndValue of response.headers) {
+          headers[keyAndValue[0]] = keyAndValue[1];
+        }
+        if ("deprecation" in headers) {
+          const matches = headers.link && headers.link.match(/<([^>]+)>; rel="deprecation"/);
+          const deprecationLink = matches && matches.pop();
+          log.warn(
+            `[@octokit/request] "${requestOptions.method} ${requestOptions.url}" is deprecated. It is scheduled to be removed on ${headers.sunset}${deprecationLink ? `. See ${deprecationLink}` : ""}`
+          );
+        }
+        if (status === 204 || status === 205) {
+          return;
+        }
+        if (requestOptions.method === "HEAD") {
+          if (status < 400) {
+            return;
+          }
+          throw new import_request_error.RequestError(response.statusText, status, {
+            response: {
+              url,
+              status,
+              headers,
+              data: void 0
+            },
+            request: requestOptions
+          });
+        }
+        if (status === 304) {
+          throw new import_request_error.RequestError("Not modified", status, {
+            response: {
+              url,
+              status,
+              headers,
+              data: await getResponseData(response)
+            },
+            request: requestOptions
+          });
+        }
+        if (status >= 400) {
+          const data = await getResponseData(response);
+          const error = new import_request_error.RequestError(toErrorMessage(data), status, {
+            response: {
+              url,
+              status,
+              headers,
+              data
+            },
+            request: requestOptions
+          });
+          throw error;
+        }
+        return getResponseData(response);
+      }).then((data) => {
+        return {
+          status,
+          url,
+          headers,
+          data
+        };
+      }).catch((error) => {
+        if (error instanceof import_request_error.RequestError)
+          throw error;
+        else if (error.name === "AbortError")
+          throw error;
+        throw new import_request_error.RequestError(error.message, 500, {
+          request: requestOptions
+        });
+      });
+    }
+    async function getResponseData(response) {
+      const contentType = response.headers.get("content-type");
+      if (/application\/json/.test(contentType)) {
+        return response.json();
+      }
+      if (!contentType || /^text\/|charset=utf-8$/.test(contentType)) {
+        return response.text();
+      }
+      return getBufferResponse(response);
+    }
+    function toErrorMessage(data) {
+      if (typeof data === "string")
+        return data;
+      if ("message" in data) {
+        if (Array.isArray(data.errors)) {
+          return `${data.message}: ${data.errors.map(JSON.stringify).join(", ")}`;
+        }
+        return data.message;
+      }
+      return `Unknown error: ${JSON.stringify(data)}`;
+    }
+    function withDefaults(oldEndpoint, newDefaults) {
+      const endpoint2 = oldEndpoint.defaults(newDefaults);
+      const newApi = function(route, parameters) {
+        const endpointOptions = endpoint2.merge(route, parameters);
+        if (!endpointOptions.request || !endpointOptions.request.hook) {
+          return fetchWrapper(endpoint2.parse(endpointOptions));
+        }
+        const request2 = (route2, parameters2) => {
+          return fetchWrapper(
+            endpoint2.parse(endpoint2.merge(route2, parameters2))
+          );
+        };
+        Object.assign(request2, {
+          endpoint: endpoint2,
+          defaults: withDefaults.bind(null, endpoint2)
+        });
+        return endpointOptions.request.hook(request2, endpointOptions);
+      };
+      return Object.assign(newApi, {
+        endpoint: endpoint2,
+        defaults: withDefaults.bind(null, endpoint2)
+      });
+    }
+    var request = withDefaults(import_endpoint.endpoint, {
+      headers: {
+        "user-agent": `octokit-request.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`
+      }
+    });
+  }
+});
+
+// node_modules/@octokit/auth-oauth-device/node_modules/@octokit/endpoint/dist-node/index.js
+var require_dist_node28 = __commonJS({
+  "node_modules/@octokit/auth-oauth-device/node_modules/@octokit/endpoint/dist-node/index.js"(exports2, module2) {
+    "use strict";
+    var __defProp2 = Object.defineProperty;
+    var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
+    var __getOwnPropNames2 = Object.getOwnPropertyNames;
+    var __hasOwnProp2 = Object.prototype.hasOwnProperty;
+    var __export2 = (target, all) => {
+      for (var name in all)
+        __defProp2(target, name, { get: all[name], enumerable: true });
+    };
+    var __copyProps2 = (to, from, except, desc) => {
+      if (from && typeof from === "object" || typeof from === "function") {
+        for (let key of __getOwnPropNames2(from))
+          if (!__hasOwnProp2.call(to, key) && key !== except)
+            __defProp2(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc2(from, key)) || desc.enumerable });
+      }
+      return to;
+    };
+    var __toCommonJS2 = (mod) => __copyProps2(__defProp2({}, "__esModule", { value: true }), mod);
+    var dist_src_exports = {};
+    __export2(dist_src_exports, {
+      endpoint: () => endpoint
+    });
+    module2.exports = __toCommonJS2(dist_src_exports);
+    function lowercaseKeys(object) {
+      if (!object) {
+        return {};
+      }
+      return Object.keys(object).reduce((newObj, key) => {
+        newObj[key.toLowerCase()] = object[key];
+        return newObj;
+      }, {});
+    }
+    var import_is_plain_object = require_is_plain_object();
+    function mergeDeep(defaults, options2) {
+      const result = Object.assign({}, defaults);
+      Object.keys(options2).forEach((key) => {
+        if ((0, import_is_plain_object.isPlainObject)(options2[key])) {
+          if (!(key in defaults))
+            Object.assign(result, { [key]: options2[key] });
+          else
+            result[key] = mergeDeep(defaults[key], options2[key]);
+        } else {
+          Object.assign(result, { [key]: options2[key] });
+        }
+      });
+      return result;
+    }
+    function removeUndefinedProperties(obj) {
+      for (const key in obj) {
+        if (obj[key] === void 0) {
+          delete obj[key];
+        }
+      }
+      return obj;
+    }
+    function merge(defaults, route, options2) {
+      if (typeof route === "string") {
+        let [method, url] = route.split(" ");
+        options2 = Object.assign(url ? { method, url } : { url: method }, options2);
+      } else {
+        options2 = Object.assign({}, route);
+      }
+      options2.headers = lowercaseKeys(options2.headers);
+      removeUndefinedProperties(options2);
+      removeUndefinedProperties(options2.headers);
+      const mergedOptions = mergeDeep(defaults || {}, options2);
+      if (defaults && defaults.mediaType.previews.length) {
+        mergedOptions.mediaType.previews = defaults.mediaType.previews.filter((preview) => !mergedOptions.mediaType.previews.includes(preview)).concat(mergedOptions.mediaType.previews);
+      }
+      mergedOptions.mediaType.previews = mergedOptions.mediaType.previews.map(
+        (preview) => preview.replace(/-preview/, "")
+      );
+      return mergedOptions;
+    }
+    function addQueryParameters(url, parameters) {
+      const separator = /\?/.test(url) ? "&" : "?";
+      const names = Object.keys(parameters);
+      if (names.length === 0) {
+        return url;
+      }
+      return url + separator + names.map((name) => {
+        if (name === "q") {
+          return "q=" + parameters.q.split("+").map(encodeURIComponent).join("+");
+        }
+        return `${name}=${encodeURIComponent(parameters[name])}`;
+      }).join("&");
+    }
+    var urlVariableRegex = /\{[^}]+\}/g;
+    function removeNonChars(variableName) {
+      return variableName.replace(/^\W+|\W+$/g, "").split(/,/);
+    }
+    function extractUrlVariableNames(url) {
+      const matches = url.match(urlVariableRegex);
+      if (!matches) {
+        return [];
+      }
+      return matches.map(removeNonChars).reduce((a, b) => a.concat(b), []);
+    }
+    function omit(object, keysToOmit) {
+      return Object.keys(object).filter((option) => !keysToOmit.includes(option)).reduce((obj, key) => {
+        obj[key] = object[key];
+        return obj;
+      }, {});
+    }
+    function encodeReserved(str) {
+      return str.split(/(%[0-9A-Fa-f]{2})/g).map(function(part) {
+        if (!/%[0-9A-Fa-f]/.test(part)) {
+          part = encodeURI(part).replace(/%5B/g, "[").replace(/%5D/g, "]");
+        }
+        return part;
+      }).join("");
+    }
+    function encodeUnreserved(str) {
+      return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
+        return "%" + c.charCodeAt(0).toString(16).toUpperCase();
+      });
+    }
+    function encodeValue(operator, value, key) {
+      value = operator === "+" || operator === "#" ? encodeReserved(value) : encodeUnreserved(value);
+      if (key) {
+        return encodeUnreserved(key) + "=" + value;
+      } else {
+        return value;
+      }
+    }
+    function isDefined(value) {
+      return value !== void 0 && value !== null;
+    }
+    function isKeyOperator(operator) {
+      return operator === ";" || operator === "&" || operator === "?";
+    }
+    function getValues(context, operator, key, modifier) {
+      var value = context[key], result = [];
+      if (isDefined(value) && value !== "") {
+        if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+          value = value.toString();
+          if (modifier && modifier !== "*") {
+            value = value.substring(0, parseInt(modifier, 10));
+          }
+          result.push(
+            encodeValue(operator, value, isKeyOperator(operator) ? key : "")
+          );
+        } else {
+          if (modifier === "*") {
+            if (Array.isArray(value)) {
+              value.filter(isDefined).forEach(function(value2) {
+                result.push(
+                  encodeValue(operator, value2, isKeyOperator(operator) ? key : "")
+                );
+              });
+            } else {
+              Object.keys(value).forEach(function(k) {
+                if (isDefined(value[k])) {
+                  result.push(encodeValue(operator, value[k], k));
+                }
+              });
+            }
+          } else {
+            const tmp = [];
+            if (Array.isArray(value)) {
+              value.filter(isDefined).forEach(function(value2) {
+                tmp.push(encodeValue(operator, value2));
+              });
+            } else {
+              Object.keys(value).forEach(function(k) {
+                if (isDefined(value[k])) {
+                  tmp.push(encodeUnreserved(k));
+                  tmp.push(encodeValue(operator, value[k].toString()));
+                }
+              });
+            }
+            if (isKeyOperator(operator)) {
+              result.push(encodeUnreserved(key) + "=" + tmp.join(","));
+            } else if (tmp.length !== 0) {
+              result.push(tmp.join(","));
+            }
+          }
+        }
+      } else {
+        if (operator === ";") {
+          if (isDefined(value)) {
+            result.push(encodeUnreserved(key));
+          }
+        } else if (value === "" && (operator === "&" || operator === "?")) {
+          result.push(encodeUnreserved(key) + "=");
+        } else if (value === "") {
+          result.push("");
+        }
+      }
+      return result;
+    }
+    function parseUrl(template) {
+      return {
+        expand: expand.bind(null, template)
+      };
+    }
+    function expand(template, context) {
+      var operators = ["+", "#", ".", "/", ";", "?", "&"];
+      return template.replace(
+        /\{([^\{\}]+)\}|([^\{\}]+)/g,
+        function(_, expression, literal) {
+          if (expression) {
+            let operator = "";
+            const values = [];
+            if (operators.indexOf(expression.charAt(0)) !== -1) {
+              operator = expression.charAt(0);
+              expression = expression.substr(1);
+            }
+            expression.split(/,/g).forEach(function(variable) {
+              var tmp = /([^:\*]*)(?::(\d+)|(\*))?/.exec(variable);
+              values.push(getValues(context, operator, tmp[1], tmp[2] || tmp[3]));
+            });
+            if (operator && operator !== "+") {
+              var separator = ",";
+              if (operator === "?") {
+                separator = "&";
+              } else if (operator !== "#") {
+                separator = operator;
+              }
+              return (values.length !== 0 ? operator : "") + values.join(separator);
+            } else {
+              return values.join(",");
+            }
+          } else {
+            return encodeReserved(literal);
+          }
+        }
+      );
+    }
+    function parse2(options2) {
+      let method = options2.method.toUpperCase();
+      let url = (options2.url || "/").replace(/:([a-z]\w+)/g, "{$1}");
+      let headers = Object.assign({}, options2.headers);
+      let body;
+      let parameters = omit(options2, [
+        "method",
+        "baseUrl",
+        "url",
+        "headers",
+        "request",
+        "mediaType"
+      ]);
+      const urlVariableNames = extractUrlVariableNames(url);
+      url = parseUrl(url).expand(parameters);
+      if (!/^http/.test(url)) {
+        url = options2.baseUrl + url;
+      }
+      const omittedParameters = Object.keys(options2).filter((option) => urlVariableNames.includes(option)).concat("baseUrl");
+      const remainingParameters = omit(parameters, omittedParameters);
+      const isBinaryRequest = /application\/octet-stream/i.test(headers.accept);
+      if (!isBinaryRequest) {
+        if (options2.mediaType.format) {
+          headers.accept = headers.accept.split(/,/).map(
+            (preview) => preview.replace(
+              /application\/vnd(\.\w+)(\.v3)?(\.\w+)?(\+json)?$/,
+              `application/vnd$1$2.${options2.mediaType.format}`
+            )
+          ).join(",");
+        }
+        if (options2.mediaType.previews.length) {
+          const previewsFromAcceptHeader = headers.accept.match(/[\w-]+(?=-preview)/g) || [];
+          headers.accept = previewsFromAcceptHeader.concat(options2.mediaType.previews).map((preview) => {
+            const format = options2.mediaType.format ? `.${options2.mediaType.format}` : "+json";
+            return `application/vnd.github.${preview}-preview${format}`;
+          }).join(",");
+        }
+      }
+      if (["GET", "HEAD"].includes(method)) {
+        url = addQueryParameters(url, remainingParameters);
+      } else {
+        if ("data" in remainingParameters) {
+          body = remainingParameters.data;
+        } else {
+          if (Object.keys(remainingParameters).length) {
+            body = remainingParameters;
+          }
+        }
+      }
+      if (!headers["content-type"] && typeof body !== "undefined") {
+        headers["content-type"] = "application/json; charset=utf-8";
+      }
+      if (["PATCH", "PUT"].includes(method) && typeof body === "undefined") {
+        body = "";
+      }
+      return Object.assign(
+        { method, url, headers },
+        typeof body !== "undefined" ? { body } : null,
+        options2.request ? { request: options2.request } : null
+      );
+    }
+    function endpointWithDefaults(defaults, route, options2) {
+      return parse2(merge(defaults, route, options2));
+    }
+    function withDefaults(oldDefaults, newDefaults) {
+      const DEFAULTS2 = merge(oldDefaults, newDefaults);
+      const endpoint2 = endpointWithDefaults.bind(null, DEFAULTS2);
+      return Object.assign(endpoint2, {
+        DEFAULTS: DEFAULTS2,
+        defaults: withDefaults.bind(null, DEFAULTS2),
+        merge: merge.bind(null, DEFAULTS2),
+        parse: parse2
+      });
+    }
+    var import_universal_user_agent = require_dist_node3();
+    var VERSION = "7.0.6";
+    var userAgent = `octokit-endpoint.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`;
+    var DEFAULTS = {
+      method: "GET",
+      baseUrl: "https://api.github.com",
+      headers: {
+        accept: "application/vnd.github.v3+json",
+        "user-agent": userAgent
+      },
+      mediaType: {
+        format: "",
+        previews: []
+      }
+    };
+    var endpoint = withDefaults(null, DEFAULTS);
+  }
+});
+
+// node_modules/@octokit/auth-oauth-device/node_modules/@octokit/request-error/dist-node/index.js
+var require_dist_node29 = __commonJS({
+  "node_modules/@octokit/auth-oauth-device/node_modules/@octokit/request-error/dist-node/index.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    function _interopDefault(ex) {
+      return ex && typeof ex === "object" && "default" in ex ? ex["default"] : ex;
+    }
+    var deprecation = require_dist_node5();
+    var once = _interopDefault(require_once());
+    var logOnceCode = once((deprecation2) => console.warn(deprecation2));
+    var logOnceHeaders = once((deprecation2) => console.warn(deprecation2));
+    var RequestError = class extends Error {
+      constructor(message, statusCode, options2) {
+        super(message);
+        if (Error.captureStackTrace) {
+          Error.captureStackTrace(this, this.constructor);
+        }
+        this.name = "HttpError";
+        this.status = statusCode;
+        let headers;
+        if ("headers" in options2 && typeof options2.headers !== "undefined") {
+          headers = options2.headers;
+        }
+        if ("response" in options2) {
+          this.response = options2.response;
+          headers = options2.response.headers;
+        }
+        const requestCopy = Object.assign({}, options2.request);
+        if (options2.request.headers.authorization) {
+          requestCopy.headers = Object.assign({}, options2.request.headers, {
+            authorization: options2.request.headers.authorization.replace(/ .*$/, " [REDACTED]")
+          });
+        }
+        requestCopy.url = requestCopy.url.replace(/\bclient_secret=\w+/g, "client_secret=[REDACTED]").replace(/\baccess_token=\w+/g, "access_token=[REDACTED]");
+        this.request = requestCopy;
+        Object.defineProperty(this, "code", {
+          get() {
+            logOnceCode(new deprecation.Deprecation("[@octokit/request-error] `error.code` is deprecated, use `error.status`."));
+            return statusCode;
+          }
+        });
+        Object.defineProperty(this, "headers", {
+          get() {
+            logOnceHeaders(new deprecation.Deprecation("[@octokit/request-error] `error.headers` is deprecated, use `error.response.headers`."));
+            return headers || {};
+          }
+        });
+      }
+    };
+    exports2.RequestError = RequestError;
+  }
+});
+
+// node_modules/@octokit/auth-oauth-device/node_modules/@octokit/request/dist-node/index.js
+var require_dist_node30 = __commonJS({
+  "node_modules/@octokit/auth-oauth-device/node_modules/@octokit/request/dist-node/index.js"(exports2, module2) {
+    "use strict";
+    var __create2 = Object.create;
+    var __defProp2 = Object.defineProperty;
+    var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
+    var __getOwnPropNames2 = Object.getOwnPropertyNames;
+    var __getProtoOf2 = Object.getPrototypeOf;
+    var __hasOwnProp2 = Object.prototype.hasOwnProperty;
+    var __export2 = (target, all) => {
+      for (var name in all)
+        __defProp2(target, name, { get: all[name], enumerable: true });
+    };
+    var __copyProps2 = (to, from, except, desc) => {
+      if (from && typeof from === "object" || typeof from === "function") {
+        for (let key of __getOwnPropNames2(from))
+          if (!__hasOwnProp2.call(to, key) && key !== except)
+            __defProp2(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc2(from, key)) || desc.enumerable });
+      }
+      return to;
+    };
+    var __toESM2 = (mod, isNodeMode, target) => (target = mod != null ? __create2(__getProtoOf2(mod)) : {}, __copyProps2(
+      // If the importer is in node compatibility mode or this is not an ESM
+      // file that has been converted to a CommonJS file using a Babel-
+      // compatible transform (i.e. "__esModule" has not been set), then set
+      // "default" to the CommonJS "module.exports" for node compatibility.
+      isNodeMode || !mod || !mod.__esModule ? __defProp2(target, "default", { value: mod, enumerable: true }) : target,
+      mod
+    ));
+    var __toCommonJS2 = (mod) => __copyProps2(__defProp2({}, "__esModule", { value: true }), mod);
+    var dist_src_exports = {};
+    __export2(dist_src_exports, {
+      request: () => request
+    });
+    module2.exports = __toCommonJS2(dist_src_exports);
+    var import_endpoint = require_dist_node28();
+    var import_universal_user_agent = require_dist_node3();
+    var VERSION = "6.2.8";
+    var import_is_plain_object = require_is_plain_object();
+    var import_node_fetch = __toESM2(require_lib6());
+    var import_request_error = require_dist_node29();
+    function getBufferResponse(response) {
+      return response.arrayBuffer();
+    }
+    function fetchWrapper(requestOptions) {
+      const log = requestOptions.request && requestOptions.request.log ? requestOptions.request.log : console;
+      if ((0, import_is_plain_object.isPlainObject)(requestOptions.body) || Array.isArray(requestOptions.body)) {
+        requestOptions.body = JSON.stringify(requestOptions.body);
+      }
+      let headers = {};
+      let status;
+      let url;
+      const fetch2 = requestOptions.request && requestOptions.request.fetch || globalThis.fetch || /* istanbul ignore next */
+      import_node_fetch.default;
+      return fetch2(
+        requestOptions.url,
+        Object.assign(
+          {
+            method: requestOptions.method,
+            body: requestOptions.body,
+            headers: requestOptions.headers,
+            redirect: requestOptions.redirect,
+            // duplex must be set if request.body is ReadableStream or Async Iterables.
+            // See https://fetch.spec.whatwg.org/#dom-requestinit-duplex.
+            ...requestOptions.body && { duplex: "half" }
+          },
+          // `requestOptions.request.agent` type is incompatible
+          // see https://github.com/octokit/types.ts/pull/264
+          requestOptions.request
+        )
+      ).then(async (response) => {
+        url = response.url;
+        status = response.status;
+        for (const keyAndValue of response.headers) {
+          headers[keyAndValue[0]] = keyAndValue[1];
+        }
+        if ("deprecation" in headers) {
+          const matches = headers.link && headers.link.match(/<([^>]+)>; rel="deprecation"/);
+          const deprecationLink = matches && matches.pop();
+          log.warn(
+            `[@octokit/request] "${requestOptions.method} ${requestOptions.url}" is deprecated. It is scheduled to be removed on ${headers.sunset}${deprecationLink ? `. See ${deprecationLink}` : ""}`
+          );
+        }
+        if (status === 204 || status === 205) {
+          return;
+        }
+        if (requestOptions.method === "HEAD") {
+          if (status < 400) {
+            return;
+          }
+          throw new import_request_error.RequestError(response.statusText, status, {
+            response: {
+              url,
+              status,
+              headers,
+              data: void 0
+            },
+            request: requestOptions
+          });
+        }
+        if (status === 304) {
+          throw new import_request_error.RequestError("Not modified", status, {
+            response: {
+              url,
+              status,
+              headers,
+              data: await getResponseData(response)
+            },
+            request: requestOptions
+          });
+        }
+        if (status >= 400) {
+          const data = await getResponseData(response);
+          const error = new import_request_error.RequestError(toErrorMessage(data), status, {
+            response: {
+              url,
+              status,
+              headers,
+              data
+            },
+            request: requestOptions
+          });
+          throw error;
+        }
+        return getResponseData(response);
+      }).then((data) => {
+        return {
+          status,
+          url,
+          headers,
+          data
+        };
+      }).catch((error) => {
+        if (error instanceof import_request_error.RequestError)
+          throw error;
+        else if (error.name === "AbortError")
+          throw error;
+        throw new import_request_error.RequestError(error.message, 500, {
+          request: requestOptions
+        });
+      });
+    }
+    async function getResponseData(response) {
+      const contentType = response.headers.get("content-type");
+      if (/application\/json/.test(contentType)) {
+        return response.json();
+      }
+      if (!contentType || /^text\/|charset=utf-8$/.test(contentType)) {
+        return response.text();
+      }
+      return getBufferResponse(response);
+    }
+    function toErrorMessage(data) {
+      if (typeof data === "string")
+        return data;
+      if ("message" in data) {
+        if (Array.isArray(data.errors)) {
+          return `${data.message}: ${data.errors.map(JSON.stringify).join(", ")}`;
+        }
+        return data.message;
+      }
+      return `Unknown error: ${JSON.stringify(data)}`;
+    }
+    function withDefaults(oldEndpoint, newDefaults) {
+      const endpoint2 = oldEndpoint.defaults(newDefaults);
+      const newApi = function(route, parameters) {
+        const endpointOptions = endpoint2.merge(route, parameters);
+        if (!endpointOptions.request || !endpointOptions.request.hook) {
+          return fetchWrapper(endpoint2.parse(endpointOptions));
+        }
+        const request2 = (route2, parameters2) => {
+          return fetchWrapper(
+            endpoint2.parse(endpoint2.merge(route2, parameters2))
+          );
+        };
+        Object.assign(request2, {
+          endpoint: endpoint2,
+          defaults: withDefaults.bind(null, endpoint2)
+        });
+        return endpointOptions.request.hook(request2, endpointOptions);
+      };
+      return Object.assign(newApi, {
+        endpoint: endpoint2,
+        defaults: withDefaults.bind(null, endpoint2)
+      });
+    }
+    var request = withDefaults(import_endpoint.endpoint, {
+      headers: {
+        "user-agent": `octokit-request.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`
+      }
+    });
+  }
+});
+
 // node_modules/@octokit/oauth-authorization-url/dist-node/index.js
-var require_dist_node23 = __commonJS({
+var require_dist_node31 = __commonJS({
   "node_modules/@octokit/oauth-authorization-url/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -73201,8 +75464,333 @@ var require_dist_node23 = __commonJS({
   }
 });
 
+// node_modules/@octokit/oauth-methods/node_modules/@octokit/endpoint/dist-node/index.js
+var require_dist_node32 = __commonJS({
+  "node_modules/@octokit/oauth-methods/node_modules/@octokit/endpoint/dist-node/index.js"(exports2, module2) {
+    "use strict";
+    var __defProp2 = Object.defineProperty;
+    var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
+    var __getOwnPropNames2 = Object.getOwnPropertyNames;
+    var __hasOwnProp2 = Object.prototype.hasOwnProperty;
+    var __export2 = (target, all) => {
+      for (var name in all)
+        __defProp2(target, name, { get: all[name], enumerable: true });
+    };
+    var __copyProps2 = (to, from, except, desc) => {
+      if (from && typeof from === "object" || typeof from === "function") {
+        for (let key of __getOwnPropNames2(from))
+          if (!__hasOwnProp2.call(to, key) && key !== except)
+            __defProp2(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc2(from, key)) || desc.enumerable });
+      }
+      return to;
+    };
+    var __toCommonJS2 = (mod) => __copyProps2(__defProp2({}, "__esModule", { value: true }), mod);
+    var dist_src_exports = {};
+    __export2(dist_src_exports, {
+      endpoint: () => endpoint
+    });
+    module2.exports = __toCommonJS2(dist_src_exports);
+    function lowercaseKeys(object) {
+      if (!object) {
+        return {};
+      }
+      return Object.keys(object).reduce((newObj, key) => {
+        newObj[key.toLowerCase()] = object[key];
+        return newObj;
+      }, {});
+    }
+    var import_is_plain_object = require_is_plain_object();
+    function mergeDeep(defaults, options2) {
+      const result = Object.assign({}, defaults);
+      Object.keys(options2).forEach((key) => {
+        if ((0, import_is_plain_object.isPlainObject)(options2[key])) {
+          if (!(key in defaults))
+            Object.assign(result, { [key]: options2[key] });
+          else
+            result[key] = mergeDeep(defaults[key], options2[key]);
+        } else {
+          Object.assign(result, { [key]: options2[key] });
+        }
+      });
+      return result;
+    }
+    function removeUndefinedProperties(obj) {
+      for (const key in obj) {
+        if (obj[key] === void 0) {
+          delete obj[key];
+        }
+      }
+      return obj;
+    }
+    function merge(defaults, route, options2) {
+      if (typeof route === "string") {
+        let [method, url] = route.split(" ");
+        options2 = Object.assign(url ? { method, url } : { url: method }, options2);
+      } else {
+        options2 = Object.assign({}, route);
+      }
+      options2.headers = lowercaseKeys(options2.headers);
+      removeUndefinedProperties(options2);
+      removeUndefinedProperties(options2.headers);
+      const mergedOptions = mergeDeep(defaults || {}, options2);
+      if (defaults && defaults.mediaType.previews.length) {
+        mergedOptions.mediaType.previews = defaults.mediaType.previews.filter((preview) => !mergedOptions.mediaType.previews.includes(preview)).concat(mergedOptions.mediaType.previews);
+      }
+      mergedOptions.mediaType.previews = mergedOptions.mediaType.previews.map(
+        (preview) => preview.replace(/-preview/, "")
+      );
+      return mergedOptions;
+    }
+    function addQueryParameters(url, parameters) {
+      const separator = /\?/.test(url) ? "&" : "?";
+      const names = Object.keys(parameters);
+      if (names.length === 0) {
+        return url;
+      }
+      return url + separator + names.map((name) => {
+        if (name === "q") {
+          return "q=" + parameters.q.split("+").map(encodeURIComponent).join("+");
+        }
+        return `${name}=${encodeURIComponent(parameters[name])}`;
+      }).join("&");
+    }
+    var urlVariableRegex = /\{[^}]+\}/g;
+    function removeNonChars(variableName) {
+      return variableName.replace(/^\W+|\W+$/g, "").split(/,/);
+    }
+    function extractUrlVariableNames(url) {
+      const matches = url.match(urlVariableRegex);
+      if (!matches) {
+        return [];
+      }
+      return matches.map(removeNonChars).reduce((a, b) => a.concat(b), []);
+    }
+    function omit(object, keysToOmit) {
+      return Object.keys(object).filter((option) => !keysToOmit.includes(option)).reduce((obj, key) => {
+        obj[key] = object[key];
+        return obj;
+      }, {});
+    }
+    function encodeReserved(str) {
+      return str.split(/(%[0-9A-Fa-f]{2})/g).map(function(part) {
+        if (!/%[0-9A-Fa-f]/.test(part)) {
+          part = encodeURI(part).replace(/%5B/g, "[").replace(/%5D/g, "]");
+        }
+        return part;
+      }).join("");
+    }
+    function encodeUnreserved(str) {
+      return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
+        return "%" + c.charCodeAt(0).toString(16).toUpperCase();
+      });
+    }
+    function encodeValue(operator, value, key) {
+      value = operator === "+" || operator === "#" ? encodeReserved(value) : encodeUnreserved(value);
+      if (key) {
+        return encodeUnreserved(key) + "=" + value;
+      } else {
+        return value;
+      }
+    }
+    function isDefined(value) {
+      return value !== void 0 && value !== null;
+    }
+    function isKeyOperator(operator) {
+      return operator === ";" || operator === "&" || operator === "?";
+    }
+    function getValues(context, operator, key, modifier) {
+      var value = context[key], result = [];
+      if (isDefined(value) && value !== "") {
+        if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+          value = value.toString();
+          if (modifier && modifier !== "*") {
+            value = value.substring(0, parseInt(modifier, 10));
+          }
+          result.push(
+            encodeValue(operator, value, isKeyOperator(operator) ? key : "")
+          );
+        } else {
+          if (modifier === "*") {
+            if (Array.isArray(value)) {
+              value.filter(isDefined).forEach(function(value2) {
+                result.push(
+                  encodeValue(operator, value2, isKeyOperator(operator) ? key : "")
+                );
+              });
+            } else {
+              Object.keys(value).forEach(function(k) {
+                if (isDefined(value[k])) {
+                  result.push(encodeValue(operator, value[k], k));
+                }
+              });
+            }
+          } else {
+            const tmp = [];
+            if (Array.isArray(value)) {
+              value.filter(isDefined).forEach(function(value2) {
+                tmp.push(encodeValue(operator, value2));
+              });
+            } else {
+              Object.keys(value).forEach(function(k) {
+                if (isDefined(value[k])) {
+                  tmp.push(encodeUnreserved(k));
+                  tmp.push(encodeValue(operator, value[k].toString()));
+                }
+              });
+            }
+            if (isKeyOperator(operator)) {
+              result.push(encodeUnreserved(key) + "=" + tmp.join(","));
+            } else if (tmp.length !== 0) {
+              result.push(tmp.join(","));
+            }
+          }
+        }
+      } else {
+        if (operator === ";") {
+          if (isDefined(value)) {
+            result.push(encodeUnreserved(key));
+          }
+        } else if (value === "" && (operator === "&" || operator === "?")) {
+          result.push(encodeUnreserved(key) + "=");
+        } else if (value === "") {
+          result.push("");
+        }
+      }
+      return result;
+    }
+    function parseUrl(template) {
+      return {
+        expand: expand.bind(null, template)
+      };
+    }
+    function expand(template, context) {
+      var operators = ["+", "#", ".", "/", ";", "?", "&"];
+      return template.replace(
+        /\{([^\{\}]+)\}|([^\{\}]+)/g,
+        function(_, expression, literal) {
+          if (expression) {
+            let operator = "";
+            const values = [];
+            if (operators.indexOf(expression.charAt(0)) !== -1) {
+              operator = expression.charAt(0);
+              expression = expression.substr(1);
+            }
+            expression.split(/,/g).forEach(function(variable) {
+              var tmp = /([^:\*]*)(?::(\d+)|(\*))?/.exec(variable);
+              values.push(getValues(context, operator, tmp[1], tmp[2] || tmp[3]));
+            });
+            if (operator && operator !== "+") {
+              var separator = ",";
+              if (operator === "?") {
+                separator = "&";
+              } else if (operator !== "#") {
+                separator = operator;
+              }
+              return (values.length !== 0 ? operator : "") + values.join(separator);
+            } else {
+              return values.join(",");
+            }
+          } else {
+            return encodeReserved(literal);
+          }
+        }
+      );
+    }
+    function parse2(options2) {
+      let method = options2.method.toUpperCase();
+      let url = (options2.url || "/").replace(/:([a-z]\w+)/g, "{$1}");
+      let headers = Object.assign({}, options2.headers);
+      let body;
+      let parameters = omit(options2, [
+        "method",
+        "baseUrl",
+        "url",
+        "headers",
+        "request",
+        "mediaType"
+      ]);
+      const urlVariableNames = extractUrlVariableNames(url);
+      url = parseUrl(url).expand(parameters);
+      if (!/^http/.test(url)) {
+        url = options2.baseUrl + url;
+      }
+      const omittedParameters = Object.keys(options2).filter((option) => urlVariableNames.includes(option)).concat("baseUrl");
+      const remainingParameters = omit(parameters, omittedParameters);
+      const isBinaryRequest = /application\/octet-stream/i.test(headers.accept);
+      if (!isBinaryRequest) {
+        if (options2.mediaType.format) {
+          headers.accept = headers.accept.split(/,/).map(
+            (preview) => preview.replace(
+              /application\/vnd(\.\w+)(\.v3)?(\.\w+)?(\+json)?$/,
+              `application/vnd$1$2.${options2.mediaType.format}`
+            )
+          ).join(",");
+        }
+        if (options2.mediaType.previews.length) {
+          const previewsFromAcceptHeader = headers.accept.match(/[\w-]+(?=-preview)/g) || [];
+          headers.accept = previewsFromAcceptHeader.concat(options2.mediaType.previews).map((preview) => {
+            const format = options2.mediaType.format ? `.${options2.mediaType.format}` : "+json";
+            return `application/vnd.github.${preview}-preview${format}`;
+          }).join(",");
+        }
+      }
+      if (["GET", "HEAD"].includes(method)) {
+        url = addQueryParameters(url, remainingParameters);
+      } else {
+        if ("data" in remainingParameters) {
+          body = remainingParameters.data;
+        } else {
+          if (Object.keys(remainingParameters).length) {
+            body = remainingParameters;
+          }
+        }
+      }
+      if (!headers["content-type"] && typeof body !== "undefined") {
+        headers["content-type"] = "application/json; charset=utf-8";
+      }
+      if (["PATCH", "PUT"].includes(method) && typeof body === "undefined") {
+        body = "";
+      }
+      return Object.assign(
+        { method, url, headers },
+        typeof body !== "undefined" ? { body } : null,
+        options2.request ? { request: options2.request } : null
+      );
+    }
+    function endpointWithDefaults(defaults, route, options2) {
+      return parse2(merge(defaults, route, options2));
+    }
+    function withDefaults(oldDefaults, newDefaults) {
+      const DEFAULTS2 = merge(oldDefaults, newDefaults);
+      const endpoint2 = endpointWithDefaults.bind(null, DEFAULTS2);
+      return Object.assign(endpoint2, {
+        DEFAULTS: DEFAULTS2,
+        defaults: withDefaults.bind(null, DEFAULTS2),
+        merge: merge.bind(null, DEFAULTS2),
+        parse: parse2
+      });
+    }
+    var import_universal_user_agent = require_dist_node3();
+    var VERSION = "7.0.6";
+    var userAgent = `octokit-endpoint.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`;
+    var DEFAULTS = {
+      method: "GET",
+      baseUrl: "https://api.github.com",
+      headers: {
+        accept: "application/vnd.github.v3+json",
+        "user-agent": userAgent
+      },
+      mediaType: {
+        format: "",
+        previews: []
+      }
+    };
+    var endpoint = withDefaults(null, DEFAULTS);
+  }
+});
+
 // node_modules/@octokit/oauth-methods/node_modules/@octokit/request-error/dist-node/index.js
-var require_dist_node24 = __commonJS({
+var require_dist_node33 = __commonJS({
   "node_modules/@octokit/oauth-methods/node_modules/@octokit/request-error/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -73255,8 +75843,203 @@ var require_dist_node24 = __commonJS({
   }
 });
 
+// node_modules/@octokit/oauth-methods/node_modules/@octokit/request/dist-node/index.js
+var require_dist_node34 = __commonJS({
+  "node_modules/@octokit/oauth-methods/node_modules/@octokit/request/dist-node/index.js"(exports2, module2) {
+    "use strict";
+    var __create2 = Object.create;
+    var __defProp2 = Object.defineProperty;
+    var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
+    var __getOwnPropNames2 = Object.getOwnPropertyNames;
+    var __getProtoOf2 = Object.getPrototypeOf;
+    var __hasOwnProp2 = Object.prototype.hasOwnProperty;
+    var __export2 = (target, all) => {
+      for (var name in all)
+        __defProp2(target, name, { get: all[name], enumerable: true });
+    };
+    var __copyProps2 = (to, from, except, desc) => {
+      if (from && typeof from === "object" || typeof from === "function") {
+        for (let key of __getOwnPropNames2(from))
+          if (!__hasOwnProp2.call(to, key) && key !== except)
+            __defProp2(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc2(from, key)) || desc.enumerable });
+      }
+      return to;
+    };
+    var __toESM2 = (mod, isNodeMode, target) => (target = mod != null ? __create2(__getProtoOf2(mod)) : {}, __copyProps2(
+      // If the importer is in node compatibility mode or this is not an ESM
+      // file that has been converted to a CommonJS file using a Babel-
+      // compatible transform (i.e. "__esModule" has not been set), then set
+      // "default" to the CommonJS "module.exports" for node compatibility.
+      isNodeMode || !mod || !mod.__esModule ? __defProp2(target, "default", { value: mod, enumerable: true }) : target,
+      mod
+    ));
+    var __toCommonJS2 = (mod) => __copyProps2(__defProp2({}, "__esModule", { value: true }), mod);
+    var dist_src_exports = {};
+    __export2(dist_src_exports, {
+      request: () => request
+    });
+    module2.exports = __toCommonJS2(dist_src_exports);
+    var import_endpoint = require_dist_node32();
+    var import_universal_user_agent = require_dist_node3();
+    var VERSION = "6.2.8";
+    var import_is_plain_object = require_is_plain_object();
+    var import_node_fetch = __toESM2(require_lib6());
+    var import_request_error = require_dist_node33();
+    function getBufferResponse(response) {
+      return response.arrayBuffer();
+    }
+    function fetchWrapper(requestOptions) {
+      const log = requestOptions.request && requestOptions.request.log ? requestOptions.request.log : console;
+      if ((0, import_is_plain_object.isPlainObject)(requestOptions.body) || Array.isArray(requestOptions.body)) {
+        requestOptions.body = JSON.stringify(requestOptions.body);
+      }
+      let headers = {};
+      let status;
+      let url;
+      const fetch2 = requestOptions.request && requestOptions.request.fetch || globalThis.fetch || /* istanbul ignore next */
+      import_node_fetch.default;
+      return fetch2(
+        requestOptions.url,
+        Object.assign(
+          {
+            method: requestOptions.method,
+            body: requestOptions.body,
+            headers: requestOptions.headers,
+            redirect: requestOptions.redirect,
+            // duplex must be set if request.body is ReadableStream or Async Iterables.
+            // See https://fetch.spec.whatwg.org/#dom-requestinit-duplex.
+            ...requestOptions.body && { duplex: "half" }
+          },
+          // `requestOptions.request.agent` type is incompatible
+          // see https://github.com/octokit/types.ts/pull/264
+          requestOptions.request
+        )
+      ).then(async (response) => {
+        url = response.url;
+        status = response.status;
+        for (const keyAndValue of response.headers) {
+          headers[keyAndValue[0]] = keyAndValue[1];
+        }
+        if ("deprecation" in headers) {
+          const matches = headers.link && headers.link.match(/<([^>]+)>; rel="deprecation"/);
+          const deprecationLink = matches && matches.pop();
+          log.warn(
+            `[@octokit/request] "${requestOptions.method} ${requestOptions.url}" is deprecated. It is scheduled to be removed on ${headers.sunset}${deprecationLink ? `. See ${deprecationLink}` : ""}`
+          );
+        }
+        if (status === 204 || status === 205) {
+          return;
+        }
+        if (requestOptions.method === "HEAD") {
+          if (status < 400) {
+            return;
+          }
+          throw new import_request_error.RequestError(response.statusText, status, {
+            response: {
+              url,
+              status,
+              headers,
+              data: void 0
+            },
+            request: requestOptions
+          });
+        }
+        if (status === 304) {
+          throw new import_request_error.RequestError("Not modified", status, {
+            response: {
+              url,
+              status,
+              headers,
+              data: await getResponseData(response)
+            },
+            request: requestOptions
+          });
+        }
+        if (status >= 400) {
+          const data = await getResponseData(response);
+          const error = new import_request_error.RequestError(toErrorMessage(data), status, {
+            response: {
+              url,
+              status,
+              headers,
+              data
+            },
+            request: requestOptions
+          });
+          throw error;
+        }
+        return getResponseData(response);
+      }).then((data) => {
+        return {
+          status,
+          url,
+          headers,
+          data
+        };
+      }).catch((error) => {
+        if (error instanceof import_request_error.RequestError)
+          throw error;
+        else if (error.name === "AbortError")
+          throw error;
+        throw new import_request_error.RequestError(error.message, 500, {
+          request: requestOptions
+        });
+      });
+    }
+    async function getResponseData(response) {
+      const contentType = response.headers.get("content-type");
+      if (/application\/json/.test(contentType)) {
+        return response.json();
+      }
+      if (!contentType || /^text\/|charset=utf-8$/.test(contentType)) {
+        return response.text();
+      }
+      return getBufferResponse(response);
+    }
+    function toErrorMessage(data) {
+      if (typeof data === "string")
+        return data;
+      if ("message" in data) {
+        if (Array.isArray(data.errors)) {
+          return `${data.message}: ${data.errors.map(JSON.stringify).join(", ")}`;
+        }
+        return data.message;
+      }
+      return `Unknown error: ${JSON.stringify(data)}`;
+    }
+    function withDefaults(oldEndpoint, newDefaults) {
+      const endpoint2 = oldEndpoint.defaults(newDefaults);
+      const newApi = function(route, parameters) {
+        const endpointOptions = endpoint2.merge(route, parameters);
+        if (!endpointOptions.request || !endpointOptions.request.hook) {
+          return fetchWrapper(endpoint2.parse(endpointOptions));
+        }
+        const request2 = (route2, parameters2) => {
+          return fetchWrapper(
+            endpoint2.parse(endpoint2.merge(route2, parameters2))
+          );
+        };
+        Object.assign(request2, {
+          endpoint: endpoint2,
+          defaults: withDefaults.bind(null, endpoint2)
+        });
+        return endpointOptions.request.hook(request2, endpointOptions);
+      };
+      return Object.assign(newApi, {
+        endpoint: endpoint2,
+        defaults: withDefaults.bind(null, endpoint2)
+      });
+    }
+    var request = withDefaults(import_endpoint.endpoint, {
+      headers: {
+        "user-agent": `octokit-request.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`
+      }
+    });
+  }
+});
+
 // node_modules/@octokit/oauth-methods/dist-node/index.js
-var require_dist_node25 = __commonJS({
+var require_dist_node35 = __commonJS({
   "node_modules/@octokit/oauth-methods/dist-node/index.js"(exports2, module2) {
     "use strict";
     var __create2 = Object.create;
@@ -73302,9 +76085,9 @@ var require_dist_node25 = __commonJS({
     });
     module2.exports = __toCommonJS2(dist_src_exports);
     var VERSION = "2.0.6";
-    var import_oauth_authorization_url = require_dist_node23();
-    var import_request = require_dist_node22();
-    var import_request_error = require_dist_node24();
+    var import_oauth_authorization_url = require_dist_node31();
+    var import_request = require_dist_node34();
+    var import_request_error = require_dist_node33();
     function requestToOAuthBaseUrl(request) {
       const endpointDefaults = request.endpoint.DEFAULTS;
       return /^https:\/\/(api\.)?github\.com$/.test(endpointDefaults.baseUrl) ? "https://github.com" : endpointDefaults.baseUrl.replace("/api/v3", "");
@@ -73345,7 +76128,7 @@ var require_dist_node25 = __commonJS({
         baseUrl
       });
     }
-    var import_request2 = require_dist_node22();
+    var import_request2 = require_dist_node34();
     async function exchangeWebFlowCode(options2) {
       const request = options2.request || /* istanbul ignore next: we always pass a custom request in tests */
       import_request2.request;
@@ -73384,7 +76167,7 @@ var require_dist_node25 = __commonJS({
     function toTimestamp(apiTimeInMs, expirationInSeconds) {
       return new Date(apiTimeInMs + expirationInSeconds * 1e3).toISOString();
     }
-    var import_request3 = require_dist_node22();
+    var import_request3 = require_dist_node34();
     async function createDeviceCode(options2) {
       const request = options2.request || /* istanbul ignore next: we always pass a custom request in tests */
       import_request3.request;
@@ -73396,7 +76179,7 @@ var require_dist_node25 = __commonJS({
       }
       return oauthRequest(request, "POST /login/device/code", parameters);
     }
-    var import_request4 = require_dist_node22();
+    var import_request4 = require_dist_node34();
     async function exchangeDeviceCode(options2) {
       const request = options2.request || /* istanbul ignore next: we always pass a custom request in tests */
       import_request4.request;
@@ -73436,7 +76219,7 @@ var require_dist_node25 = __commonJS({
     function toTimestamp2(apiTimeInMs, expirationInSeconds) {
       return new Date(apiTimeInMs + expirationInSeconds * 1e3).toISOString();
     }
-    var import_request5 = require_dist_node22();
+    var import_request5 = require_dist_node34();
     var import_btoa_lite = __toESM2(require_btoa_node());
     async function checkToken(options2) {
       const request = options2.request || /* istanbul ignore next: we always pass a custom request in tests */
@@ -73464,7 +76247,7 @@ var require_dist_node25 = __commonJS({
       }
       return { ...response, authentication };
     }
-    var import_request6 = require_dist_node22();
+    var import_request6 = require_dist_node34();
     async function refreshToken(options2) {
       const request = options2.request || /* istanbul ignore next: we always pass a custom request in tests */
       import_request6.request;
@@ -73496,7 +76279,7 @@ var require_dist_node25 = __commonJS({
     function toTimestamp3(apiTimeInMs, expirationInSeconds) {
       return new Date(apiTimeInMs + expirationInSeconds * 1e3).toISOString();
     }
-    var import_request7 = require_dist_node22();
+    var import_request7 = require_dist_node34();
     var import_btoa_lite2 = __toESM2(require_btoa_node());
     async function scopeToken(options2) {
       const {
@@ -73531,7 +76314,7 @@ var require_dist_node25 = __commonJS({
       );
       return { ...response, authentication };
     }
-    var import_request8 = require_dist_node22();
+    var import_request8 = require_dist_node34();
     var import_btoa_lite3 = __toESM2(require_btoa_node());
     async function resetToken(options2) {
       const request = options2.request || /* istanbul ignore next: we always pass a custom request in tests */
@@ -73561,7 +76344,7 @@ var require_dist_node25 = __commonJS({
       }
       return { ...response, authentication };
     }
-    var import_request9 = require_dist_node22();
+    var import_request9 = require_dist_node34();
     var import_btoa_lite4 = __toESM2(require_btoa_node());
     async function deleteToken(options2) {
       const request = options2.request || /* istanbul ignore next: we always pass a custom request in tests */
@@ -73578,7 +76361,7 @@ var require_dist_node25 = __commonJS({
         }
       );
     }
-    var import_request10 = require_dist_node22();
+    var import_request10 = require_dist_node34();
     var import_btoa_lite5 = __toESM2(require_btoa_node());
     async function deleteAuthorization(options2) {
       const request = options2.request || /* istanbul ignore next: we always pass a custom request in tests */
@@ -73599,7 +76382,7 @@ var require_dist_node25 = __commonJS({
 });
 
 // node_modules/@octokit/auth-oauth-device/dist-node/index.js
-var require_dist_node26 = __commonJS({
+var require_dist_node36 = __commonJS({
   "node_modules/@octokit/auth-oauth-device/dist-node/index.js"(exports2, module2) {
     "use strict";
     var __defProp2 = Object.defineProperty;
@@ -73625,8 +76408,8 @@ var require_dist_node26 = __commonJS({
     });
     module2.exports = __toCommonJS2(dist_src_exports);
     var import_universal_user_agent = require_dist_node3();
-    var import_request = require_dist_node22();
-    var import_oauth_methods = require_dist_node25();
+    var import_request = require_dist_node30();
+    var import_oauth_methods = require_dist_node35();
     async function getOAuthAccessToken(state, options2) {
       const cachedAuthentication = getCachedAuthentication(state, options2.auth);
       if (cachedAuthentication)
@@ -73756,7 +76539,7 @@ var require_dist_node26 = __commonJS({
 });
 
 // node_modules/@octokit/auth-oauth-user/dist-node/index.js
-var require_dist_node27 = __commonJS({
+var require_dist_node37 = __commonJS({
   "node_modules/@octokit/auth-oauth-user/dist-node/index.js"(exports2, module2) {
     "use strict";
     var __create2 = Object.create;
@@ -73793,10 +76576,10 @@ var require_dist_node27 = __commonJS({
     });
     module2.exports = __toCommonJS2(dist_src_exports);
     var import_universal_user_agent = require_dist_node3();
-    var import_request = require_dist_node22();
+    var import_request = require_dist_node27();
     var VERSION = "2.1.2";
-    var import_auth_oauth_device = require_dist_node26();
-    var import_oauth_methods = require_dist_node25();
+    var import_auth_oauth_device = require_dist_node36();
+    var import_oauth_methods = require_dist_node35();
     async function getAuthentication(state) {
       if ("code" in state.strategyOptions) {
         const { authentication } = await (0, import_oauth_methods.exchangeWebFlowCode)({
@@ -73842,7 +76625,7 @@ var require_dist_node27 = __commonJS({
       }
       throw new Error("[@octokit/auth-oauth-user] Invalid strategy options");
     }
-    var import_oauth_methods2 = require_dist_node25();
+    var import_oauth_methods2 = require_dist_node35();
     async function auth(state, options2 = {}) {
       var _a, _b;
       if (!state.authentication) {
@@ -73984,7 +76767,7 @@ var require_dist_node27 = __commonJS({
 });
 
 // node_modules/@octokit/auth-oauth-app/dist-node/index.js
-var require_dist_node28 = __commonJS({
+var require_dist_node38 = __commonJS({
   "node_modules/@octokit/auth-oauth-app/dist-node/index.js"(exports2, module2) {
     "use strict";
     var __create2 = Object.create;
@@ -74021,9 +76804,9 @@ var require_dist_node28 = __commonJS({
     });
     module2.exports = __toCommonJS2(dist_src_exports);
     var import_universal_user_agent = require_dist_node3();
-    var import_request = require_dist_node22();
+    var import_request = require_dist_node24();
     var import_btoa_lite = __toESM2(require_btoa_node());
-    var import_auth_oauth_user = require_dist_node27();
+    var import_auth_oauth_user = require_dist_node37();
     async function auth(state, authOptions) {
       if (authOptions.type === "oauth-app") {
         return {
@@ -74061,7 +76844,7 @@ var require_dist_node28 = __commonJS({
       return userAuth();
     }
     var import_btoa_lite2 = __toESM2(require_btoa_node());
-    var import_auth_oauth_user2 = require_dist_node27();
+    var import_auth_oauth_user2 = require_dist_node37();
     async function hook(state, request2, route, parameters) {
       let endpoint = request2.endpoint.merge(
         route,
@@ -74087,7 +76870,7 @@ var require_dist_node28 = __commonJS({
       }
     }
     var VERSION = "5.0.6";
-    var import_auth_oauth_user3 = require_dist_node27();
+    var import_auth_oauth_user3 = require_dist_node37();
     function createOAuthAppAuth(options2) {
       const state = Object.assign(
         {
@@ -75098,6 +77881,18 @@ var require_semver = __commonJS({
     var { safeRe: re, t } = require_re();
     var parseOptions = require_parse_options();
     var { compareIdentifiers } = require_identifiers();
+    var isPrereleaseIdentifier = (prerelease, identifier) => {
+      const identifiers = identifier.split(".");
+      if (identifiers.length > prerelease.length) {
+        return false;
+      }
+      for (let i = 0; i < identifiers.length; i++) {
+        if (compareIdentifiers(prerelease[i], identifiers[i]) !== 0) {
+          return false;
+        }
+      }
+      return true;
+    };
     var SemVer = class _SemVer {
       constructor(version2, options2) {
         options2 = parseOptions(options2);
@@ -75344,8 +78139,9 @@ var require_semver = __commonJS({
               if (identifierBase === false) {
                 prerelease = [identifier];
               }
-              if (compareIdentifiers(this.prerelease[0], identifier) === 0) {
-                if (isNaN(this.prerelease[1])) {
+              if (isPrereleaseIdentifier(this.prerelease, identifier)) {
+                const prereleaseBase = this.prerelease[identifier.split(".").length];
+                if (isNaN(prereleaseBase)) {
                   this.prerelease = prerelease;
                 }
               } else {
@@ -75747,6 +78543,47 @@ var require_coerce = __commonJS({
   }
 });
 
+// node_modules/jsonwebtoken/node_modules/semver/functions/truncate.js
+var require_truncate = __commonJS({
+  "node_modules/jsonwebtoken/node_modules/semver/functions/truncate.js"(exports2, module2) {
+    "use strict";
+    var parse2 = require_parse3();
+    var constants = require_constants9();
+    var SemVer = require_semver();
+    var truncate = (version2, truncation, options2) => {
+      if (!constants.RELEASE_TYPES.includes(truncation)) {
+        return null;
+      }
+      const clonedVersion = cloneInputVersion(version2, options2);
+      return clonedVersion && doTruncation(clonedVersion, truncation);
+    };
+    var cloneInputVersion = (version2, options2) => {
+      const versionStringToParse = version2 instanceof SemVer ? version2.version : version2;
+      return parse2(versionStringToParse, options2);
+    };
+    var doTruncation = (version2, truncation) => {
+      if (isPrerelease(truncation)) {
+        return version2.version;
+      }
+      version2.prerelease = [];
+      switch (truncation) {
+        case "major":
+          version2.minor = 0;
+          version2.patch = 0;
+          break;
+        case "minor":
+          version2.patch = 0;
+          break;
+      }
+      return version2.format();
+    };
+    var isPrerelease = (type) => {
+      return type.startsWith("pre");
+    };
+    module2.exports = truncate;
+  }
+});
+
 // node_modules/jsonwebtoken/node_modules/semver/internal/lrucache.js
 var require_lrucache = __commonJS({
   "node_modules/jsonwebtoken/node_modules/semver/internal/lrucache.js"(exports2, module2) {
@@ -75855,6 +78692,7 @@ var require_range = __commonJS({
         return this.range;
       }
       parseRange(range) {
+        range = range.replace(BUILDSTRIPRE, "");
         const memoOpts = (this.options.includePrerelease && FLAG_INCLUDE_PRERELEASE) | (this.options.loose && FLAG_LOOSE);
         const memoKey = memoOpts + ":" + range;
         const cached = cache.get(memoKey);
@@ -75937,12 +78775,14 @@ var require_range = __commonJS({
     var SemVer = require_semver();
     var {
       safeRe: re,
+      src,
       t,
       comparatorTrimReplace,
       tildeTrimReplace,
       caretTrimReplace
     } = require_re();
     var { FLAG_INCLUDE_PRERELEASE, FLAG_LOOSE } = require_constants9();
+    var BUILDSTRIPRE = new RegExp(src[t.BUILD], "g");
     var isNullSet = (c) => c.value === "<0.0.0-0";
     var isAny = (c) => c.value === "";
     var isSatisfiable = (comparators, options2) => {
@@ -75971,20 +78811,22 @@ var require_range = __commonJS({
       return comp;
     };
     var isX = (id) => !id || id.toLowerCase() === "x" || id === "*";
+    var invalidXRangeOrder = (M, m, p) => isX(M) && !isX(m) || isX(m) && p && !isX(p);
     var replaceTildes = (comp, options2) => {
       return comp.trim().split(/\s+/).map((c) => replaceTilde(c, options2)).join(" ");
     };
     var replaceTilde = (comp, options2) => {
       const r = options2.loose ? re[t.TILDELOOSE] : re[t.TILDE];
+      const z = options2.includePrerelease ? "-0" : "";
       return comp.replace(r, (_, M, m, p, pr) => {
         debug("tilde", comp, _, M, m, p, pr);
         let ret;
         if (isX(M)) {
           ret = "";
         } else if (isX(m)) {
-          ret = `>=${M}.0.0 <${+M + 1}.0.0-0`;
+          ret = `>=${M}.0.0${z} <${+M + 1}.0.0-0`;
         } else if (isX(p)) {
-          ret = `>=${M}.${m}.0 <${M}.${+m + 1}.0-0`;
+          ret = `>=${M}.${m}.0${z} <${M}.${+m + 1}.0-0`;
         } else if (pr) {
           debug("replaceTilde pr", pr);
           ret = `>=${M}.${m}.${p}-${pr} <${M}.${+m + 1}.0-0`;
@@ -76030,9 +78872,9 @@ var require_range = __commonJS({
           debug("no pr");
           if (M === "0") {
             if (m === "0") {
-              ret = `>=${M}.${m}.${p}${z} <${M}.${m}.${+p + 1}-0`;
+              ret = `>=${M}.${m}.${p} <${M}.${m}.${+p + 1}-0`;
             } else {
-              ret = `>=${M}.${m}.${p}${z} <${M}.${+m + 1}.0-0`;
+              ret = `>=${M}.${m}.${p} <${M}.${+m + 1}.0-0`;
             }
           } else {
             ret = `>=${M}.${m}.${p} <${+M + 1}.0.0-0`;
@@ -76051,6 +78893,9 @@ var require_range = __commonJS({
       const r = options2.loose ? re[t.XRANGELOOSE] : re[t.XRANGE];
       return comp.replace(r, (ret, gtlt, M, m, p, pr) => {
         debug("xRange", comp, ret, gtlt, M, m, p, pr);
+        if (invalidXRangeOrder(M, m, p)) {
+          return comp;
+        }
         const xM = isX(M);
         const xm = xM || isX(m);
         const xp = xm || isX(p);
@@ -76698,7 +79543,7 @@ var require_subset = __commonJS({
             if (higher === c && higher !== gt) {
               return false;
             }
-          } else if (gt.operator === ">=" && !satisfies(gt.semver, String(c), options2)) {
+          } else if (gt.operator === ">=" && !c.test(gt.semver)) {
             return false;
           }
         }
@@ -76713,7 +79558,7 @@ var require_subset = __commonJS({
             if (lower === c && lower !== lt) {
               return false;
             }
-          } else if (lt.operator === "<=" && !satisfies(lt.semver, String(c), options2)) {
+          } else if (lt.operator === "<=" && !c.test(lt.semver)) {
             return false;
           }
         }
@@ -76781,6 +79626,7 @@ var require_semver2 = __commonJS({
     var lte = require_lte();
     var cmp = require_cmp();
     var coerce = require_coerce();
+    var truncate = require_truncate();
     var Comparator = require_comparator();
     var Range = require_range();
     var satisfies = require_satisfies();
@@ -76819,6 +79665,7 @@ var require_semver2 = __commonJS({
       lte,
       cmp,
       coerce,
+      truncate,
       Comparator,
       Range,
       satisfies,
@@ -77799,7 +80646,7 @@ var require_jsonwebtoken = __commonJS({
 });
 
 // node_modules/universal-github-app-jwt/dist-node/index.js
-var require_dist_node29 = __commonJS({
+var require_dist_node39 = __commonJS({
   "node_modules/universal-github-app-jwt/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -79075,7 +81922,7 @@ var require_cjs7 = __commonJS({
 });
 
 // node_modules/@octokit/auth-app/dist-node/index.js
-var require_dist_node30 = __commonJS({
+var require_dist_node40 = __commonJS({
   "node_modules/@octokit/auth-app/dist-node/index.js"(exports2, module2) {
     "use strict";
     var __defProp2 = Object.defineProperty;
@@ -79102,10 +81949,10 @@ var require_dist_node30 = __commonJS({
     });
     module2.exports = __toCommonJS2(dist_src_exports);
     var import_universal_user_agent = require_dist_node3();
-    var import_request = require_dist_node22();
-    var import_auth_oauth_app = require_dist_node28();
+    var import_request = require_dist_node21();
+    var import_auth_oauth_app = require_dist_node38();
     var import_deprecation = require_dist_node5();
-    var import_universal_github_app_jwt = require_dist_node29();
+    var import_universal_github_app_jwt = require_dist_node39();
     async function getAppAuthentication({
       appId,
       privateKey,
@@ -79355,7 +82202,7 @@ var require_dist_node30 = __commonJS({
           throw new Error(`Invalid auth type: ${authOptions.type}`);
       }
     }
-    var import_auth_oauth_user = require_dist_node27();
+    var import_auth_oauth_user = require_dist_node37();
     var PATHS = [
       "/app",
       "/app/hook/config",
@@ -79475,7 +82322,7 @@ var require_dist_node30 = __commonJS({
       }
     }
     var VERSION = "4.0.13";
-    var import_auth_oauth_user2 = require_dist_node27();
+    var import_auth_oauth_user2 = require_dist_node37();
     function createAppAuth(options2) {
       if (!options2.appId) {
         throw new Error("[@octokit/auth-app] appId option is required");
@@ -79529,13 +82376,13 @@ var require_dist_node30 = __commonJS({
 });
 
 // node_modules/octokit-auth-probot/dist-node/index.js
-var require_dist_node31 = __commonJS({
+var require_dist_node41 = __commonJS({
   "node_modules/octokit-auth-probot/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    var authUnauthenticated = require_dist_node18();
-    var authToken = require_dist_node19();
-    var authApp = require_dist_node30();
+    var authUnauthenticated = require_dist_node17();
+    var authToken = require_dist_node18();
+    var authApp = require_dist_node40();
     function ownKeys(object, enumerableOnly) {
       var keys = Object.keys(object);
       if (Object.getOwnPropertySymbols) {
@@ -79729,14 +82576,14 @@ var require_probot_octokit = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.ProbotOctokit = void 0;
-    var core_1 = require_dist_node11();
-    var plugin_enterprise_compatibility_1 = require_dist_node12();
-    var plugin_paginate_rest_1 = require_dist_node13();
-    var plugin_rest_endpoint_methods_1 = require_dist_node14();
-    var plugin_retry_1 = require_dist_node15();
-    var plugin_throttling_1 = require_dist_node16();
-    var octokit_plugin_config_1 = require_dist_node17();
-    var octokit_auth_probot_1 = require_dist_node31();
+    var core_1 = require_dist_node10();
+    var plugin_enterprise_compatibility_1 = require_dist_node11();
+    var plugin_paginate_rest_1 = require_dist_node12();
+    var plugin_rest_endpoint_methods_1 = require_dist_node13();
+    var plugin_retry_1 = require_dist_node14();
+    var plugin_throttling_1 = require_dist_node15();
+    var octokit_plugin_config_1 = require_dist_node16();
+    var octokit_auth_probot_1 = require_dist_node41();
     var octokit_plugin_probot_request_logging_1 = require_octokit_plugin_probot_request_logging();
     var version_1 = require_version3();
     var defaultOptions = {
@@ -94079,10 +96926,7 @@ var require_json2 = __commonJS({
       var index = str.indexOf(char);
       var partial = "";
       if (index !== -1) {
-        partial = str.substring(0, index) + JSON_SYNTAX_CHAR;
-        for (var i = index + 1; i < str.length; i++) {
-          partial += JSON_SYNTAX_CHAR;
-        }
+        partial = str.substring(0, index) + new Array(str.length - index + 1).join(JSON_SYNTAX_CHAR);
       }
       try {
         JSON.parse(partial);
@@ -94857,9 +97701,8 @@ var require_side_channel_list = __commonJS({
           }
         },
         "delete": function(key) {
-          var root = $o && $o.next;
           var deletedNode = listDelete($o, key);
-          if (deletedNode && root && root === deletedNode) {
+          if (deletedNode && $o && !$o.next) {
             $o = void 0;
           }
           return !!deletedNode;
@@ -95851,7 +98694,8 @@ var require_side_channel = __commonJS({
       var channel = {
         assert: function(key) {
           if (!channel.has(key)) {
-            throw new $TypeError("Side channel does not contain " + inspect(key));
+            var keyDesc = key && Object(key) === key ? "the given object key" : inspect(key);
+            throw new $TypeError("Side channel does not contain " + keyDesc);
           }
         },
         "delete": function(key) {
@@ -95907,6 +98751,7 @@ var require_utils11 = __commonJS({
     "use strict";
     var formats = require_formats();
     var getSideChannel = require_side_channel();
+    var defineProperty = require_es_define_property();
     var has = Object.prototype.hasOwnProperty;
     var isArray = Array.isArray;
     var overflowChannel = getSideChannel();
@@ -95926,7 +98771,7 @@ var require_utils11 = __commonJS({
     var hexTable = (function() {
       var array = [];
       for (var i = 0; i < 256; ++i) {
-        array.push("%" + ((i < 16 ? "0" : "") + i.toString(16)).toUpperCase());
+        array[array.length] = "%" + ((i < 16 ? "0" : "") + i.toString(16)).toUpperCase();
       }
       return array;
     })();
@@ -95938,7 +98783,7 @@ var require_utils11 = __commonJS({
           var compacted = [];
           for (var j = 0; j < obj.length; ++j) {
             if (typeof obj[j] !== "undefined") {
-              compacted.push(obj[j]);
+              compacted[compacted.length] = obj[j];
             }
           }
           item.obj[item.prop] = compacted;
@@ -95954,18 +98799,39 @@ var require_utils11 = __commonJS({
       }
       return obj;
     };
+    var setProperty = function setProperty2(obj, key, value) {
+      if (key === "__proto__" && defineProperty) {
+        defineProperty(obj, key, {
+          configurable: true,
+          enumerable: true,
+          value,
+          writable: true
+        });
+      } else {
+        obj[key] = value;
+      }
+    };
     var merge = function merge2(target, source, options2) {
       if (!source) {
         return target;
       }
       if (typeof source !== "object" && typeof source !== "function") {
         if (isArray(target)) {
-          target.push(source);
+          var nextIndex = target.length;
+          if (options2 && typeof options2.arrayLimit === "number" && nextIndex >= options2.arrayLimit) {
+            if (options2.throwOnLimitExceeded) {
+              throw new RangeError("Array limit exceeded. Only " + options2.arrayLimit + " element" + (options2.arrayLimit === 1 ? "" : "s") + " allowed in an array.");
+            }
+            return markOverflow(arrayToObject(target.concat(source), options2), nextIndex);
+          }
+          target[nextIndex] = source;
         } else if (target && typeof target === "object") {
           if (isOverflow(target)) {
             var newIndex = getMaxIndex(target) + 1;
             target[newIndex] = source;
             setMaxIndex(target, newIndex);
+          } else if (options2 && options2.strictMerge) {
+            return [target, source];
           } else if (options2 && (options2.plainObjects || options2.allowPrototypes) || !has.call(Object.prototype, source)) {
             target[source] = true;
           }
@@ -95984,7 +98850,14 @@ var require_utils11 = __commonJS({
           }
           return markOverflow(result, getMaxIndex(source) + 1);
         }
-        return [target].concat(source);
+        var combined = [target].concat(source);
+        if (options2 && typeof options2.arrayLimit === "number" && combined.length > options2.arrayLimit) {
+          if (options2.throwOnLimitExceeded) {
+            throw new RangeError("Array limit exceeded. Only " + options2.arrayLimit + " element" + (options2.arrayLimit === 1 ? "" : "s") + " allowed in an array.");
+          }
+          return markOverflow(arrayToObject(combined, options2), combined.length - 1);
+        }
+        return combined;
       }
       var mergeTarget = target;
       if (isArray(target) && !isArray(source)) {
@@ -95997,27 +98870,42 @@ var require_utils11 = __commonJS({
             if (targetItem && typeof targetItem === "object" && item && typeof item === "object") {
               target[i] = merge2(targetItem, item, options2);
             } else {
-              target.push(item);
+              target[target.length] = item;
             }
           } else {
             target[i] = item;
           }
         });
+        if (options2 && typeof options2.arrayLimit === "number" && target.length > options2.arrayLimit) {
+          if (options2.throwOnLimitExceeded) {
+            throw new RangeError("Array limit exceeded. Only " + options2.arrayLimit + " element" + (options2.arrayLimit === 1 ? "" : "s") + " allowed in an array.");
+          }
+          return markOverflow(arrayToObject(target, options2), target.length - 1);
+        }
         return target;
       }
       return Object.keys(source).reduce(function(acc, key) {
         var value = source[key];
         if (has.call(acc, key)) {
-          acc[key] = merge2(acc[key], value, options2);
+          setProperty(acc, key, merge2(acc[key], value, options2));
         } else {
-          acc[key] = value;
+          setProperty(acc, key, value);
+        }
+        if (isOverflow(source) && !isOverflow(acc)) {
+          markOverflow(acc, getMaxIndex(source));
+        }
+        if (isOverflow(acc)) {
+          var keyNum = parseInt(key, 10);
+          if (String(keyNum) === key && keyNum >= 0 && keyNum > getMaxIndex(acc)) {
+            setMaxIndex(acc, keyNum);
+          }
         }
         return acc;
       }, mergeTarget);
     };
     var assign = function assignSingleSource(target, source) {
       return Object.keys(source).reduce(function(acc, key) {
-        acc[key] = source[key];
+        setProperty(acc, key, source[key]);
         return acc;
       }, target);
     };
@@ -96051,6 +98939,13 @@ var require_utils11 = __commonJS({
       var out = "";
       for (var j = 0; j < string.length; j += limit) {
         var segment = string.length >= limit ? string.slice(j, j + limit) : string;
+        if (j + limit < string.length) {
+          var last = segment.charCodeAt(segment.length - 1);
+          if (last >= 55296 && last <= 56319) {
+            segment = segment.slice(0, -1);
+            j -= 1;
+          }
+        }
         var arr = [];
         for (var i = 0; i < segment.length; ++i) {
           var c = segment.charCodeAt(i);
@@ -96080,7 +98975,7 @@ var require_utils11 = __commonJS({
     };
     var compact = function compact2(value) {
       var queue = [{ obj: { o: value }, prop: "o" }];
-      var refs = [];
+      var refs = getSideChannel();
       for (var i = 0; i < queue.length; ++i) {
         var item = queue[i];
         var obj = item.obj[item.prop];
@@ -96088,9 +98983,9 @@ var require_utils11 = __commonJS({
         for (var j = 0; j < keys.length; ++j) {
           var key = keys[j];
           var val = obj[key];
-          if (typeof val === "object" && val !== null && refs.indexOf(val) === -1) {
-            queue.push({ obj, prop: key });
-            refs.push(val);
+          if (typeof val === "object" && val !== null && !refs.has(val)) {
+            queue[queue.length] = { obj, prop: key };
+            refs.set(val, true);
           }
         }
       }
@@ -96106,8 +99001,11 @@ var require_utils11 = __commonJS({
       }
       return !!(obj.constructor && obj.constructor.isBuffer && obj.constructor.isBuffer(obj));
     };
-    var combine = function combine2(a, b, arrayLimit, plainObjects) {
+    var combine = function combine2(a, b, arrayLimit, plainObjects, throwOnLimitExceeded) {
       if (isOverflow(a)) {
+        if (throwOnLimitExceeded) {
+          throw new RangeError("Array limit exceeded. Only " + arrayLimit + " element" + (arrayLimit === 1 ? "" : "s") + " allowed in an array.");
+        }
         var newIndex = getMaxIndex(a) + 1;
         a[newIndex] = b;
         setMaxIndex(a, newIndex);
@@ -96115,6 +99013,9 @@ var require_utils11 = __commonJS({
       }
       var result = [].concat(a, b);
       if (result.length > arrayLimit) {
+        if (throwOnLimitExceeded) {
+          throw new RangeError("Array limit exceeded. Only " + arrayLimit + " element" + (arrayLimit === 1 ? "" : "s") + " allowed in an array.");
+        }
         return markOverflow(arrayToObject(result, { plainObjects }), result.length - 1);
       }
       return result;
@@ -96123,7 +99024,7 @@ var require_utils11 = __commonJS({
       if (isArray(val)) {
         var mapped = [];
         for (var i = 0; i < val.length; i += 1) {
-          mapped.push(fn(val[i]));
+          mapped[mapped.length] = fn(val[i]);
         }
         return mapped;
       }
@@ -96139,6 +99040,7 @@ var require_utils11 = __commonJS({
       isBuffer,
       isOverflow,
       isRegExp,
+      markOverflow,
       maybeMap,
       merge
     };
@@ -96233,7 +99135,7 @@ var require_stringify = __commonJS({
       }
       if (obj === null) {
         if (strictNullHandling) {
-          return encoder && !encodeValuesOnly ? encoder(prefix, defaults.encoder, charset, "key", format) : prefix;
+          return formatter(encoder && !encodeValuesOnly ? encoder(prefix, defaults.encoder, charset, "key", format) : prefix);
         }
         obj = "";
       }
@@ -96251,7 +99153,9 @@ var require_stringify = __commonJS({
       var objKeys;
       if (generateArrayPrefix === "comma" && isArray(obj)) {
         if (encodeValuesOnly && encoder) {
-          obj = utils.maybeMap(obj, encoder);
+          obj = utils.maybeMap(obj, function(v) {
+            return v == null ? v : encoder(v);
+          });
         }
         objKeys = [{ value: obj.length > 0 ? obj.join(",") || null : void 0 }];
       } else if (isArray(filter)) {
@@ -96389,6 +99293,9 @@ var require_stringify = __commonJS({
       var sideChannel = getSideChannel();
       for (var i = 0; i < objKeys.length; ++i) {
         var key = objKeys[i];
+        if (typeof key === "undefined" || key === null) {
+          continue;
+        }
         var value = obj[key];
         if (options2.skipNulls && value === null) {
           continue;
@@ -96418,9 +99325,9 @@ var require_stringify = __commonJS({
       var prefix = options2.addQueryPrefix === true ? "?" : "";
       if (options2.charsetSentinel) {
         if (options2.charset === "iso-8859-1") {
-          prefix += "utf8=%26%2310003%3B&";
+          prefix += "utf8=%26%2310003%3B" + options2.delimiter;
         } else {
-          prefix += "utf8=%E2%9C%93&";
+          prefix += "utf8=%E2%9C%93" + options2.delimiter;
         }
       }
       return joined.length > 0 ? prefix + joined : "";
@@ -96455,6 +99362,7 @@ var require_parse4 = __commonJS({
       parseArrays: true,
       plainObjects: false,
       strictDepth: false,
+      strictMerge: true,
       strictNullHandling: false,
       throwOnLimitExceeded: false
     };
@@ -96463,8 +99371,19 @@ var require_parse4 = __commonJS({
         return String.fromCharCode(parseInt(numberStr, 10));
       });
     };
-    var parseArrayValue = function(val, options2, currentArrayLength) {
+    var parseArrayValue = function(val, options2, currentArrayLength, isFlatArrayValue) {
       if (val && typeof val === "string" && options2.comma && val.indexOf(",") > -1) {
+        if (isFlatArrayValue && options2.throwOnLimitExceeded) {
+          var commaCount = 0;
+          var commaIndex = val.indexOf(",");
+          while (commaIndex > -1) {
+            commaCount += 1;
+            if (commaCount >= options2.arrayLimit) {
+              throw new RangeError("Array limit exceeded. Only " + options2.arrayLimit + " element" + (options2.arrayLimit === 1 ? "" : "s") + " allowed in an array.");
+            }
+            commaIndex = val.indexOf(",", commaIndex + 1);
+          }
+        }
         return val.split(",");
       }
       if (options2.throwOnLimitExceeded && currentArrayLength >= options2.arrayLimit) {
@@ -96481,9 +99400,9 @@ var require_parse4 = __commonJS({
       var limit = options2.parameterLimit === Infinity ? void 0 : options2.parameterLimit;
       var parts = cleanStr.split(
         options2.delimiter,
-        options2.throwOnLimitExceeded ? limit + 1 : limit
+        options2.throwOnLimitExceeded && typeof limit !== "undefined" ? limit + 1 : limit
       );
-      if (options2.throwOnLimitExceeded && parts.length > limit) {
+      if (options2.throwOnLimitExceeded && typeof limit !== "undefined" && parts.length > limit) {
         throw new RangeError("Parameter limit exceeded. Only " + limit + " parameter" + (limit === 1 ? "" : "s") + " allowed.");
       }
       var skipIndex = -1;
@@ -96521,7 +99440,8 @@ var require_parse4 = __commonJS({
               parseArrayValue(
                 part.slice(pos + 1),
                 options2,
-                isArray(obj[key]) ? obj[key].length : 0
+                isArray(obj[key]) ? obj[key].length : 0,
+                part.indexOf("[]=") === -1
               ),
               function(encodedVal) {
                 return options2.decoder(encodedVal, defaults.decoder, charset, "value");
@@ -96535,14 +99455,18 @@ var require_parse4 = __commonJS({
         if (part.indexOf("[]=") > -1) {
           val = isArray(val) ? [val] : val;
         }
+        if (options2.comma && isArray(val) && val.length > options2.arrayLimit) {
+          val = utils.combine([], val, options2.arrayLimit, options2.plainObjects, options2.throwOnLimitExceeded);
+        }
         if (key !== null) {
           var existing = has.call(obj, key);
-          if (existing && options2.duplicates === "combine") {
+          if (existing && (options2.duplicates === "combine" || part.indexOf("[]=") > -1)) {
             obj[key] = utils.combine(
               obj[key],
               val,
               options2.arrayLimit,
-              options2.plainObjects
+              options2.plainObjects,
+              options2.throwOnLimitExceeded
             );
           } else if (!existing || options2.duplicates === "last") {
             obj[key] = val;
@@ -96569,7 +99493,8 @@ var require_parse4 = __commonJS({
               [],
               leaf,
               options2.arrayLimit,
-              options2.plainObjects
+              options2.plainObjects,
+              options2.throwOnLimitExceeded
             );
           }
         } else {
@@ -96577,11 +99502,17 @@ var require_parse4 = __commonJS({
           var cleanRoot = root.charAt(0) === "[" && root.charAt(root.length - 1) === "]" ? root.slice(1, -1) : root;
           var decodedRoot = options2.decodeDotInKeys ? cleanRoot.replace(/%2E/g, ".") : cleanRoot;
           var index = parseInt(decodedRoot, 10);
+          var isValidArrayIndex = !isNaN(index) && root !== decodedRoot && String(index) === decodedRoot && index >= 0 && options2.parseArrays;
           if (!options2.parseArrays && decodedRoot === "") {
             obj = { 0: leaf };
-          } else if (!isNaN(index) && root !== decodedRoot && String(index) === decodedRoot && index >= 0 && (options2.parseArrays && index <= options2.arrayLimit)) {
+          } else if (isValidArrayIndex && index < options2.arrayLimit) {
             obj = [];
             obj[index] = leaf;
+          } else if (isValidArrayIndex && options2.throwOnLimitExceeded) {
+            throw new RangeError("Array limit exceeded. Only " + options2.arrayLimit + " element" + (options2.arrayLimit === 1 ? "" : "s") + " allowed in an array.");
+          } else if (isValidArrayIndex) {
+            obj[index] = leaf;
+            utils.markOverflow(obj, index);
           } else if (decodedRoot !== "__proto__") {
             obj[decodedRoot] = leaf;
           }
@@ -96590,8 +99521,8 @@ var require_parse4 = __commonJS({
       }
       return leaf;
     };
-    var splitKeyIntoSegments = function splitKeyIntoSegments2(givenKey, options2) {
-      var key = options2.allowDots ? givenKey.replace(/\.([^.[]+)/g, "[$1]") : givenKey;
+    var splitKeyIntoSegments = function splitKeyIntoSegments2(originalKey, options2) {
+      var key = options2.allowDots ? originalKey.replace(/\.([^.[]+)/g, "[$1]") : originalKey;
       if (options2.depth <= 0) {
         if (!options2.plainObjects && has.call(Object.prototype, key)) {
           if (!options2.allowPrototypes) {
@@ -96600,37 +99531,56 @@ var require_parse4 = __commonJS({
         }
         return [key];
       }
-      var brackets = /(\[[^[\]]*])/;
-      var child = /(\[[^[\]]*])/g;
-      var segment = brackets.exec(key);
-      var parent = segment ? key.slice(0, segment.index) : key;
-      var keys = [];
+      var segments = [];
+      var first = key.indexOf("[");
+      var parent = first >= 0 ? key.slice(0, first) : key;
       if (parent) {
         if (!options2.plainObjects && has.call(Object.prototype, parent)) {
           if (!options2.allowPrototypes) {
             return;
           }
         }
-        keys.push(parent);
+        segments[segments.length] = parent;
       }
-      var i = 0;
-      while ((segment = child.exec(key)) !== null && i < options2.depth) {
-        i += 1;
-        var segmentContent = segment[1].slice(1, -1);
-        if (!options2.plainObjects && has.call(Object.prototype, segmentContent)) {
-          if (!options2.allowPrototypes) {
-            return;
+      var n = key.length;
+      var open = first;
+      var collected = 0;
+      while (open >= 0 && collected < options2.depth) {
+        var level = 1;
+        var i = open + 1;
+        var close = -1;
+        while (i < n && close < 0) {
+          var cu = key.charCodeAt(i);
+          if (cu === 91) {
+            level += 1;
+          } else if (cu === 93) {
+            level -= 1;
+            if (level === 0) {
+              close = i;
+            }
           }
+          i += 1;
         }
-        keys.push(segment[1]);
+        if (close < 0) {
+          segments[segments.length] = "[" + key.slice(open) + "]";
+          return segments;
+        }
+        var seg = key.slice(open, close + 1);
+        var content = seg.slice(1, -1);
+        if (!options2.plainObjects && has.call(Object.prototype, content) && !options2.allowPrototypes) {
+          return;
+        }
+        segments[segments.length] = seg;
+        collected += 1;
+        open = key.indexOf("[", close + 1);
       }
-      if (segment) {
+      if (open >= 0) {
         if (options2.strictDepth === true) {
           throw new RangeError("Input depth exceeded depth option of " + options2.depth + " and strictDepth is true");
         }
-        keys.push("[" + key.slice(segment.index) + "]");
+        segments[segments.length] = "[" + key.slice(open) + "]";
       }
-      return keys;
+      return segments;
     };
     var parseKeys = function parseQueryStringKeys(givenKey, val, options2, valuesParsed) {
       if (!givenKey) {
@@ -96688,6 +99638,7 @@ var require_parse4 = __commonJS({
         parseArrays: opts.parseArrays !== false,
         plainObjects: typeof opts.plainObjects === "boolean" ? opts.plainObjects : defaults.plainObjects,
         strictDepth: typeof opts.strictDepth === "boolean" ? !!opts.strictDepth : defaults.strictDepth,
+        strictMerge: typeof opts.strictMerge === "boolean" ? !!opts.strictMerge : defaults.strictMerge,
         strictNullHandling: typeof opts.strictNullHandling === "boolean" ? opts.strictNullHandling : defaults.strictNullHandling,
         throwOnLimitExceeded: typeof opts.throwOnLimitExceeded === "boolean" ? opts.throwOnLimitExceeded : false
       };
@@ -96846,14 +99797,14 @@ var require_urlencoded2 = __commonJS({
     }
     function parameterCount(body, limit) {
       var count = 0;
-      var index = 0;
-      while ((index = body.indexOf("&", index)) !== -1) {
+      var index = -1;
+      do {
         count++;
-        index++;
-        if (count === limit) {
+        if (count > limit) {
           return void 0;
         }
-      }
+        index = body.indexOf("&", index + 1);
+      } while (index !== -1);
       return count;
     }
     function parser2(name) {
@@ -98245,6 +101196,7 @@ var require_path_to_regexp = __commonJS({
           }
           pos = offset + match.length;
           if (match === "*") {
+            backtrack = "";
             extraOffset += 3;
             return "(.*)";
           }
@@ -98265,6 +101217,7 @@ var require_path_to_regexp = __commonJS({
             offset: offset + extraOffset
           });
           var result = "(?:" + format + slash + capture + (star ? "((?:[/" + format + "].+?)?)" : "") + ")" + optional;
+          backtrack = "";
           extraOffset += result.length - match.length;
           return result;
         }
@@ -101413,7 +104366,8 @@ var require_utils12 = __commonJS({
     }
     function parseExtendedQueryString(str) {
       return qs.parse(str, {
-        allowPrototypes: true
+        allowPrototypes: true,
+        arrayLimit: 1e3
       });
     }
     function newObject() {
@@ -105123,7 +108077,7 @@ var require_helpers = __commonJS({
       if (instance.helpers[helperName]) {
         instance.hooks[helperName] = instance.helpers[helperName];
         if (!keepHelper) {
-          delete instance.helpers[helperName];
+          instance.helpers[helperName] = void 0;
         }
       }
     }
@@ -105215,22 +108169,6 @@ var require_logger3 = __commonJS({
   }
 });
 
-// node_modules/handlebars/dist/cjs/handlebars/internal/create-new-lookup-object.js
-var require_create_new_lookup_object = __commonJS({
-  "node_modules/handlebars/dist/cjs/handlebars/internal/create-new-lookup-object.js"(exports2) {
-    "use strict";
-    exports2.__esModule = true;
-    exports2.createNewLookupObject = createNewLookupObject;
-    var _utils = require_utils13();
-    function createNewLookupObject() {
-      for (var _len = arguments.length, sources = Array(_len), _key = 0; _key < _len; _key++) {
-        sources[_key] = arguments[_key];
-      }
-      return _utils.extend.apply(void 0, [/* @__PURE__ */ Object.create(null)].concat(sources));
-    }
-  }
-});
-
 // node_modules/handlebars/dist/cjs/handlebars/internal/proto-access.js
 var require_proto_access = __commonJS({
   "node_modules/handlebars/dist/cjs/handlebars/internal/proto-access.js"(exports2) {
@@ -105242,25 +108180,28 @@ var require_proto_access = __commonJS({
     function _interopRequireDefault(obj) {
       return obj && obj.__esModule ? obj : { "default": obj };
     }
-    var _createNewLookupObject = require_create_new_lookup_object();
+    var _utils = require_utils13();
     var _logger = require_logger3();
     var _logger2 = _interopRequireDefault(_logger);
     var loggedProperties = /* @__PURE__ */ Object.create(null);
     function createProtoAccessControl(runtimeOptions) {
-      var defaultMethodWhiteList = /* @__PURE__ */ Object.create(null);
-      defaultMethodWhiteList["constructor"] = false;
-      defaultMethodWhiteList["__defineGetter__"] = false;
-      defaultMethodWhiteList["__defineSetter__"] = false;
-      defaultMethodWhiteList["__lookupGetter__"] = false;
-      var defaultPropertyWhiteList = /* @__PURE__ */ Object.create(null);
-      defaultPropertyWhiteList["__proto__"] = false;
+      var propertyWhiteList = /* @__PURE__ */ Object.create(null);
+      propertyWhiteList["__proto__"] = false;
+      _utils.extend(propertyWhiteList, runtimeOptions.allowedProtoProperties);
+      var methodWhiteList = /* @__PURE__ */ Object.create(null);
+      methodWhiteList["constructor"] = false;
+      methodWhiteList["__defineGetter__"] = false;
+      methodWhiteList["__defineSetter__"] = false;
+      methodWhiteList["__lookupGetter__"] = false;
+      methodWhiteList["__lookupSetter__"] = false;
+      _utils.extend(methodWhiteList, runtimeOptions.allowedProtoMethods);
       return {
         properties: {
-          whitelist: _createNewLookupObject.createNewLookupObject(defaultPropertyWhiteList, runtimeOptions.allowedProtoProperties),
+          whitelist: propertyWhiteList,
           defaultValue: runtimeOptions.allowProtoPropertiesByDefault
         },
         methods: {
-          whitelist: _createNewLookupObject.createNewLookupObject(defaultMethodWhiteList, runtimeOptions.allowedProtoMethods),
+          whitelist: methodWhiteList,
           defaultValue: runtimeOptions.allowProtoMethodsByDefault
         }
       };
@@ -105313,7 +108254,7 @@ var require_base3 = __commonJS({
     var _logger = require_logger3();
     var _logger2 = _interopRequireDefault(_logger);
     var _internalProtoAccess = require_proto_access();
-    var VERSION = "4.7.8";
+    var VERSION = "4.7.9";
     exports2.VERSION = VERSION;
     var COMPILER_REVISION = 8;
     exports2.COMPILER_REVISION = COMPILER_REVISION;
@@ -105499,14 +108440,12 @@ var require_runtime = __commonJS({
           }
         }
         partial = env.VM.resolvePartial.call(this, partial, context, options2);
-        var extendedOptions = Utils.extend({}, options2, {
-          hooks: this.hooks,
-          protoAccessControl: this.protoAccessControl
-        });
-        var result = env.VM.invokePartial.call(this, partial, context, extendedOptions);
+        options2.hooks = this.hooks;
+        options2.protoAccessControl = this.protoAccessControl;
+        var result = env.VM.invokePartial.call(this, partial, context, options2);
         if (result == null && env.compile) {
           options2.partials[options2.name] = env.compile(partial, templateSpec.compilerOptions, env);
-          result = options2.partials[options2.name](context, extendedOptions);
+          result = options2.partials[options2.name](context, options2);
         }
         if (result != null) {
           if (options2.indent) {
@@ -105551,7 +108490,7 @@ var require_runtime = __commonJS({
           for (var i = 0; i < len; i++) {
             var result = depths[i] && container.lookupProperty(depths[i], name);
             if (result != null) {
-              return depths[i][name];
+              return result;
             }
           }
         },
@@ -105617,8 +108556,9 @@ var require_runtime = __commonJS({
       ret.isTop = true;
       ret._setup = function(options2) {
         if (!options2.partial) {
-          var mergedHelpers = Utils.extend({}, env.helpers, options2.helpers);
-          wrapHelpersToPassLookupProperty(mergedHelpers, container);
+          var mergedHelpers = {};
+          addHelpers(mergedHelpers, env.helpers, container);
+          addHelpers(mergedHelpers, options2.helpers, container);
           container.helpers = mergedHelpers;
           if (templateSpec.usePartial) {
             container.partials = container.mergeIfNeeded(options2.partials, env.partials);
@@ -105668,18 +108608,18 @@ var require_runtime = __commonJS({
     function resolvePartial(partial, context, options2) {
       if (!partial) {
         if (options2.name === "@partial-block") {
-          partial = options2.data["partial-block"];
+          partial = lookupOwnProperty(options2.data, "partial-block");
         } else {
-          partial = options2.partials[options2.name];
+          partial = lookupOwnProperty(options2.partials, options2.name);
         }
       } else if (!partial.call && !options2.name) {
         options2.name = partial;
-        partial = options2.partials[partial];
+        partial = lookupOwnProperty(options2.partials, partial);
       }
       return partial;
     }
     function invokePartial(partial, context, options2) {
-      var currentPartialBlock = options2.data && options2.data["partial-block"];
+      var currentPartialBlock = lookupOwnProperty(options2.data, "partial-block");
       options2.partial = true;
       if (options2.ids) {
         options2.data.contextPath = options2.ids[0] || options2.data.contextPath;
@@ -105712,6 +108652,11 @@ var require_runtime = __commonJS({
     function noop() {
       return "";
     }
+    function lookupOwnProperty(obj, name) {
+      if (obj && Object.prototype.hasOwnProperty.call(obj, name)) {
+        return obj[name];
+      }
+    }
     function initData(context, data) {
       if (!data || !("root" in data)) {
         data = data ? _base.createFrame(data) : {};
@@ -105727,16 +108672,18 @@ var require_runtime = __commonJS({
       }
       return prog;
     }
-    function wrapHelpersToPassLookupProperty(mergedHelpers, container) {
-      Object.keys(mergedHelpers).forEach(function(helperName) {
-        var helper = mergedHelpers[helperName];
+    function addHelpers(mergedHelpers, helpers, container) {
+      if (!helpers) return;
+      Object.keys(helpers).forEach(function(helperName) {
+        var helper = helpers[helperName];
         mergedHelpers[helperName] = passLookupPropertyOption(helper, container);
       });
     }
     function passLookupPropertyOption(helper, container) {
       var lookupProperty = container.lookupProperty;
       return _internalWrapHelper.wrapHelper(helper, function(options2) {
-        return Utils.extend({ lookupProperty }, options2);
+        options2.lookupProperty = lookupProperty;
+        return options2;
       });
     }
   }
@@ -106546,7 +109493,7 @@ var require_parser3 = __commonJS({
               break;
           }
         };
-        lexer2.rules = [/^(?:[^\x00]*?(?=(\{\{)))/, /^(?:[^\x00]+)/, /^(?:[^\x00]{2,}?(?=(\{\{|\\\{\{|\\\\\{\{|$)))/, /^(?:\{\{\{\{(?=[^/]))/, /^(?:\{\{\{\{\/[^\s!"#%-,\.\/;->@\[-\^`\{-~]+(?=[=}\s\/.])\}\}\}\})/, /^(?:[^\x00]+?(?=(\{\{\{\{)))/, /^(?:[\s\S]*?--(~)?\}\})/, /^(?:\()/, /^(?:\))/, /^(?:\{\{\{\{)/, /^(?:\}\}\}\})/, /^(?:\{\{(~)?>)/, /^(?:\{\{(~)?#>)/, /^(?:\{\{(~)?#\*?)/, /^(?:\{\{(~)?\/)/, /^(?:\{\{(~)?\^\s*(~)?\}\})/, /^(?:\{\{(~)?\s*else\s*(~)?\}\})/, /^(?:\{\{(~)?\^)/, /^(?:\{\{(~)?\s*else\b)/, /^(?:\{\{(~)?\{)/, /^(?:\{\{(~)?&)/, /^(?:\{\{(~)?!--)/, /^(?:\{\{(~)?![\s\S]*?\}\})/, /^(?:\{\{(~)?\*?)/, /^(?:=)/, /^(?:\.\.)/, /^(?:\.(?=([=~}\s\/.)|])))/, /^(?:[\/.])/, /^(?:\s+)/, /^(?:\}(~)?\}\})/, /^(?:(~)?\}\})/, /^(?:"(\\["]|[^"])*")/, /^(?:'(\\[']|[^'])*')/, /^(?:@)/, /^(?:true(?=([~}\s)])))/, /^(?:false(?=([~}\s)])))/, /^(?:undefined(?=([~}\s)])))/, /^(?:null(?=([~}\s)])))/, /^(?:-?[0-9]+(?:\.[0-9]+)?(?=([~}\s)])))/, /^(?:as\s+\|)/, /^(?:\|)/, /^(?:([^\s!"#%-,\.\/;->@\[-\^`\{-~]+(?=([=~}\s\/.)|]))))/, /^(?:\[(\\\]|[^\]])*\])/, /^(?:.)/, /^(?:$)/];
+        lexer2.rules = [/^(?:[^\x00]*?(?=(\{\{)))/, /^(?:[^\x00]+)/, /^(?:[^\x00]{2,}?(?=(\{\{|\\\{\{|\\\\\{\{|$)))/, /^(?:\{\{\{\{(?=[^\/]))/, /^(?:\{\{\{\{\/[^\s!"#%-,\.\/;->@\[-\^`\{-~]+(?=[=}\s\/.])\}\}\}\})/, /^(?:[^\x00]+?(?=(\{\{\{\{)))/, /^(?:[\s\S]*?--(~)?\}\})/, /^(?:\()/, /^(?:\))/, /^(?:\{\{\{\{)/, /^(?:\}\}\}\})/, /^(?:\{\{(~)?>)/, /^(?:\{\{(~)?#>)/, /^(?:\{\{(~)?#\*?)/, /^(?:\{\{(~)?\/)/, /^(?:\{\{(~)?\^\s*(~)?\}\})/, /^(?:\{\{(~)?\s*else\s*(~)?\}\})/, /^(?:\{\{(~)?\^)/, /^(?:\{\{(~)?\s*else\b)/, /^(?:\{\{(~)?\{)/, /^(?:\{\{(~)?&)/, /^(?:\{\{(~)?!--)/, /^(?:\{\{(~)?![\s\S]*?\}\})/, /^(?:\{\{(~)?\*?)/, /^(?:=)/, /^(?:\.\.)/, /^(?:\.(?=([=~}\s\/.)|])))/, /^(?:[\/.])/, /^(?:\s+)/, /^(?:\}(~)?\}\})/, /^(?:(~)?\}\})/, /^(?:"(\\["]|[^"])*")/, /^(?:'(\\[']|[^'])*')/, /^(?:@)/, /^(?:true(?=([~}\s)])))/, /^(?:false(?=([~}\s)])))/, /^(?:undefined(?=([~}\s)])))/, /^(?:null(?=([~}\s)])))/, /^(?:-?[0-9]+(?:\.[0-9]+)?(?=([~}\s)])))/, /^(?:as\s+\|)/, /^(?:\|)/, /^(?:([^\s!"#%-,\.\/;->@\[-\^`\{-~]+(?=([=~}\s\/.)|]))))/, /^(?:\[(\\\]|[^\]])*\])/, /^(?:.)/, /^(?:$)/];
         lexer2.conditions = { "mu": { "rules": [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44], "inclusive": false }, "emu": { "rules": [2], "inclusive": false }, "com": { "rules": [6], "inclusive": false }, "raw": { "rules": [3, 4, 5], "inclusive": false }, "INITIAL": { "rules": [0, 1, 44], "inclusive": true } };
         return lexer2;
       })();
@@ -107053,12 +110000,15 @@ var require_base4 = __commonJS({
     var _whitespaceControl2 = _interopRequireDefault(_whitespaceControl);
     var _helpers = require_helpers2();
     var Helpers = _interopRequireWildcard(_helpers);
+    var _exception = require_exception2();
+    var _exception2 = _interopRequireDefault(_exception);
     var _utils = require_utils13();
     exports2.parser = _parser2["default"];
     var yy = {};
     _utils.extend(yy, Helpers);
     function parseWithoutProcessing(input, options2) {
       if (input.type === "Program") {
+        validateInputAst(input);
         return input;
       }
       _parser2["default"].yy = yy;
@@ -107072,6 +110022,51 @@ var require_base4 = __commonJS({
       var ast = parseWithoutProcessing(input, options2);
       var strip = new _whitespaceControl2["default"](options2);
       return strip.accept(ast);
+    }
+    function validateInputAst(ast) {
+      validateAstNode(ast);
+    }
+    function validateAstNode(node) {
+      if (node == null) {
+        return;
+      }
+      if (Array.isArray(node)) {
+        node.forEach(validateAstNode);
+        return;
+      }
+      if (typeof node !== "object") {
+        return;
+      }
+      if (node.type === "PathExpression") {
+        if (!isValidDepth(node.depth)) {
+          throw new _exception2["default"]("Invalid AST: PathExpression.depth must be an integer");
+        }
+        if (!Array.isArray(node.parts)) {
+          throw new _exception2["default"]("Invalid AST: PathExpression.parts must be an array");
+        }
+        for (var i = 0; i < node.parts.length; i++) {
+          if (typeof node.parts[i] !== "string") {
+            throw new _exception2["default"]("Invalid AST: PathExpression.parts must only contain strings");
+          }
+        }
+      } else if (node.type === "NumberLiteral") {
+        if (typeof node.value !== "number" || !isFinite(node.value)) {
+          throw new _exception2["default"]("Invalid AST: NumberLiteral.value must be a number");
+        }
+      } else if (node.type === "BooleanLiteral") {
+        if (typeof node.value !== "boolean") {
+          throw new _exception2["default"]("Invalid AST: BooleanLiteral.value must be a boolean");
+        }
+      }
+      Object.keys(node).forEach(function(propertyName) {
+        if (propertyName === "loc") {
+          return;
+        }
+        validateAstNode(node[propertyName]);
+      });
+    }
+    function isValidDepth(depth) {
+      return typeof depth === "number" && isFinite(depth) && Math.floor(depth) === depth && depth >= 0;
     }
   }
 });
@@ -109501,12 +112496,10 @@ var require_javascript_compiler = __commonJS({
           var programs = _context.programs;
           var decorators = _context.decorators;
           for (i = 0, l = programs.length; i < l; i++) {
-            if (programs[i]) {
-              ret[i] = programs[i];
-              if (decorators[i]) {
-                ret[i + "_d"] = decorators[i];
-                ret.useDecorators = true;
-              }
+            ret[i] = programs[i];
+            if (decorators[i]) {
+              ret[i + "_d"] = decorators[i];
+              ret.useDecorators = true;
             }
           }
           if (this.environment.usePartial) {
@@ -109767,22 +112760,25 @@ var require_javascript_compiler = __commonJS({
         }
         this.resolvePath("data", parts, 0, true, strict);
       },
-      resolvePath: function resolvePath(type, parts, i, falsy, strict) {
+      resolvePath: function resolvePath(type, parts, startPartIndex, falsy, strict) {
         var _this2 = this;
         if (this.options.strict || this.options.assumeObjects) {
-          this.push(strictLookup(this.options.strict && strict, this, parts, i, type));
+          this.push(strictLookup(this.options.strict && strict, this, parts, startPartIndex, type));
           return;
         }
         var len = parts.length;
-        for (; i < len; i++) {
-          this.replaceStack(function(current) {
-            var lookup = _this2.nameLookup(current, parts[i], type);
+        var _loop = function(i2) {
+          _this2.replaceStack(function(current) {
+            var lookup = _this2.nameLookup(current, parts[i2], type);
             if (!falsy) {
               return [" != null ? ", lookup, " : ", current];
             } else {
               return [" && ", lookup];
             }
           });
+        };
+        for (var i = startPartIndex; i < len; i++) {
+          _loop(i);
         }
       },
       // [resolvePossibleLambda]
@@ -109886,7 +112882,9 @@ var require_javascript_compiler = __commonJS({
       // and inserts the decorator into the decorators list.
       registerDecorator: function registerDecorator(paramSize, name) {
         var foundDecorator = this.nameLookup("decorators", name, "decorator"), options2 = this.setupHelperArgs(name, paramSize);
-        this.decorators.push(["fn = ", this.decorators.functionCall(foundDecorator, "", ["fn", "props", "container", options2]), " || fn;"]);
+        this.decorators.push(["var decorator = ", foundDecorator, ";"]);
+        this.decorators.push(['if (typeof decorator !== "function") { throw new Error(', this.quotedString('Missing decorator: "' + name + '"'), "); }"]);
+        this.decorators.push(["fn = ", this.decorators.functionCall("decorator", "", ["fn", "props", "container", options2]), " || fn;"]);
       },
       // [invokeHelper]
       //
@@ -110033,8 +113031,7 @@ var require_javascript_compiler = __commonJS({
           compiler = new this.compiler();
           var existing = this.matchExistingProgram(child);
           if (existing == null) {
-            this.context.programs.push("");
-            var index = this.context.programs.length;
+            var index = this.context.programs.push("") - 1;
             child.index = index;
             child.name = "program" + index;
             this.context.programs[index] = compiler.compile(child, options2, this.context, !this.precompile);
@@ -110278,16 +113275,16 @@ var require_javascript_compiler = __commonJS({
     JavaScriptCompiler.isValidJavaScriptVariableName = function(name) {
       return !JavaScriptCompiler.RESERVED_WORDS[name] && /^[a-zA-Z_$][0-9a-zA-Z_$]*$/.test(name);
     };
-    function strictLookup(requireTerminal, compiler, parts, i, type) {
+    function strictLookup(requireTerminal, compiler, parts, startPartIndex, type) {
       var stack = compiler.popStack(), len = parts.length;
       if (requireTerminal) {
         len--;
       }
-      for (; i < len; i++) {
+      for (var i = startPartIndex; i < len; i++) {
         stack = compiler.nameLookup(stack, parts[i], type);
       }
       if (requireTerminal) {
-        return [compiler.aliasable("container.strict"), "(", stack, ", ", compiler.quotedString(parts[i]), ", ", JSON.stringify(compiler.source.currentLocation), " )"];
+        return [compiler.aliasable("container.strict"), "(", stack, ", ", compiler.quotedString(parts[len]), ", ", JSON.stringify(compiler.source.currentLocation), " )"];
       } else {
         return stack;
       }
@@ -111612,9 +114609,9 @@ var require_balanced_match = __commonJS({
   }
 });
 
-// node_modules/brace-expansion/index.js
+// node_modules/express-handlebars/node_modules/brace-expansion/index.js
 var require_brace_expansion = __commonJS({
-  "node_modules/brace-expansion/index.js"(exports2, module2) {
+  "node_modules/express-handlebars/node_modules/brace-expansion/index.js"(exports2, module2) {
     var balanced = require_balanced_match();
     module2.exports = expandTop;
     var escSlash = "\0SLASH" + Math.random() + "\0";
@@ -111651,13 +114648,15 @@ var require_brace_expansion = __commonJS({
       parts.push.apply(parts, p);
       return parts;
     }
-    function expandTop(str) {
+    function expandTop(str, options2) {
       if (!str)
         return [];
+      options2 = options2 || {};
+      var max = options2.max == null ? Infinity : options2.max;
       if (str.substr(0, 2) === "{}") {
         str = "\\{\\}" + str.substr(2);
       }
-      return expand(escapeBraces(str), true).map(unescapeBraces);
+      return expand(escapeBraces(str), max, true).map(unescapeBraces);
     }
     function embrace(str) {
       return "{" + str + "}";
@@ -111671,14 +114670,14 @@ var require_brace_expansion = __commonJS({
     function gte(i, y) {
       return i >= y;
     }
-    function expand(str, isTop) {
+    function expand(str, max, isTop) {
       var expansions = [];
       var m = balanced("{", "}", str);
       if (!m) return [str];
       var pre = m.pre;
-      var post = m.post.length ? expand(m.post, false) : [""];
+      var post = m.post.length ? expand(m.post, max, false) : [""];
       if (/\$$/.test(m.pre)) {
-        for (var k = 0; k < post.length; k++) {
+        for (var k = 0; k < post.length && k < max; k++) {
           var expansion = pre + "{" + m.body + "}" + post[k];
           expansions.push(expansion);
         }
@@ -111690,7 +114689,7 @@ var require_brace_expansion = __commonJS({
         if (!isSequence && !isOptions) {
           if (m.post.match(/,(?!,).*\}/)) {
             str = m.pre + "{" + m.body + escClose + m.post;
-            return expand(str);
+            return expand(str, max, true);
           }
           return [str];
         }
@@ -111700,7 +114699,7 @@ var require_brace_expansion = __commonJS({
         } else {
           n = parseCommaParts(m.body);
           if (n.length === 1) {
-            n = expand(n[0], false).map(embrace);
+            n = expand(n[0], max, false).map(embrace);
             if (n.length === 1) {
               return post.map(function(p) {
                 return m.pre + n[0] + p;
@@ -111713,7 +114712,7 @@ var require_brace_expansion = __commonJS({
           var x = numeric(n[0]);
           var y = numeric(n[1]);
           var width = Math.max(n[0].length, n[1].length);
-          var incr = n.length == 3 ? Math.abs(numeric(n[2])) : 1;
+          var incr = n.length == 3 ? Math.max(Math.abs(numeric(n[2])), 1) : 1;
           var test = lte;
           var reverse = y < x;
           if (reverse) {
@@ -111722,7 +114721,7 @@ var require_brace_expansion = __commonJS({
           }
           var pad = n.some(isPadded);
           N = [];
-          for (var i = x; test(i, y); i += incr) {
+          for (var i = x; test(i, y) && N.length < max; i += incr) {
             var c;
             if (isAlphaSequence) {
               c = String.fromCharCode(i);
@@ -111746,11 +114745,11 @@ var require_brace_expansion = __commonJS({
         } else {
           N = [];
           for (var j = 0; j < n.length; j++) {
-            N.push.apply(N, expand(n[j], false));
+            N.push.apply(N, expand(n[j], max, false));
           }
         }
         for (var j = 0; j < N.length; j++) {
-          for (var k = 0; k < post.length; k++) {
+          for (var k = 0; k < post.length && expansions.length < max; k++) {
             var expansion = pre + N[j] + post[k];
             if (!isTop || isSequence || expansion)
               expansions.push(expansion);
@@ -111858,6 +114857,7 @@ var require_minimatch = __commonJS({
         assertValidPattern(pattern);
         if (!options2) options2 = {};
         this.options = options2;
+        this.maxGlobstarRecursion = options2.maxGlobstarRecursion !== void 0 ? options2.maxGlobstarRecursion : 200;
         this.set = [];
         this.pattern = pattern;
         this.windowsPathsNoEscape = !!options2.windowsPathsNoEscape || options2.allowWindowsEscape === false;
@@ -111914,51 +114914,146 @@ var require_minimatch = __commonJS({
       // out of pattern, then that's fine, as long as all
       // the parts match.
       matchOne(file, pattern, partial) {
-        var options2 = this.options;
-        this.debug(
-          "matchOne",
-          { "this": this, file, pattern }
-        );
-        this.debug("matchOne", file.length, pattern.length);
-        for (var fi = 0, pi = 0, fl = file.length, pl = pattern.length; fi < fl && pi < pl; fi++, pi++) {
-          this.debug("matchOne loop");
-          var p = pattern[pi];
-          var f = file[fi];
-          this.debug(pattern, p, f);
-          if (p === false) return false;
-          if (p === GLOBSTAR) {
-            this.debug("GLOBSTAR", [pattern, p, f]);
-            var fr = fi;
-            var pr = pi + 1;
-            if (pr === pl) {
-              this.debug("** at the end");
-              for (; fi < fl; fi++) {
-                if (file[fi] === "." || file[fi] === ".." || !options2.dot && file[fi].charAt(0) === ".") return false;
-              }
-              return true;
-            }
-            while (fr < fl) {
-              var swallowee = file[fr];
-              this.debug("\nglobstar while", file, fr, pattern, pr, swallowee);
-              if (this.matchOne(file.slice(fr), pattern.slice(pr), partial)) {
-                this.debug("globstar found match!", fr, fl, swallowee);
-                return true;
-              } else {
-                if (swallowee === "." || swallowee === ".." || !options2.dot && swallowee.charAt(0) === ".") {
-                  this.debug("dot detected!", file, fr, pattern, pr);
-                  break;
-                }
-                this.debug("globstar swallow a segment, and continue");
-                fr++;
-              }
-            }
-            if (partial) {
-              this.debug("\n>>> no match, partial?", file, fr, pattern, pr);
-              if (fr === fl) return true;
-            }
+        if (pattern.indexOf(GLOBSTAR) !== -1) {
+          return this._matchGlobstar(file, pattern, partial, 0, 0);
+        }
+        return this._matchOne(file, pattern, partial, 0, 0);
+      }
+      _matchGlobstar(file, pattern, partial, fileIndex, patternIndex) {
+        let firstgs = -1;
+        for (let i = patternIndex; i < pattern.length; i++) {
+          if (pattern[i] === GLOBSTAR) {
+            firstgs = i;
+            break;
+          }
+        }
+        let lastgs = -1;
+        for (let i = pattern.length - 1; i >= 0; i--) {
+          if (pattern[i] === GLOBSTAR) {
+            lastgs = i;
+            break;
+          }
+        }
+        const head = pattern.slice(patternIndex, firstgs);
+        const body = partial ? pattern.slice(firstgs + 1) : pattern.slice(firstgs + 1, lastgs);
+        const tail = partial ? [] : pattern.slice(lastgs + 1);
+        if (head.length) {
+          const fileHead = file.slice(fileIndex, fileIndex + head.length);
+          if (!this._matchOne(fileHead, head, partial, 0, 0)) {
             return false;
           }
-          var hit;
+          fileIndex += head.length;
+        }
+        let fileTailMatch = 0;
+        if (tail.length) {
+          if (tail.length + fileIndex > file.length) return false;
+          const tailStart = file.length - tail.length;
+          if (this._matchOne(file, tail, partial, tailStart, 0)) {
+            fileTailMatch = tail.length;
+          } else {
+            if (file[file.length - 1] !== "" || fileIndex + tail.length === file.length) {
+              return false;
+            }
+            if (!this._matchOne(file, tail, partial, tailStart - 1, 0)) {
+              return false;
+            }
+            fileTailMatch = tail.length + 1;
+          }
+        }
+        if (!body.length) {
+          let sawSome = !!fileTailMatch;
+          for (let i = fileIndex; i < file.length - fileTailMatch; i++) {
+            const f = String(file[i]);
+            sawSome = true;
+            if (f === "." || f === ".." || !this.options.dot && f.charAt(0) === ".") {
+              return false;
+            }
+          }
+          return partial || sawSome;
+        }
+        const bodySegments = [[[], 0]];
+        let currentBody = bodySegments[0];
+        let nonGsParts = 0;
+        const nonGsPartsSums = [0];
+        for (const b of body) {
+          if (b === GLOBSTAR) {
+            nonGsPartsSums.push(nonGsParts);
+            currentBody = [[], 0];
+            bodySegments.push(currentBody);
+          } else {
+            currentBody[0].push(b);
+            nonGsParts++;
+          }
+        }
+        let idx = bodySegments.length - 1;
+        const fileLength = file.length - fileTailMatch;
+        for (const b of bodySegments) {
+          b[1] = fileLength - (nonGsPartsSums[idx--] + b[0].length);
+        }
+        return !!this._matchGlobStarBodySections(
+          file,
+          bodySegments,
+          fileIndex,
+          0,
+          partial,
+          0,
+          !!fileTailMatch
+        );
+      }
+      // return false for "nope, not matching"
+      // return null for "not matching, cannot keep trying"
+      _matchGlobStarBodySections(file, bodySegments, fileIndex, bodyIndex, partial, globStarDepth, sawTail) {
+        const bs = bodySegments[bodyIndex];
+        if (!bs) {
+          for (let i = fileIndex; i < file.length; i++) {
+            sawTail = true;
+            const f = file[i];
+            if (f === "." || f === ".." || !this.options.dot && f.charAt(0) === ".") {
+              return false;
+            }
+          }
+          return sawTail;
+        }
+        const [body, after] = bs;
+        while (fileIndex <= after) {
+          const m = this._matchOne(
+            file.slice(0, fileIndex + body.length),
+            body,
+            partial,
+            fileIndex,
+            0
+          );
+          if (m && globStarDepth < this.maxGlobstarRecursion) {
+            const sub = this._matchGlobStarBodySections(
+              file,
+              bodySegments,
+              fileIndex + body.length,
+              bodyIndex + 1,
+              partial,
+              globStarDepth + 1,
+              sawTail
+            );
+            if (sub !== false) {
+              return sub;
+            }
+          }
+          const f = file[fileIndex];
+          if (f === "." || f === ".." || !this.options.dot && f.charAt(0) === ".") {
+            return false;
+          }
+          fileIndex++;
+        }
+        return partial || null;
+      }
+      _matchOne(file, pattern, partial, fileIndex, patternIndex) {
+        let fi, pi, fl, pl;
+        for (fi = fileIndex, pi = patternIndex, fl = file.length, pl = pattern.length; fi < fl && pi < pl; fi++, pi++) {
+          this.debug("matchOne loop");
+          const p = pattern[pi];
+          const f = file[fi];
+          this.debug(pattern, p, f);
+          if (p === false || p === GLOBSTAR) return false;
+          let hit;
           if (typeof p === "string") {
             hit = f === p;
             this.debug("string match", p, f, hit);
@@ -112065,6 +115160,7 @@ var require_minimatch = __commonJS({
                 re += c;
                 continue;
               }
+              if (c === "*" && stateChar === "*") continue;
               this.debug("call clearStateChar %j", stateChar);
               clearStateChar();
               stateChar = c;
@@ -114145,9 +117241,9 @@ var require_server = __commonJS({
   }
 });
 
-// node_modules/path-exists/index.js
+// node_modules/pkg-conf/node_modules/path-exists/index.js
 var require_path_exists = __commonJS({
-  "node_modules/path-exists/index.js"(exports2, module2) {
+  "node_modules/pkg-conf/node_modules/path-exists/index.js"(exports2, module2) {
     "use strict";
     var fs = require("fs");
     module2.exports = (fp) => new Promise((resolve) => {
@@ -114178,9 +117274,9 @@ var require_p_try = __commonJS({
   }
 });
 
-// node_modules/p-locate/node_modules/p-limit/index.js
+// node_modules/pkg-conf/node_modules/p-limit/index.js
 var require_p_limit = __commonJS({
-  "node_modules/p-locate/node_modules/p-limit/index.js"(exports2, module2) {
+  "node_modules/pkg-conf/node_modules/p-limit/index.js"(exports2, module2) {
     "use strict";
     var pTry = require_p_try();
     var pLimit = (concurrency) => {
@@ -114229,9 +117325,9 @@ var require_p_limit = __commonJS({
   }
 });
 
-// node_modules/p-locate/index.js
+// node_modules/pkg-conf/node_modules/p-locate/index.js
 var require_p_locate = __commonJS({
-  "node_modules/p-locate/index.js"(exports2, module2) {
+  "node_modules/pkg-conf/node_modules/p-locate/index.js"(exports2, module2) {
     "use strict";
     var pLimit = require_p_limit();
     var EndError = class extends Error {
@@ -114256,9 +117352,9 @@ var require_p_locate = __commonJS({
   }
 });
 
-// node_modules/locate-path/index.js
+// node_modules/pkg-conf/node_modules/locate-path/index.js
 var require_locate_path = __commonJS({
-  "node_modules/locate-path/index.js"(exports2, module2) {
+  "node_modules/pkg-conf/node_modules/locate-path/index.js"(exports2, module2) {
     "use strict";
     var path = require("path");
     var pathExists = require_path_exists();
@@ -114324,9 +117420,9 @@ var require_find_up = __commonJS({
   }
 });
 
-// node_modules/strip-bom/index.js
+// node_modules/load-json-file/node_modules/strip-bom/index.js
 var require_strip_bom = __commonJS({
-  "node_modules/strip-bom/index.js"(exports2, module2) {
+  "node_modules/load-json-file/node_modules/strip-bom/index.js"(exports2, module2) {
     "use strict";
     module2.exports = (x) => {
       if (typeof x !== "string") {
@@ -115987,6 +119083,7 @@ var require_loader2 = __commonJS({
       this.legacy = options2["legacy"] || false;
       this.json = options2["json"] || false;
       this.listener = options2["listener"] || null;
+      this.maxTotalMergeKeys = typeof options2["maxTotalMergeKeys"] === "number" ? options2["maxTotalMergeKeys"] : 1e4;
       this.implicitTypes = this.schema.compiledImplicit;
       this.typeMap = this.schema.compiledTypeMap;
       this.length = input.length;
@@ -115994,6 +119091,7 @@ var require_loader2 = __commonJS({
       this.line = 0;
       this.lineStart = 0;
       this.lineIndent = 0;
+      this.totalMergeKeys = 0;
       this.documents = [];
     }
     function generateError(state, message) {
@@ -116078,6 +119176,9 @@ var require_loader2 = __commonJS({
       sourceKeys = Object.keys(source);
       for (index = 0, quantity = sourceKeys.length; index < quantity; index += 1) {
         key = sourceKeys[index];
+        if (state.maxTotalMergeKeys !== -1 && ++state.totalMergeKeys > state.maxTotalMergeKeys) {
+          throwError(state, "merge keys exceeded maxTotalMergeKeys (" + state.maxTotalMergeKeys + ")");
+        }
         if (!_hasOwnProperty.call(destination, key)) {
           setProperty(destination, key, source[key]);
           overridableKeys[key] = true;
@@ -117802,9 +120903,9 @@ var require_setup = __commonJS({
   }
 });
 
-// node_modules/commander/index.js
+// node_modules/probot/node_modules/commander/index.js
 var require_commander2 = __commonJS({
-  "node_modules/commander/index.js"(exports2, module2) {
+  "node_modules/probot/node_modules/commander/index.js"(exports2, module2) {
     var EventEmitter = require("events").EventEmitter;
     var spawn = require("child_process").spawn;
     var path = require("path");
@@ -119306,7 +122407,7 @@ Read more on https://git.io/JJc0W`);
 });
 
 // node_modules/@probot/get-private-key/dist-node/index.js
-var require_dist_node32 = __commonJS({
+var require_dist_node42 = __commonJS({
   "node_modules/@probot/get-private-key/dist-node/index.js"(exports2, module2) {
     "use strict";
     var __defProp2 = Object.defineProperty;
@@ -119431,7 +122532,7 @@ var require_read_cli_options = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.readCliOptions = void 0;
     var commander_1 = __importDefault(require_commander2());
-    var get_private_key_1 = require_dist_node32();
+    var get_private_key_1 = require_dist_node42();
     function readCliOptions(argv) {
       commander_1.default.usage("[options] <apps...>").option("-p, --port <n>", "Port to start the server on", String(process.env.PORT || 3e3)).option("-H --host <host>", "Host to start the server on", process.env.HOST).option("-W, --webhook-proxy <url>", "URL of the webhook proxy service.`", process.env.WEBHOOK_PROXY_URL).option("-w, --webhook-path <path>", "URL path which receives webhooks. Ex: `/webhook`", process.env.WEBHOOK_PATH).option("-a, --app <id>", "ID of the GitHub App", process.env.APP_ID).option("-s, --secret <secret>", "Webhook secret of the GitHub App", process.env.WEBHOOK_SECRET).option("-P, --private-key <file>", "Path to private key file (.pem) for the GitHub App", process.env.PRIVATE_KEY_PATH).option("-L, --log-level <level>", 'One of: "trace" | "debug" | "info" | "warn" | "error" | "fatal"', process.env.LOG_LEVEL || "info").option("--log-format <format>", 'One of: "pretty", "json"', process.env.LOG_FORMAT).option("--log-level-in-string", "Set to log levels (trace, debug, info, ...) as words instead of numbers (10, 20, 30, ...)", process.env.LOG_LEVEL_IN_STRING === "true").option("--sentry-dsn <dsn>", 'Set to your Sentry DSN, e.g. "https://1234abcd@sentry.io/12345"', process.env.SENTRY_DSN).option("--redis-url <url>", 'Set to a "redis://" url in order to enable cluster support for request throttling. Example: "redis://:secret@redis-123.redislabs.com:12345/0"', process.env.REDIS_URL).option("--base-url <url>", 'GitHub API base URL. If you use GitHub Enterprise Server, and your hostname is "https://github.acme-inc.com", then the root URL is "https://github.acme-inc.com/api/v3"', process.env.GHE_HOST ? `${process.env.GHE_PROTOCOL || "https"}://${process.env.GHE_HOST}/api/v3` : "https://api.github.com").parse(argv);
       const { app: appId, privateKey: privateKeyPath, redisUrl, ...options2 } = commander_1.default;
@@ -119452,7 +122553,7 @@ var require_read_env_options = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.readEnvOptions = void 0;
-    var get_private_key_1 = require_dist_node32();
+    var get_private_key_1 = require_dist_node42();
     function readEnvOptions(env = process.env) {
       const privateKey = get_private_key_1.getPrivateKey({ env });
       const logFormat = env.LOG_FORMAT || (env.NODE_ENV === "production" ? "json" : "pretty");
@@ -119517,7 +122618,7 @@ var require_homedir = __commonJS({
       var home = process.env.HOME;
       var user = process.env.LOGNAME || process.env.USER || process.env.LNAME || process.env.USERNAME;
       if (process.platform === "win32") {
-        return process.env.USERPROFILE || process.env.HOMEDRIVE + process.env.HOMEPATH || home || null;
+        return process.env.USERPROFILE || process.env.HOMEDRIVE && process.env.HOMEPATH && process.env.HOMEDRIVE + process.env.HOMEPATH || home || null;
       }
       if (process.platform === "darwin") {
         return home || (user ? "/Users/" + user : null);
@@ -119533,13 +122634,15 @@ var require_homedir = __commonJS({
 // node_modules/resolve/lib/caller.js
 var require_caller = __commonJS({
   "node_modules/resolve/lib/caller.js"(exports2, module2) {
+    "use strict";
+    var $Error = require_es_errors();
     module2.exports = function() {
-      var origPrepareStackTrace = Error.prepareStackTrace;
-      Error.prepareStackTrace = function(_, stack2) {
+      var origPrepareStackTrace = $Error.prepareStackTrace;
+      $Error.prepareStackTrace = function(_, stack2) {
         return stack2;
       };
-      var stack = new Error().stack;
-      Error.prepareStackTrace = origPrepareStackTrace;
+      var stack = new $Error().stack;
+      $Error.prepareStackTrace = origPrepareStackTrace;
       return stack[2].getFileName();
     };
   }
@@ -119612,7 +122715,7 @@ var require_node_modules_paths = __commonJS({
     var parse2 = path.parse || require_path_parse();
     var driveLetterRegex = /^([A-Za-z]:)/;
     var uncPathRegex = /^\\\\/;
-    var getNodeModulesDirs = function getNodeModulesDirs2(absoluteStart, modules) {
+    function getNodeModulesDirs(absoluteStart, modules) {
       var prefix = "/";
       if (driveLetterRegex.test(absoluteStart)) {
         prefix = "";
@@ -119630,7 +122733,7 @@ var require_node_modules_paths = __commonJS({
           return path.resolve(prefix, aPath, moduleDir);
         }));
       }, []);
-    };
+    }
     module2.exports = function nodeModulesPaths(start, opts, request) {
       var modules = opts && opts.moduleDirectory ? [].concat(opts.moduleDirectory) : ["node_modules"];
       if (opts && typeof opts.paths === "function") {
@@ -119652,77 +122755,8 @@ var require_node_modules_paths = __commonJS({
 // node_modules/resolve/lib/normalize-options.js
 var require_normalize_options = __commonJS({
   "node_modules/resolve/lib/normalize-options.js"(exports2, module2) {
-    var path = require("path");
-    module2.exports = function(_, opts) {
-      opts = opts || {};
-      if (opts.forceNodeResolution || !process.versions.pnp)
-        return opts;
-      const { findPnpApi } = require("module");
-      const runPnpResolution = (request, basedir) => {
-        const parts = request.match(/^((?:@[^/]+\/)?[^/]+)(\/.*)?/);
-        if (!parts)
-          throw new Error(`Assertion failed: Expected the "resolve" package to call the "paths" callback with package names only (got "${request}")`);
-        if (basedir.charAt(basedir.length - 1) !== `/`)
-          basedir = path.join(basedir, `/`);
-        const api = findPnpApi(basedir);
-        if (api === null)
-          return void 0;
-        let manifestPath;
-        try {
-          manifestPath = api.resolveToUnqualified(`${parts[1]}/package.json`, basedir, { considerBuiltins: false });
-        } catch (err) {
-          return null;
-        }
-        if (manifestPath === null)
-          throw new Error(`Assertion failed: The resolution thinks that "${parts[1]}" is a Node builtin`);
-        const packagePath = path.dirname(manifestPath);
-        const unqualifiedPath = typeof parts[2] !== `undefined` ? path.join(packagePath, parts[2]) : packagePath;
-        return { packagePath, unqualifiedPath };
-      };
-      const runPnpResolutionOnArray = (request, paths2) => {
-        for (let i = 0; i < paths2.length; i++) {
-          const resolution = runPnpResolution(request, paths2[i]);
-          if (resolution || i === paths2.length - 1) {
-            return resolution;
-          }
-        }
-        return null;
-      };
-      const originalPaths = Array.isArray(opts.paths) ? opts.paths : [];
-      const packageIterator = (request, basedir, getCandidates, opts2) => {
-        const pathsToTest = [basedir].concat(originalPaths);
-        const resolution = runPnpResolutionOnArray(request, pathsToTest);
-        if (resolution == null)
-          return getCandidates();
-        return [resolution.unqualifiedPath];
-      };
-      const paths = (request, basedir, getNodeModulePaths, opts2) => {
-        const pathsToTest = [basedir].concat(originalPaths);
-        const resolution = runPnpResolutionOnArray(request, pathsToTest);
-        if (resolution == null)
-          return getNodeModulePaths().concat(originalPaths);
-        let nodeModules = path.dirname(resolution.packagePath);
-        if (request.match(/^@[^/]+\//))
-          nodeModules = path.dirname(nodeModules);
-        return [nodeModules];
-      };
-      let isInsideIterator = false;
-      if (!opts.__skipPackageIterator) {
-        opts.packageIterator = function(request, basedir, getCandidates, opts2) {
-          isInsideIterator = true;
-          try {
-            return packageIterator(request, basedir, getCandidates, opts2);
-          } finally {
-            isInsideIterator = false;
-          }
-        };
-      }
-      opts.paths = function(request, basedir, getNodeModulePaths, opts2) {
-        if (isInsideIterator)
-          return getNodeModulePaths().concat(originalPaths);
-        return paths(request, basedir, getNodeModulePaths, opts2);
-      };
-      return opts;
+    module2.exports = function(x, opts) {
+      return opts || {};
     };
   }
 });
@@ -119824,18 +122858,18 @@ var require_core4 = __commonJS({
       "node:sea": [">= 20.12 && < 21", ">= 21.7"],
       smalloc: ">= 0.11.5 && < 3",
       "node:sqlite": [">= 22.13 && < 23", ">= 23.4"],
-      _stream_duplex: ">= 0.9.4",
-      "node:_stream_duplex": [">= 14.18 && < 15", ">= 16"],
-      _stream_transform: ">= 0.9.4",
-      "node:_stream_transform": [">= 14.18 && < 15", ">= 16"],
-      _stream_wrap: ">= 1.4.1",
-      "node:_stream_wrap": [">= 14.18 && < 15", ">= 16"],
-      _stream_passthrough: ">= 0.9.4",
-      "node:_stream_passthrough": [">= 14.18 && < 15", ">= 16"],
-      _stream_readable: ">= 0.9.4",
-      "node:_stream_readable": [">= 14.18 && < 15", ">= 16"],
-      _stream_writable: ">= 0.9.4",
-      "node:_stream_writable": [">= 14.18 && < 15", ">= 16"],
+      _stream_duplex: ">= 0.9.4 && < 26",
+      "node:_stream_duplex": [">= 14.18 && < 15", ">= 16 && < 26"],
+      _stream_transform: ">= 0.9.4 && < 26",
+      "node:_stream_transform": [">= 14.18 && < 15", ">= 16 && < 26"],
+      _stream_wrap: ">= 1.4.1 && < 26",
+      "node:_stream_wrap": [">= 14.18 && < 15", ">= 16 && < 26"],
+      _stream_passthrough: ">= 0.9.4 && < 26",
+      "node:_stream_passthrough": [">= 14.18 && < 15", ">= 16 && < 26"],
+      _stream_readable: ">= 0.9.4 && < 26",
+      "node:_stream_readable": [">= 14.18 && < 15", ">= 16 && < 26"],
+      _stream_writable: ">= 0.9.4 && < 26",
+      "node:_stream_writable": [">= 14.18 && < 15", ">= 16 && < 26"],
       stream: true,
       "node:stream": [">= 14.18 && < 15", ">= 16"],
       "stream/consumers": ">= 16.7",
@@ -119968,17 +123002,20 @@ var require_async2 = __commonJS({
     var nodeModulesPaths = require_node_modules_paths();
     var normalizeOptions = require_normalize_options();
     var isCore = require_is_core_module();
+    var $Error = require_es_errors();
+    var $TypeError = require_type2();
     var realpathFS = process.platform !== "win32" && fs.realpath && typeof fs.realpath.native === "function" ? fs.realpath.native : fs.realpath;
     var relativePathRegex = /^(?:\.\.?(?:\/|$)|\/|([A-Za-z]:)?[/\\])/;
     var windowsDriveRegex = /^\w:[/\\]*$/;
     var nodeModulesRegex = /[/\\]node_modules[/\\]*$/;
     var homedir = getHomedir();
-    var defaultPaths = function() {
+    function defaultPaths() {
+      if (!homedir) return [];
       return [
         path.join(homedir, ".node_modules"),
         path.join(homedir, ".node_libraries")
       ];
-    };
+    }
     var defaultIsFile = function isFile(file, cb) {
       fs.stat(file, function(err, stat) {
         if (!err) {
@@ -120003,14 +123040,14 @@ var require_async2 = __commonJS({
         else cb(null, realpathErr ? x : realPath);
       });
     };
-    var maybeRealpath = function maybeRealpath2(realpath, x, opts, cb) {
+    function maybeRealpath(realpath, x, opts, cb) {
       if (opts && opts.preserveSymlinks === false) {
         realpath(x, cb);
       } else {
         cb(null, x);
       }
-    };
-    var defaultReadPackage = function defaultReadPackage2(readFile, pkgfile, cb) {
+    }
+    function defaultReadPackage(readFile, pkgfile, cb) {
       readFile(pkgfile, function(readFileErr, body) {
         if (readFileErr) cb(readFileErr);
         else {
@@ -120022,14 +123059,14 @@ var require_async2 = __commonJS({
           }
         }
       });
-    };
-    var getPackageCandidates = function getPackageCandidates2(x, start, opts) {
+    }
+    function getPackageCandidates(x, start, opts) {
       var dirs = nodeModulesPaths(start, opts, x);
       for (var i = 0; i < dirs.length; i++) {
         dirs[i] = path.join(dirs[i], x);
       }
       return dirs;
-    };
+    }
     module2.exports = function resolve(x, options2, callback) {
       var cb = callback;
       var opts = options2;
@@ -120038,7 +123075,7 @@ var require_async2 = __commonJS({
         opts = {};
       }
       if (typeof x !== "string") {
-        var err = new TypeError("Path must be a string.");
+        var err = new $TypeError("Path must be a string.");
         return process.nextTick(function() {
           cb(err);
         });
@@ -120050,7 +123087,7 @@ var require_async2 = __commonJS({
       var realpath = opts.realpath || defaultRealpath;
       var readPackage = opts.readPackage || defaultReadPackage;
       if (opts.readFile && opts.readPackage) {
-        var conflictErr = new TypeError("`readFile` and `readPackage` are mutually exclusive.");
+        var conflictErr = new $TypeError("`readFile` and `readPackage` are mutually exclusive.");
         return process.nextTick(function() {
           cb(conflictErr);
         });
@@ -120092,7 +123129,7 @@ var require_async2 = __commonJS({
               }
             });
           } else {
-            var moduleError = new Error("Cannot find module '" + x + "' from '" + parent + "'");
+            var moduleError = new $Error("Cannot find module '" + x + "' from '" + parent + "'");
             moduleError.code = "MODULE_NOT_FOUND";
             cb(moduleError);
           }
@@ -120112,7 +123149,7 @@ var require_async2 = __commonJS({
               }
             });
           } else {
-            var moduleError = new Error("Cannot find module '" + x + "' from '" + parent + "'");
+            var moduleError = new $Error("Cannot find module '" + x + "' from '" + parent + "'");
             moduleError.code = "MODULE_NOT_FOUND";
             cb(moduleError);
           }
@@ -120141,7 +123178,7 @@ var require_async2 = __commonJS({
               var rel = rfile.slice(0, rfile.length - exts2[0].length);
               var r = opts.pathFilter(pkg, x3, rel);
               if (r) return load(
-                [""].concat(extensions.slice()),
+                [""].concat(extensions),
                 path.resolve(dir, r),
                 pkg
               );
@@ -120167,7 +123204,9 @@ var require_async2 = __commonJS({
           isFile(pkgfile, function(err2, ex) {
             if (!ex) return loadpkg(path.dirname(dir), cb2);
             readPackage(readFile, pkgfile, function(err3, pkgParam) {
-              if (err3) cb2(err3);
+              if (err3) {
+                return cb2(err3);
+              }
               var pkg = pkgParam;
               if (pkg && opts.packageFilter) {
                 pkg = opts.packageFilter(pkg, pkgfile);
@@ -120198,7 +123237,7 @@ var require_async2 = __commonJS({
               }
               if (pkg && pkg.main) {
                 if (typeof pkg.main !== "string") {
-                  var mainError = new TypeError("package \u201C" + pkg.name + "\u201D `main` must be a string");
+                  var mainError = new $TypeError("package \u201C" + pkg.name + "\u201D `main` must be a string");
                   mainError.code = "INVALID_PACKAGE_MAIN";
                   return cb2(mainError);
                 }
@@ -120457,6 +123496,8 @@ var require_sync2 = __commonJS({
     var isCore = require_is_core_module();
     var fs = require("fs");
     var path = require("path");
+    var $Error = require_es_errors();
+    var $TypeError = require_type2();
     var getHomedir = require_homedir();
     var caller = require_caller();
     var nodeModulesPaths = require_node_modules_paths();
@@ -120466,12 +123507,13 @@ var require_sync2 = __commonJS({
     var windowsDriveRegex = /^\w:[/\\]*$/;
     var nodeModulesRegex = /[/\\]node_modules[/\\]*$/;
     var homedir = getHomedir();
-    var defaultPaths = function() {
+    function defaultPaths() {
+      if (!homedir) return [];
       return [
         path.join(homedir, ".node_modules"),
         path.join(homedir, ".node_libraries")
       ];
-    };
+    }
     var defaultIsFile = function isFile(file) {
       try {
         var stat = fs.statSync(file, { throwIfNoEntry: false });
@@ -120500,30 +123542,30 @@ var require_sync2 = __commonJS({
       }
       return x;
     };
-    var maybeRealpathSync = function maybeRealpathSync2(realpathSync, x, opts) {
+    function maybeRealpathSync(realpathSync, x, opts) {
       if (opts && opts.preserveSymlinks === false) {
         return realpathSync(x);
       }
       return x;
-    };
-    var defaultReadPackageSync = function defaultReadPackageSync2(readFileSync, pkgfile) {
+    }
+    function defaultReadPackageSync(readFileSync, pkgfile) {
       var body = readFileSync(pkgfile);
       try {
         var pkg = JSON.parse(body);
         return pkg;
       } catch (jsonErr) {
       }
-    };
-    var getPackageCandidates = function getPackageCandidates2(x, start, opts) {
+    }
+    function getPackageCandidates(x, start, opts) {
       var dirs = nodeModulesPaths(start, opts, x);
       for (var i = 0; i < dirs.length; i++) {
         dirs[i] = path.join(dirs[i], x);
       }
       return dirs;
-    };
+    }
     module2.exports = function resolveSync(x, options2) {
       if (typeof x !== "string") {
-        throw new TypeError("Path must be a string.");
+        throw new $TypeError("Path must be a string.");
       }
       var opts = normalizeOptions(x, options2);
       var isFile = opts.isFile || defaultIsFile;
@@ -120532,7 +123574,7 @@ var require_sync2 = __commonJS({
       var realpathSync = opts.realpathSync || defaultRealpathSync;
       var readPackageSync = opts.readPackageSync || defaultReadPackageSync;
       if (opts.readFileSync && opts.readPackageSync) {
-        throw new TypeError("`readFileSync` and `readPackageSync` are mutually exclusive.");
+        throw new $TypeError("`readFileSync` and `readPackageSync` are mutually exclusive.");
       }
       var packageIterator = opts.packageIterator;
       var extensions = opts.extensions || [".js"];
@@ -120552,7 +123594,7 @@ var require_sync2 = __commonJS({
         var n = loadNodeModulesSync(x, absoluteStart);
         if (n) return maybeRealpathSync(realpathSync, n, opts);
       }
-      var err = new Error("Cannot find module '" + x + "' from '" + parent + "'");
+      var err = new $Error("Cannot find module '" + x + "' from '" + parent + "'");
       err.code = "MODULE_NOT_FOUND";
       throw err;
       function loadAsFileSync(x2) {
@@ -120610,7 +123652,7 @@ var require_sync2 = __commonJS({
           }
           if (pkg && pkg.main) {
             if (typeof pkg.main !== "string") {
-              var mainError = new TypeError("package \u201C" + pkg.name + "\u201D `main` must be a string");
+              var mainError = new $TypeError("package \u201C" + pkg.name + "\u201D `main` must be a string");
               mainError.code = "INVALID_PACKAGE_MAIN";
               throw mainError;
             }
@@ -120841,7 +123883,7 @@ var require_create_probot = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.createProbot = void 0;
-    var get_private_key_1 = require_dist_node32();
+    var get_private_key_1 = require_dist_node42();
     var get_log_1 = require_get_log();
     var probot_1 = require_probot();
     var DEFAULTS = {
@@ -121671,6 +124713,8 @@ var require_Alias = __commonJS({
        * instance of the `source` anchor before this node.
        */
       resolve(doc, ctx) {
+        if (ctx?.maxAliasCount === 0)
+          throw new ReferenceError("Alias resolution is disabled");
         let nodes;
         if (ctx?.aliasResolveCache) {
           nodes = ctx.aliasResolveCache;
@@ -122470,6 +125514,7 @@ var require_stringify2 = __commonJS({
         nullStr: "null",
         simpleKeys: false,
         singleQuote: null,
+        trailingComma: false,
         trueStr: "true",
         verifyAliasOrder: true
       }, doc.schema.toStringOptions, options2);
@@ -122742,18 +125787,18 @@ var require_merge3 = __commonJS({
     };
     var isMergeKey = (ctx, key) => (merge.identify(key) || identity.isScalar(key) && (!key.type || key.type === Scalar.Scalar.PLAIN) && merge.identify(key.value)) && ctx?.doc.schema.tags.some((tag) => tag.tag === merge.tag && tag.default);
     function addMergeToJSMap(ctx, map, value) {
-      value = ctx && identity.isAlias(value) ? value.resolve(ctx.doc) : value;
-      if (identity.isSeq(value))
-        for (const it of value.items)
+      const source = resolveAliasValue(ctx, value);
+      if (identity.isSeq(source))
+        for (const it of source.items)
           mergeValue(ctx, map, it);
-      else if (Array.isArray(value))
-        for (const it of value)
+      else if (Array.isArray(source))
+        for (const it of source)
           mergeValue(ctx, map, it);
       else
-        mergeValue(ctx, map, value);
+        mergeValue(ctx, map, source);
     }
     function mergeValue(ctx, map, value) {
-      const source = ctx && identity.isAlias(value) ? value.resolve(ctx.doc) : value;
+      const source = resolveAliasValue(ctx, value);
       if (!identity.isMap(source))
         throw new Error("Merge sources must be maps or map aliases");
       const srcMap = source.toJSON(null, ctx, Map);
@@ -122773,6 +125818,9 @@ var require_merge3 = __commonJS({
         }
       }
       return map;
+    }
+    function resolveAliasValue(ctx, value) {
+      return ctx && identity.isAlias(value) ? value.resolve(ctx.doc, ctx) : value;
     }
     exports2.addMergeToJSMap = addMergeToJSMap;
     exports2.isMergeKey = isMergeKey;
@@ -122987,12 +126035,19 @@ ${indent}${line}` : "\n";
         if (comment)
           reqNewline = true;
         let str = stringify2.stringify(item, itemCtx, () => comment = null);
-        if (i < items.length - 1)
+        reqNewline || (reqNewline = lines.length > linesAtValue || str.includes("\n"));
+        if (i < items.length - 1) {
           str += ",";
+        } else if (ctx.options.trailingComma) {
+          if (ctx.options.lineWidth > 0) {
+            reqNewline || (reqNewline = lines.reduce((sum, line) => sum + line.length + 2, 2) + (str.length + 2) > ctx.options.lineWidth);
+          }
+          if (reqNewline) {
+            str += ",";
+          }
+        }
         if (comment)
           str += stringifyComment.lineComment(str, itemIndent, commentString(comment));
-        if (!reqNewline && (lines.length > linesAtValue || str.includes("\n")))
-          reqNewline = true;
         lines.push(str);
         linesAtValue = lines.length;
       }
@@ -123404,7 +126459,7 @@ var require_stringifyNumber = __commonJS({
       if (!isFinite(num))
         return isNaN(num) ? ".nan" : num < 0 ? "-.inf" : ".inf";
       let n = Object.is(value, -0) ? "-0" : JSON.stringify(value);
-      if (!format && minFractionDigits && (!tag || tag === "tag:yaml.org,2002:float") && /^\d/.test(n)) {
+      if (!format && minFractionDigits && (!tag || tag === "tag:yaml.org,2002:float") && /^-?\d/.test(n) && !n.includes("e")) {
         let i = n.indexOf(".");
         if (i < 0) {
           i = n.length;
@@ -125776,7 +128831,7 @@ var require_resolve_flow_scalar = __commonJS({
             while (next === " " || next === "	")
               next = source[++i + 1];
           } else if (next === "x" || next === "u" || next === "U") {
-            const length = { x: 2, u: 4, U: 8 }[next];
+            const length = next === "x" ? 2 : next === "u" ? 4 : 8;
             res += parseCharCode(source, i + 1, length, onError);
             i += length;
           } else {
@@ -125851,12 +128906,13 @@ var require_resolve_flow_scalar = __commonJS({
       const cc = source.substr(offset, length);
       const ok = cc.length === length && /^[0-9a-fA-F]+$/.test(cc);
       const code = ok ? parseInt(cc, 16) : NaN;
-      if (isNaN(code)) {
+      try {
+        return String.fromCodePoint(code);
+      } catch {
         const raw = source.substr(offset - 2, length + 2);
         onError(offset - 2, "BAD_DQ_ESCAPE", `Invalid escape sequence ${raw}`);
         return raw;
       }
-      return String.fromCodePoint(code);
     }
     exports2.resolveFlowScalar = resolveFlowScalar;
   }
@@ -126006,17 +129062,22 @@ var require_compose_node = __commonJS({
         case "block-map":
         case "block-seq":
         case "flow-collection":
-          node = composeCollection.composeCollection(CN, ctx, token, props, onError);
-          if (anchor)
-            node.anchor = anchor.source.substring(1);
+          try {
+            node = composeCollection.composeCollection(CN, ctx, token, props, onError);
+            if (anchor)
+              node.anchor = anchor.source.substring(1);
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            onError(token, "RESOURCE_EXHAUSTION", message);
+          }
           break;
         default: {
           const message = token.type === "error" ? token.message : `Unsupported token (type: ${token.type})`;
           onError(token, "UNEXPECTED_TOKEN", message);
-          node = composeEmptyNode(ctx, token.offset, void 0, null, props, onError);
           isSrcToken = false;
         }
       }
+      node ?? (node = composeEmptyNode(ctx, token.offset, void 0, null, props, onError));
       if (anchor && node.anchor === "")
         onError(anchor, "BAD_ALIAS", "Anchor cannot be an empty string");
       if (atKey && ctx.options.stringKeys && (!identity.isScalar(node) || typeof node.value !== "string" || node.tag && node.tag !== "tag:yaml.org,2002:str")) {
@@ -126201,8 +129262,10 @@ ${cb}` : comment;
           }
         }
         if (afterDoc) {
-          Array.prototype.push.apply(doc.errors, this.errors);
-          Array.prototype.push.apply(doc.warnings, this.warnings);
+          for (let i = 0; i < this.errors.length; ++i)
+            doc.errors.push(this.errors[i]);
+          for (let i = 0; i < this.warnings.length; ++i)
+            doc.warnings.push(this.warnings[i]);
         } else {
           doc.errors = this.errors;
           doc.warnings = this.warnings;
@@ -126935,7 +129998,7 @@ var require_lexer = __commonJS({
           const n = (yield* this.pushCount(1)) + (yield* this.pushSpaces(true));
           this.indentNext = this.indentValue + 1;
           this.indentValue += n;
-          return yield* this.parseBlockStart();
+          return "block-start";
         }
         return "doc";
       }
@@ -127234,28 +130297,38 @@ var require_lexer = __commonJS({
         return 0;
       }
       *pushIndicators() {
-        switch (this.charAt(0)) {
-          case "!":
-            return (yield* this.pushTag()) + (yield* this.pushSpaces(true)) + (yield* this.pushIndicators());
-          case "&":
-            return (yield* this.pushUntil(isNotAnchorChar)) + (yield* this.pushSpaces(true)) + (yield* this.pushIndicators());
-          case "-":
-          // this is an error
-          case "?":
-          // this is an error outside flow collections
-          case ":": {
-            const inFlow = this.flowLevel > 0;
-            const ch1 = this.charAt(1);
-            if (isEmpty(ch1) || inFlow && flowIndicatorChars.has(ch1)) {
-              if (!inFlow)
-                this.indentNext = this.indentValue + 1;
-              else if (this.flowKey)
-                this.flowKey = false;
-              return (yield* this.pushCount(1)) + (yield* this.pushSpaces(true)) + (yield* this.pushIndicators());
+        let n = 0;
+        loop: while (true) {
+          switch (this.charAt(0)) {
+            case "!":
+              n += yield* this.pushTag();
+              n += yield* this.pushSpaces(true);
+              continue loop;
+            case "&":
+              n += yield* this.pushUntil(isNotAnchorChar);
+              n += yield* this.pushSpaces(true);
+              continue loop;
+            case "-":
+            // this is an error
+            case "?":
+            // this is an error outside flow collections
+            case ":": {
+              const inFlow = this.flowLevel > 0;
+              const ch1 = this.charAt(1);
+              if (isEmpty(ch1) || inFlow && flowIndicatorChars.has(ch1)) {
+                if (!inFlow)
+                  this.indentNext = this.indentValue + 1;
+                else if (this.flowKey)
+                  this.flowKey = false;
+                n += yield* this.pushCount(1);
+                n += yield* this.pushSpaces(true);
+                continue loop;
+              }
             }
           }
+          break loop;
         }
-        return 0;
+        return n;
       }
       *pushTag() {
         if (this.charAt(1) === "<") {
@@ -127414,6 +130487,13 @@ var require_parser4 = __commonJS({
       }
       return prev.splice(i, prev.length);
     }
+    function arrayPushArray(target, source) {
+      if (source.length < 1e5)
+        Array.prototype.push.apply(target, source);
+      else
+        for (let i = 0; i < source.length; ++i)
+          target.push(source[i]);
+    }
     function fixFlowSeqItems(fc) {
       if (fc.start.type === "flow-seq-start") {
         for (const it of fc.items) {
@@ -127423,11 +130503,11 @@ var require_parser4 = __commonJS({
             delete it.key;
             if (isFlowToken(it.value)) {
               if (it.value.end)
-                Array.prototype.push.apply(it.value.end, it.sep);
+                arrayPushArray(it.value.end, it.sep);
               else
                 it.value.end = it.sep;
             } else
-              Array.prototype.push.apply(it.start, it.sep);
+              arrayPushArray(it.start, it.sep);
             delete it.sep;
           }
         }
@@ -127782,7 +130862,7 @@ var require_parser4 = __commonJS({
                 const prev = map.items[map.items.length - 2];
                 const end = prev?.value?.end;
                 if (Array.isArray(end)) {
-                  Array.prototype.push.apply(end, it.start);
+                  arrayPushArray(end, it.start);
                   end.push(this.sourceToken);
                   map.items.pop();
                   return;
@@ -127970,7 +131050,7 @@ var require_parser4 = __commonJS({
                 const prev = seq.items[seq.items.length - 2];
                 const end = prev?.value?.end;
                 if (Array.isArray(end)) {
-                  Array.prototype.push.apply(end, it.start);
+                  arrayPushArray(end, it.start);
                   end.push(this.sourceToken);
                   seq.items.pop();
                   return;
@@ -128409,9 +131489,9 @@ var require_strip_ansi = __commonJS({
   }
 });
 
-// node_modules/is-fullwidth-code-point/index.js
+// node_modules/string-width/node_modules/is-fullwidth-code-point/index.js
 var require_is_fullwidth_code_point = __commonJS({
-  "node_modules/is-fullwidth-code-point/index.js"(exports2, module2) {
+  "node_modules/string-width/node_modules/is-fullwidth-code-point/index.js"(exports2, module2) {
     "use strict";
     var isFullwidthCodePoint = (codePoint) => {
       if (Number.isNaN(codePoint)) {
@@ -147573,6 +150653,658 @@ var require_coerce2 = __commonJS({
   }
 });
 
+// node_modules/semver/node_modules/yallist/iterator.js
+var require_iterator2 = __commonJS({
+  "node_modules/semver/node_modules/yallist/iterator.js"(exports2, module2) {
+    "use strict";
+    module2.exports = function(Yallist) {
+      Yallist.prototype[Symbol.iterator] = function* () {
+        for (let walker = this.head; walker; walker = walker.next) {
+          yield walker.value;
+        }
+      };
+    };
+  }
+});
+
+// node_modules/semver/node_modules/yallist/yallist.js
+var require_yallist2 = __commonJS({
+  "node_modules/semver/node_modules/yallist/yallist.js"(exports2, module2) {
+    "use strict";
+    module2.exports = Yallist;
+    Yallist.Node = Node;
+    Yallist.create = Yallist;
+    function Yallist(list) {
+      var self2 = this;
+      if (!(self2 instanceof Yallist)) {
+        self2 = new Yallist();
+      }
+      self2.tail = null;
+      self2.head = null;
+      self2.length = 0;
+      if (list && typeof list.forEach === "function") {
+        list.forEach(function(item) {
+          self2.push(item);
+        });
+      } else if (arguments.length > 0) {
+        for (var i = 0, l = arguments.length; i < l; i++) {
+          self2.push(arguments[i]);
+        }
+      }
+      return self2;
+    }
+    Yallist.prototype.removeNode = function(node) {
+      if (node.list !== this) {
+        throw new Error("removing node which does not belong to this list");
+      }
+      var next = node.next;
+      var prev = node.prev;
+      if (next) {
+        next.prev = prev;
+      }
+      if (prev) {
+        prev.next = next;
+      }
+      if (node === this.head) {
+        this.head = next;
+      }
+      if (node === this.tail) {
+        this.tail = prev;
+      }
+      node.list.length--;
+      node.next = null;
+      node.prev = null;
+      node.list = null;
+      return next;
+    };
+    Yallist.prototype.unshiftNode = function(node) {
+      if (node === this.head) {
+        return;
+      }
+      if (node.list) {
+        node.list.removeNode(node);
+      }
+      var head = this.head;
+      node.list = this;
+      node.next = head;
+      if (head) {
+        head.prev = node;
+      }
+      this.head = node;
+      if (!this.tail) {
+        this.tail = node;
+      }
+      this.length++;
+    };
+    Yallist.prototype.pushNode = function(node) {
+      if (node === this.tail) {
+        return;
+      }
+      if (node.list) {
+        node.list.removeNode(node);
+      }
+      var tail = this.tail;
+      node.list = this;
+      node.prev = tail;
+      if (tail) {
+        tail.next = node;
+      }
+      this.tail = node;
+      if (!this.head) {
+        this.head = node;
+      }
+      this.length++;
+    };
+    Yallist.prototype.push = function() {
+      for (var i = 0, l = arguments.length; i < l; i++) {
+        push(this, arguments[i]);
+      }
+      return this.length;
+    };
+    Yallist.prototype.unshift = function() {
+      for (var i = 0, l = arguments.length; i < l; i++) {
+        unshift(this, arguments[i]);
+      }
+      return this.length;
+    };
+    Yallist.prototype.pop = function() {
+      if (!this.tail) {
+        return void 0;
+      }
+      var res = this.tail.value;
+      this.tail = this.tail.prev;
+      if (this.tail) {
+        this.tail.next = null;
+      } else {
+        this.head = null;
+      }
+      this.length--;
+      return res;
+    };
+    Yallist.prototype.shift = function() {
+      if (!this.head) {
+        return void 0;
+      }
+      var res = this.head.value;
+      this.head = this.head.next;
+      if (this.head) {
+        this.head.prev = null;
+      } else {
+        this.tail = null;
+      }
+      this.length--;
+      return res;
+    };
+    Yallist.prototype.forEach = function(fn, thisp) {
+      thisp = thisp || this;
+      for (var walker = this.head, i = 0; walker !== null; i++) {
+        fn.call(thisp, walker.value, i, this);
+        walker = walker.next;
+      }
+    };
+    Yallist.prototype.forEachReverse = function(fn, thisp) {
+      thisp = thisp || this;
+      for (var walker = this.tail, i = this.length - 1; walker !== null; i--) {
+        fn.call(thisp, walker.value, i, this);
+        walker = walker.prev;
+      }
+    };
+    Yallist.prototype.get = function(n) {
+      for (var i = 0, walker = this.head; walker !== null && i < n; i++) {
+        walker = walker.next;
+      }
+      if (i === n && walker !== null) {
+        return walker.value;
+      }
+    };
+    Yallist.prototype.getReverse = function(n) {
+      for (var i = 0, walker = this.tail; walker !== null && i < n; i++) {
+        walker = walker.prev;
+      }
+      if (i === n && walker !== null) {
+        return walker.value;
+      }
+    };
+    Yallist.prototype.map = function(fn, thisp) {
+      thisp = thisp || this;
+      var res = new Yallist();
+      for (var walker = this.head; walker !== null; ) {
+        res.push(fn.call(thisp, walker.value, this));
+        walker = walker.next;
+      }
+      return res;
+    };
+    Yallist.prototype.mapReverse = function(fn, thisp) {
+      thisp = thisp || this;
+      var res = new Yallist();
+      for (var walker = this.tail; walker !== null; ) {
+        res.push(fn.call(thisp, walker.value, this));
+        walker = walker.prev;
+      }
+      return res;
+    };
+    Yallist.prototype.reduce = function(fn, initial) {
+      var acc;
+      var walker = this.head;
+      if (arguments.length > 1) {
+        acc = initial;
+      } else if (this.head) {
+        walker = this.head.next;
+        acc = this.head.value;
+      } else {
+        throw new TypeError("Reduce of empty list with no initial value");
+      }
+      for (var i = 0; walker !== null; i++) {
+        acc = fn(acc, walker.value, i);
+        walker = walker.next;
+      }
+      return acc;
+    };
+    Yallist.prototype.reduceReverse = function(fn, initial) {
+      var acc;
+      var walker = this.tail;
+      if (arguments.length > 1) {
+        acc = initial;
+      } else if (this.tail) {
+        walker = this.tail.prev;
+        acc = this.tail.value;
+      } else {
+        throw new TypeError("Reduce of empty list with no initial value");
+      }
+      for (var i = this.length - 1; walker !== null; i--) {
+        acc = fn(acc, walker.value, i);
+        walker = walker.prev;
+      }
+      return acc;
+    };
+    Yallist.prototype.toArray = function() {
+      var arr = new Array(this.length);
+      for (var i = 0, walker = this.head; walker !== null; i++) {
+        arr[i] = walker.value;
+        walker = walker.next;
+      }
+      return arr;
+    };
+    Yallist.prototype.toArrayReverse = function() {
+      var arr = new Array(this.length);
+      for (var i = 0, walker = this.tail; walker !== null; i++) {
+        arr[i] = walker.value;
+        walker = walker.prev;
+      }
+      return arr;
+    };
+    Yallist.prototype.slice = function(from, to) {
+      to = to || this.length;
+      if (to < 0) {
+        to += this.length;
+      }
+      from = from || 0;
+      if (from < 0) {
+        from += this.length;
+      }
+      var ret = new Yallist();
+      if (to < from || to < 0) {
+        return ret;
+      }
+      if (from < 0) {
+        from = 0;
+      }
+      if (to > this.length) {
+        to = this.length;
+      }
+      for (var i = 0, walker = this.head; walker !== null && i < from; i++) {
+        walker = walker.next;
+      }
+      for (; walker !== null && i < to; i++, walker = walker.next) {
+        ret.push(walker.value);
+      }
+      return ret;
+    };
+    Yallist.prototype.sliceReverse = function(from, to) {
+      to = to || this.length;
+      if (to < 0) {
+        to += this.length;
+      }
+      from = from || 0;
+      if (from < 0) {
+        from += this.length;
+      }
+      var ret = new Yallist();
+      if (to < from || to < 0) {
+        return ret;
+      }
+      if (from < 0) {
+        from = 0;
+      }
+      if (to > this.length) {
+        to = this.length;
+      }
+      for (var i = this.length, walker = this.tail; walker !== null && i > to; i--) {
+        walker = walker.prev;
+      }
+      for (; walker !== null && i > from; i--, walker = walker.prev) {
+        ret.push(walker.value);
+      }
+      return ret;
+    };
+    Yallist.prototype.splice = function(start, deleteCount, ...nodes) {
+      if (start > this.length) {
+        start = this.length - 1;
+      }
+      if (start < 0) {
+        start = this.length + start;
+      }
+      for (var i = 0, walker = this.head; walker !== null && i < start; i++) {
+        walker = walker.next;
+      }
+      var ret = [];
+      for (var i = 0; walker && i < deleteCount; i++) {
+        ret.push(walker.value);
+        walker = this.removeNode(walker);
+      }
+      if (walker === null) {
+        walker = this.tail;
+      }
+      if (walker !== this.head && walker !== this.tail) {
+        walker = walker.prev;
+      }
+      for (var i = 0; i < nodes.length; i++) {
+        walker = insert(this, walker, nodes[i]);
+      }
+      return ret;
+    };
+    Yallist.prototype.reverse = function() {
+      var head = this.head;
+      var tail = this.tail;
+      for (var walker = head; walker !== null; walker = walker.prev) {
+        var p = walker.prev;
+        walker.prev = walker.next;
+        walker.next = p;
+      }
+      this.head = tail;
+      this.tail = head;
+      return this;
+    };
+    function insert(self2, node, value) {
+      var inserted = node === self2.head ? new Node(value, null, node, self2) : new Node(value, node, node.next, self2);
+      if (inserted.next === null) {
+        self2.tail = inserted;
+      }
+      if (inserted.prev === null) {
+        self2.head = inserted;
+      }
+      self2.length++;
+      return inserted;
+    }
+    function push(self2, item) {
+      self2.tail = new Node(item, self2.tail, null, self2);
+      if (!self2.head) {
+        self2.head = self2.tail;
+      }
+      self2.length++;
+    }
+    function unshift(self2, item) {
+      self2.head = new Node(item, null, self2.head, self2);
+      if (!self2.tail) {
+        self2.tail = self2.head;
+      }
+      self2.length++;
+    }
+    function Node(value, prev, next, list) {
+      if (!(this instanceof Node)) {
+        return new Node(value, prev, next, list);
+      }
+      this.list = list;
+      this.value = value;
+      if (prev) {
+        prev.next = this;
+        this.prev = prev;
+      } else {
+        this.prev = null;
+      }
+      if (next) {
+        next.prev = this;
+        this.next = next;
+      } else {
+        this.next = null;
+      }
+    }
+    try {
+      require_iterator2()(Yallist);
+    } catch (er) {
+    }
+  }
+});
+
+// node_modules/semver/node_modules/lru-cache/index.js
+var require_lru_cache2 = __commonJS({
+  "node_modules/semver/node_modules/lru-cache/index.js"(exports2, module2) {
+    "use strict";
+    var Yallist = require_yallist2();
+    var MAX = /* @__PURE__ */ Symbol("max");
+    var LENGTH = /* @__PURE__ */ Symbol("length");
+    var LENGTH_CALCULATOR = /* @__PURE__ */ Symbol("lengthCalculator");
+    var ALLOW_STALE = /* @__PURE__ */ Symbol("allowStale");
+    var MAX_AGE = /* @__PURE__ */ Symbol("maxAge");
+    var DISPOSE = /* @__PURE__ */ Symbol("dispose");
+    var NO_DISPOSE_ON_SET = /* @__PURE__ */ Symbol("noDisposeOnSet");
+    var LRU_LIST = /* @__PURE__ */ Symbol("lruList");
+    var CACHE = /* @__PURE__ */ Symbol("cache");
+    var UPDATE_AGE_ON_GET = /* @__PURE__ */ Symbol("updateAgeOnGet");
+    var naiveLength = () => 1;
+    var LRUCache = class {
+      constructor(options2) {
+        if (typeof options2 === "number")
+          options2 = { max: options2 };
+        if (!options2)
+          options2 = {};
+        if (options2.max && (typeof options2.max !== "number" || options2.max < 0))
+          throw new TypeError("max must be a non-negative number");
+        const max = this[MAX] = options2.max || Infinity;
+        const lc = options2.length || naiveLength;
+        this[LENGTH_CALCULATOR] = typeof lc !== "function" ? naiveLength : lc;
+        this[ALLOW_STALE] = options2.stale || false;
+        if (options2.maxAge && typeof options2.maxAge !== "number")
+          throw new TypeError("maxAge must be a number");
+        this[MAX_AGE] = options2.maxAge || 0;
+        this[DISPOSE] = options2.dispose;
+        this[NO_DISPOSE_ON_SET] = options2.noDisposeOnSet || false;
+        this[UPDATE_AGE_ON_GET] = options2.updateAgeOnGet || false;
+        this.reset();
+      }
+      // resize the cache when the max changes.
+      set max(mL) {
+        if (typeof mL !== "number" || mL < 0)
+          throw new TypeError("max must be a non-negative number");
+        this[MAX] = mL || Infinity;
+        trim(this);
+      }
+      get max() {
+        return this[MAX];
+      }
+      set allowStale(allowStale) {
+        this[ALLOW_STALE] = !!allowStale;
+      }
+      get allowStale() {
+        return this[ALLOW_STALE];
+      }
+      set maxAge(mA) {
+        if (typeof mA !== "number")
+          throw new TypeError("maxAge must be a non-negative number");
+        this[MAX_AGE] = mA;
+        trim(this);
+      }
+      get maxAge() {
+        return this[MAX_AGE];
+      }
+      // resize the cache when the lengthCalculator changes.
+      set lengthCalculator(lC) {
+        if (typeof lC !== "function")
+          lC = naiveLength;
+        if (lC !== this[LENGTH_CALCULATOR]) {
+          this[LENGTH_CALCULATOR] = lC;
+          this[LENGTH] = 0;
+          this[LRU_LIST].forEach((hit) => {
+            hit.length = this[LENGTH_CALCULATOR](hit.value, hit.key);
+            this[LENGTH] += hit.length;
+          });
+        }
+        trim(this);
+      }
+      get lengthCalculator() {
+        return this[LENGTH_CALCULATOR];
+      }
+      get length() {
+        return this[LENGTH];
+      }
+      get itemCount() {
+        return this[LRU_LIST].length;
+      }
+      rforEach(fn, thisp) {
+        thisp = thisp || this;
+        for (let walker = this[LRU_LIST].tail; walker !== null; ) {
+          const prev = walker.prev;
+          forEachStep(this, fn, walker, thisp);
+          walker = prev;
+        }
+      }
+      forEach(fn, thisp) {
+        thisp = thisp || this;
+        for (let walker = this[LRU_LIST].head; walker !== null; ) {
+          const next = walker.next;
+          forEachStep(this, fn, walker, thisp);
+          walker = next;
+        }
+      }
+      keys() {
+        return this[LRU_LIST].toArray().map((k) => k.key);
+      }
+      values() {
+        return this[LRU_LIST].toArray().map((k) => k.value);
+      }
+      reset() {
+        if (this[DISPOSE] && this[LRU_LIST] && this[LRU_LIST].length) {
+          this[LRU_LIST].forEach((hit) => this[DISPOSE](hit.key, hit.value));
+        }
+        this[CACHE] = /* @__PURE__ */ new Map();
+        this[LRU_LIST] = new Yallist();
+        this[LENGTH] = 0;
+      }
+      dump() {
+        return this[LRU_LIST].map((hit) => isStale(this, hit) ? false : {
+          k: hit.key,
+          v: hit.value,
+          e: hit.now + (hit.maxAge || 0)
+        }).toArray().filter((h) => h);
+      }
+      dumpLru() {
+        return this[LRU_LIST];
+      }
+      set(key, value, maxAge) {
+        maxAge = maxAge || this[MAX_AGE];
+        if (maxAge && typeof maxAge !== "number")
+          throw new TypeError("maxAge must be a number");
+        const now = maxAge ? Date.now() : 0;
+        const len = this[LENGTH_CALCULATOR](value, key);
+        if (this[CACHE].has(key)) {
+          if (len > this[MAX]) {
+            del(this, this[CACHE].get(key));
+            return false;
+          }
+          const node = this[CACHE].get(key);
+          const item = node.value;
+          if (this[DISPOSE]) {
+            if (!this[NO_DISPOSE_ON_SET])
+              this[DISPOSE](key, item.value);
+          }
+          item.now = now;
+          item.maxAge = maxAge;
+          item.value = value;
+          this[LENGTH] += len - item.length;
+          item.length = len;
+          this.get(key);
+          trim(this);
+          return true;
+        }
+        const hit = new Entry(key, value, len, now, maxAge);
+        if (hit.length > this[MAX]) {
+          if (this[DISPOSE])
+            this[DISPOSE](key, value);
+          return false;
+        }
+        this[LENGTH] += hit.length;
+        this[LRU_LIST].unshift(hit);
+        this[CACHE].set(key, this[LRU_LIST].head);
+        trim(this);
+        return true;
+      }
+      has(key) {
+        if (!this[CACHE].has(key)) return false;
+        const hit = this[CACHE].get(key).value;
+        return !isStale(this, hit);
+      }
+      get(key) {
+        return get(this, key, true);
+      }
+      peek(key) {
+        return get(this, key, false);
+      }
+      pop() {
+        const node = this[LRU_LIST].tail;
+        if (!node)
+          return null;
+        del(this, node);
+        return node.value;
+      }
+      del(key) {
+        del(this, this[CACHE].get(key));
+      }
+      load(arr) {
+        this.reset();
+        const now = Date.now();
+        for (let l = arr.length - 1; l >= 0; l--) {
+          const hit = arr[l];
+          const expiresAt = hit.e || 0;
+          if (expiresAt === 0)
+            this.set(hit.k, hit.v);
+          else {
+            const maxAge = expiresAt - now;
+            if (maxAge > 0) {
+              this.set(hit.k, hit.v, maxAge);
+            }
+          }
+        }
+      }
+      prune() {
+        this[CACHE].forEach((value, key) => get(this, key, false));
+      }
+    };
+    var get = (self2, key, doUse) => {
+      const node = self2[CACHE].get(key);
+      if (node) {
+        const hit = node.value;
+        if (isStale(self2, hit)) {
+          del(self2, node);
+          if (!self2[ALLOW_STALE])
+            return void 0;
+        } else {
+          if (doUse) {
+            if (self2[UPDATE_AGE_ON_GET])
+              node.value.now = Date.now();
+            self2[LRU_LIST].unshiftNode(node);
+          }
+        }
+        return hit.value;
+      }
+    };
+    var isStale = (self2, hit) => {
+      if (!hit || !hit.maxAge && !self2[MAX_AGE])
+        return false;
+      const diff = Date.now() - hit.now;
+      return hit.maxAge ? diff > hit.maxAge : self2[MAX_AGE] && diff > self2[MAX_AGE];
+    };
+    var trim = (self2) => {
+      if (self2[LENGTH] > self2[MAX]) {
+        for (let walker = self2[LRU_LIST].tail; self2[LENGTH] > self2[MAX] && walker !== null; ) {
+          const prev = walker.prev;
+          del(self2, walker);
+          walker = prev;
+        }
+      }
+    };
+    var del = (self2, node) => {
+      if (node) {
+        const hit = node.value;
+        if (self2[DISPOSE])
+          self2[DISPOSE](hit.key, hit.value);
+        self2[LENGTH] -= hit.length;
+        self2[CACHE].delete(hit.key);
+        self2[LRU_LIST].removeNode(node);
+      }
+    };
+    var Entry = class {
+      constructor(key, value, length, now, maxAge) {
+        this.key = key;
+        this.value = value;
+        this.length = length;
+        this.now = now;
+        this.maxAge = maxAge || 0;
+      }
+    };
+    var forEachStep = (self2, fn, node, thisp) => {
+      let hit = node.value;
+      if (isStale(self2, hit)) {
+        del(self2, node);
+        if (!self2[ALLOW_STALE])
+          hit = void 0;
+      }
+      if (hit)
+        fn.call(thisp, hit.value, hit.key, self2);
+    };
+    module2.exports = LRUCache;
+  }
+});
+
 // node_modules/semver/classes/range.js
 var require_range3 = __commonJS({
   "node_modules/semver/classes/range.js"(exports2, module2) {
@@ -147700,7 +151432,7 @@ var require_range3 = __commonJS({
       }
     };
     module2.exports = Range;
-    var LRU = require_lru_cache();
+    var LRU = require_lru_cache2();
     var cache = new LRU({ max: 1e3 });
     var parseOptions = require_parse_options2();
     var Comparator = require_comparator2();
@@ -150069,16 +153801,16 @@ var require_index_min = __commonJS({
         let e = t.match(n);
         return e ? e[0] : null;
       }, zs = (n, t, e) => {
-        let s, i, r, h, o, a = e.indexOf(n), l = e.indexOf(t, a + 1), u = a;
+        let s, i, r, h, o, a = e.indexOf(n), l = e.indexOf(t, a + 1), f = a;
         if (a >= 0 && l > 0) {
           if (n === t) return [a, l];
-          for (s = [], r = e.length; u >= 0 && !o; ) {
-            if (u === a) s.push(u), a = e.indexOf(n, u + 1);
+          for (s = [], r = e.length; f >= 0 && !o; ) {
+            if (f === a) s.push(f), a = e.indexOf(n, f + 1);
             else if (s.length === 1) {
               let c = s.pop();
               c !== void 0 && (o = [c, l]);
-            } else i = s.pop(), i !== void 0 && i < r && (r = i, h = l), l = e.indexOf(t, u + 1);
-            u = a < l && a >= 0 ? a : l;
+            } else i = s.pop(), i !== void 0 && i < r && (r = i, h = l), l = e.indexOf(t, f + 1);
+            f = a < l && a >= 0 ? a : l;
           }
           s.length && h !== void 0 && (o = [r, h]);
         }
@@ -150137,18 +153869,18 @@ var require_index_min = __commonJS({
           s.push(a);
         }
         else {
-          let o = /^-?\d+\.\.-?\d+(?:\.\.-?\d+)?$/.test(i.body), a = /^[a-zA-Z]\.\.[a-zA-Z](?:\.\.-?\d+)?$/.test(i.body), l = o || a, u = i.body.indexOf(",") >= 0;
-          if (!l && !u) return i.post.match(/,(?!,).*\}/) ? (n = i.pre + "{" + i.body + ue + i.post, ht(n, t, true)) : [n];
+          let o = /^-?\d+\.\.-?\d+(?:\.\.-?\d+)?$/.test(i.body), a = /^[a-zA-Z]\.\.[a-zA-Z](?:\.\.-?\d+)?$/.test(i.body), l = o || a, f = i.body.indexOf(",") >= 0;
+          if (!l && !f) return i.post.match(/,(?!,).*\}/) ? (n = i.pre + "{" + i.body + ue + i.post, ht(n, t, true)) : [n];
           let c;
           if (l) c = i.body.split(/\.\./);
-          else if (c = Ve(i.body), c.length === 1 && c[0] !== void 0 && (c = ht(c[0], t, false).map(si), c.length === 1)) return h.map((f) => i.pre + c[0] + f);
+          else if (c = Ve(i.body), c.length === 1 && c[0] !== void 0 && (c = ht(c[0], t, false).map(si), c.length === 1)) return h.map((u) => i.pre + c[0] + u);
           let d;
           if (l && c[0] !== void 0 && c[1] !== void 0) {
-            let f = ce(c[0]), m = ce(c[1]), p = Math.max(c[0].length, c[1].length), b = c.length === 3 && c[2] !== void 0 ? Math.abs(ce(c[2])) : 1, w = ri;
-            m < f && (b *= -1, w = ni);
+            let u = ce(c[0]), m = ce(c[1]), p = Math.max(c[0].length, c[1].length), b = c.length === 3 && c[2] !== void 0 ? Math.abs(ce(c[2])) : 1, w = ri;
+            m < u && (b *= -1, w = ni);
             let E = c.some(ii);
             d = [];
-            for (let y = f; w(y, m); y += b) {
+            for (let y = u; w(y, m); y += b) {
               let S;
               if (a) S = String.fromCharCode(y), S === "\\" && (S = "");
               else if (S = String(y), E) {
@@ -150162,25 +153894,25 @@ var require_index_min = __commonJS({
             }
           } else {
             d = [];
-            for (let f = 0; f < c.length; f++) d.push.apply(d, ht(c[f], t, false));
+            for (let u = 0; u < c.length; u++) d.push.apply(d, ht(c[u], t, false));
           }
-          for (let f = 0; f < d.length; f++) for (let m = 0; m < h.length && s.length < t; m++) {
-            let p = r + d[f] + h[m];
+          for (let u = 0; u < d.length; u++) for (let m = 0; m < h.length && s.length < t; m++) {
+            let p = r + d[u] + h[m];
             (!e || l || p) && s.push(p);
           }
         }
         return s;
       }
     });
-    var Xe = R((xt) => {
+    var Xe = R((Ct) => {
       "use strict";
-      Object.defineProperty(xt, "__esModule", { value: true });
-      xt.assertValidPattern = void 0;
+      Object.defineProperty(Ct, "__esModule", { value: true });
+      Ct.assertValidPattern = void 0;
       var hi = 1024 * 64, oi = (n) => {
         if (typeof n != "string") throw new TypeError("invalid pattern");
         if (n.length > hi) throw new TypeError("pattern is too long");
       };
-      xt.assertValidPattern = oi;
+      Ct.assertValidPattern = oi;
     });
     var Je = R((Rt) => {
       "use strict";
@@ -150189,7 +153921,7 @@ var require_index_min = __commonJS({
       var ai = { "[:alnum:]": ["\\p{L}\\p{Nl}\\p{Nd}", true], "[:alpha:]": ["\\p{L}\\p{Nl}", true], "[:ascii:]": ["\\x00-\\x7f", false], "[:blank:]": ["\\p{Zs}\\t", true], "[:cntrl:]": ["\\p{Cc}", true], "[:digit:]": ["\\p{Nd}", true], "[:graph:]": ["\\p{Z}\\p{C}", true, true], "[:lower:]": ["\\p{Ll}", true], "[:print:]": ["\\p{C}", true], "[:punct:]": ["\\p{P}", true], "[:space:]": ["\\p{Z}\\t\\r\\n\\v\\f", true], "[:upper:]": ["\\p{Lu}", true], "[:word:]": ["\\p{L}\\p{Nl}\\p{Nd}\\p{Pc}", true], "[:xdigit:]": ["A-Fa-f0-9", false] }, ot = (n) => n.replace(/[[\]\\-]/g, "\\$&"), li = (n) => n.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"), Ye = (n) => n.join(""), ci = (n, t) => {
         let e = t;
         if (n.charAt(e) !== "[") throw new Error("not in a brace expression");
-        let s = [], i = [], r = e + 1, h = false, o = false, a = false, l = false, u = e, c = "";
+        let s = [], i = [], r = e + 1, h = false, o = false, a = false, l = false, f = e, c = "";
         t: for (; r < n.length; ) {
           let p = n.charAt(r);
           if ((p === "!" || p === "^") && r === e + 1) {
@@ -150197,7 +153929,7 @@ var require_index_min = __commonJS({
             continue;
           }
           if (p === "]" && h && !a) {
-            u = r + 1;
+            f = r + 1;
             break;
           }
           if (h = true, p === "\\" && !a) {
@@ -150225,14 +153957,14 @@ var require_index_min = __commonJS({
           }
           s.push(ot(p)), r++;
         }
-        if (u < r) return ["", false, 0, false];
+        if (f < r) return ["", false, 0, false];
         if (!s.length && !i.length) return ["$.", false, n.length - e, true];
         if (i.length === 0 && s.length === 1 && /^\\?.$/.test(s[0]) && !l) {
           let p = s[0].length === 2 ? s[0].slice(-1) : s[0];
-          return [li(p), false, u - e, false];
+          return [li(p), false, f - e, false];
         }
-        let d = "[" + (l ? "^" : "") + Ye(s) + "]", f = "[" + (l ? "" : "^") + Ye(i) + "]";
-        return [s.length && i.length ? "(" + d + "|" + f + ")" : s.length ? d : f, o, u - e, true];
+        let d = "[" + (l ? "^" : "") + Ye(s) + "]", u = "[" + (l ? "" : "^") + Ye(i) + "]";
+        return [s.length && i.length ? "(" + d + "|" + u + ")" : s.length ? d : u, o, f - e, true];
       };
       Rt.parseClass = ci;
     });
@@ -150328,56 +154060,56 @@ var require_index_min = __commonJS({
         static #i(t, e, s, i) {
           let r = false, h = false, o = -1, a = false;
           if (e.type === null) {
-            let f = s, m = "";
-            for (; f < t.length; ) {
-              let p = t.charAt(f++);
+            let u = s, m = "";
+            for (; u < t.length; ) {
+              let p = t.charAt(u++);
               if (r || p === "\\") {
                 r = !r, m += p;
                 continue;
               }
               if (h) {
-                f === o + 1 ? (p === "^" || p === "!") && (a = true) : p === "]" && !(f === o + 2 && a) && (h = false), m += p;
+                u === o + 1 ? (p === "^" || p === "!") && (a = true) : p === "]" && !(u === o + 2 && a) && (h = false), m += p;
                 continue;
               } else if (p === "[") {
-                h = true, o = f, a = false, m += p;
+                h = true, o = u, a = false, m += p;
                 continue;
               }
-              if (!i.noext && Ze(p) && t.charAt(f) === "(") {
+              if (!i.noext && Ze(p) && t.charAt(u) === "(") {
                 e.push(m), m = "";
                 let b = new n(p, e);
-                f = n.#i(t, b, f, i), e.push(b);
+                u = n.#i(t, b, u, i), e.push(b);
                 continue;
               }
               m += p;
             }
-            return e.push(m), f;
+            return e.push(m), u;
           }
-          let l = s + 1, u = new n(null, e), c = [], d = "";
+          let l = s + 1, f = new n(null, e), c = [], d = "";
           for (; l < t.length; ) {
-            let f = t.charAt(l++);
-            if (r || f === "\\") {
-              r = !r, d += f;
+            let u = t.charAt(l++);
+            if (r || u === "\\") {
+              r = !r, d += u;
               continue;
             }
             if (h) {
-              l === o + 1 ? (f === "^" || f === "!") && (a = true) : f === "]" && !(l === o + 2 && a) && (h = false), d += f;
+              l === o + 1 ? (u === "^" || u === "!") && (a = true) : u === "]" && !(l === o + 2 && a) && (h = false), d += u;
               continue;
-            } else if (f === "[") {
-              h = true, o = l, a = false, d += f;
-              continue;
-            }
-            if (Ze(f) && t.charAt(l) === "(") {
-              u.push(d), d = "";
-              let m = new n(f, u);
-              u.push(m), l = n.#i(t, m, l, i);
+            } else if (u === "[") {
+              h = true, o = l, a = false, d += u;
               continue;
             }
-            if (f === "|") {
-              u.push(d), d = "", c.push(u), u = new n(null, e);
+            if (Ze(u) && t.charAt(l) === "(") {
+              f.push(d), d = "";
+              let m = new n(u, f);
+              f.push(m), l = n.#i(t, m, l, i);
               continue;
             }
-            if (f === ")") return d === "" && e.#r.length === 0 && (e.#u = true), u.push(d), d = "", e.push(...c, u), l;
-            d += f;
+            if (u === "|") {
+              f.push(d), d = "", c.push(f), f = new n(null, e);
+              continue;
+            }
+            if (u === ")") return d === "" && e.#r.length === 0 && (e.#u = true), f.push(d), d = "", e.push(...c, f), l;
+            d += u;
           }
           return e.type = null, e.#s = void 0, e.#r = [t.substring(s - 1)], l;
         }
@@ -150398,16 +154130,16 @@ var require_index_min = __commonJS({
         toRegExpSource(t) {
           let e = t ?? !!this.#o.dot;
           if (this.#t === this && this.#a(), !this.type) {
-            let a = this.isStart() && this.isEnd() && !this.#r.some((f) => typeof f != "string"), l = this.#r.map((f) => {
-              let [m, p, b, w] = typeof f == "string" ? n.#v(f, this.#s, a) : f.toRegExpSource(t);
+            let a = this.isStart() && this.isEnd() && !this.#r.some((u) => typeof u != "string"), l = this.#r.map((u) => {
+              let [m, p, b, w] = typeof u == "string" ? n.#v(u, this.#s, a) : u.toRegExpSource(t);
               return this.#s = this.#s || b, this.#n = this.#n || w, m;
-            }).join(""), u = "";
+            }).join(""), f = "";
             if (this.isStart() && typeof this.#r[0] == "string" && !(this.#r.length === 1 && gi.has(this.#r[0]))) {
               let m = mi, p = e && m.has(l.charAt(0)) || l.startsWith("\\.") && m.has(l.charAt(2)) || l.startsWith("\\.\\.") && m.has(l.charAt(4)), b = !e && !t && m.has(l.charAt(0));
-              u = p ? pi : b ? Pt : "";
+              f = p ? pi : b ? Pt : "";
             }
             let c = "";
-            return this.isEnd() && this.#t.#c && this.#h?.type === "!" && (c = "(?:$|\\/)"), [u + l + c, (0, Mt.unescape)(l), this.#s = !!this.#s, this.#n];
+            return this.isEnd() && this.#t.#c && this.#h?.type === "!" && (c = "(?:$|\\/)"), [f + l + c, (0, Mt.unescape)(l), this.#s = !!this.#s, this.#n];
           }
           let s = this.type === "*" || this.type === "+", i = this.type === "!" ? "(?:(?!(?:" : "(?:", r = this.#d(e);
           if (this.isStart() && this.isEnd() && !r && this.type !== "!") {
@@ -150432,33 +154164,34 @@ var require_index_min = __commonJS({
           }).filter((e) => !(this.isStart() && this.isEnd()) || !!e).join("|");
         }
         static #v(t, e, s = false) {
-          let i = false, r = "", h = false;
-          for (let o = 0; o < t.length; o++) {
-            let a = t.charAt(o);
+          let i = false, r = "", h = false, o = false;
+          for (let a = 0; a < t.length; a++) {
+            let l = t.charAt(a);
             if (i) {
-              i = false, r += (wi.has(a) ? "\\" : "") + a;
+              i = false, r += (wi.has(l) ? "\\" : "") + l;
               continue;
             }
-            if (a === "\\") {
-              o === t.length - 1 ? r += "\\\\" : i = true;
+            if (l === "*") {
+              if (o) continue;
+              o = true, r += s && /^[*]+$/.test(t) ? ts : Qe, e = true;
+              continue;
+            } else o = false;
+            if (l === "\\") {
+              a === t.length - 1 ? r += "\\\\" : i = true;
               continue;
             }
-            if (a === "[") {
-              let [l, u, c, d] = (0, fi.parseClass)(t, o);
-              if (c) {
-                r += l, h = h || u, o += c - 1, e = e || d;
+            if (l === "[") {
+              let [f, c, d, u] = (0, fi.parseClass)(t, a);
+              if (d) {
+                r += f, h = h || c, a += d - 1, e = e || u;
                 continue;
               }
             }
-            if (a === "*") {
-              r += s && t === "*" ? ts : Qe, e = true;
-              continue;
-            }
-            if (a === "?") {
+            if (l === "?") {
               r += de, e = true;
               continue;
             }
-            r += bi(a);
+            r += bi(l);
           }
           return [r, (0, Mt.unescape)(t), !!e, h];
         }
@@ -150478,7 +154211,7 @@ var require_index_min = __commonJS({
       g.unescape = g.escape = g.AST = g.Minimatch = g.match = g.makeRe = g.braceExpand = g.defaults = g.filter = g.GLOBSTAR = g.sep = g.minimatch = void 0;
       var Si = Ke(), jt = Xe(), is = pe(), vi = me(), Ei = kt(), _i = (n, t, e = {}) => ((0, jt.assertValidPattern)(t), !e.nocomment && t.charAt(0) === "#" ? false : new J(t, e).match(n));
       g.minimatch = _i;
-      var Oi = /^\*+([^+@!?\*\[\(]*)$/, Ti = (n) => (t) => !t.startsWith(".") && t.endsWith(n), Ci = (n) => (t) => t.endsWith(n), xi = (n) => (n = n.toLowerCase(), (t) => !t.startsWith(".") && t.toLowerCase().endsWith(n)), Ri = (n) => (n = n.toLowerCase(), (t) => t.toLowerCase().endsWith(n)), Ai = /^\*+\.\*+$/, ki = (n) => !n.startsWith(".") && n.includes("."), Mi = (n) => n !== "." && n !== ".." && n.includes("."), Pi = /^\.\*+$/, Di = (n) => n !== "." && n !== ".." && n.startsWith("."), Fi = /^\*+$/, ji = (n) => n.length !== 0 && !n.startsWith("."), Ni = (n) => n.length !== 0 && n !== "." && n !== "..", Li = /^\?+([^+@!?\*\[\(]*)?$/, Wi = ([n, t = ""]) => {
+      var Oi = /^\*+([^+@!?\*\[\(]*)$/, xi = (n) => (t) => !t.startsWith(".") && t.endsWith(n), Ti = (n) => (t) => t.endsWith(n), Ci = (n) => (n = n.toLowerCase(), (t) => !t.startsWith(".") && t.toLowerCase().endsWith(n)), Ri = (n) => (n = n.toLowerCase(), (t) => t.toLowerCase().endsWith(n)), Ai = /^\*+\.\*+$/, ki = (n) => !n.startsWith(".") && n.includes("."), Mi = (n) => n !== "." && n !== ".." && n.includes("."), Pi = /^\.\*+$/, Di = (n) => n !== "." && n !== ".." && n.startsWith("."), Fi = /^\*+$/, ji = (n) => n.length !== 0 && !n.startsWith("."), Ni = (n) => n.length !== 0 && n !== "." && n !== "..", Li = /^\?+([^+@!?\*\[\(]*)?$/, Wi = ([n, t = ""]) => {
         let e = rs([n]);
         return t ? (t = t.toLowerCase(), (s) => e(s) && s.toLowerCase().endsWith(t)) : e;
       }, Bi = ([n, t = ""]) => {
@@ -150525,7 +154258,7 @@ var require_index_min = __commonJS({
       };
       g.defaults = Vi;
       g.minimatch.defaults = g.defaults;
-      var Ki = (n, t = {}) => ((0, jt.assertValidPattern)(n), t.nobrace || !/\{(?:(?!\{).)*\}/.test(n) ? [n] : (0, Si.expand)(n));
+      var Ki = (n, t = {}) => ((0, jt.assertValidPattern)(n), t.nobrace || !/\{(?:(?!\{).)*\}/.test(n) ? [n] : (0, Si.expand)(n, { max: t.braceExpandMax }));
       g.braceExpand = Ki;
       g.minimatch.braceExpand = g.braceExpand;
       var Xi = (n, t = {}) => new J(n, t).makeRe();
@@ -150556,7 +154289,9 @@ var require_index_min = __commonJS({
         windowsNoMagicRoot;
         regexp;
         constructor(t, e = {}) {
-          (0, jt.assertValidPattern)(t), e = e || {}, this.options = e, this.pattern = t, this.platform = e.platform || hs, this.isWindows = this.platform === "win32", this.windowsPathsNoEscape = !!e.windowsPathsNoEscape || e.allowWindowsEscape === false, this.windowsPathsNoEscape && (this.pattern = this.pattern.replace(/\\/g, "/")), this.preserveMultipleSlashes = !!e.preserveMultipleSlashes, this.regexp = null, this.negate = false, this.nonegate = !!e.nonegate, this.comment = false, this.empty = false, this.partial = !!e.partial, this.nocase = !!this.options.nocase, this.windowsNoMagicRoot = e.windowsNoMagicRoot !== void 0 ? e.windowsNoMagicRoot : !!(this.isWindows && this.nocase), this.globSet = [], this.globParts = [], this.set = [], this.make();
+          (0, jt.assertValidPattern)(t), e = e || {}, this.options = e, this.pattern = t, this.platform = e.platform || hs, this.isWindows = this.platform === "win32";
+          let s = "allowWindowsEscape";
+          this.windowsPathsNoEscape = !!e.windowsPathsNoEscape || e[s] === false, this.windowsPathsNoEscape && (this.pattern = this.pattern.replace(/\\/g, "/")), this.preserveMultipleSlashes = !!e.preserveMultipleSlashes, this.regexp = null, this.negate = false, this.nonegate = !!e.nonegate, this.comment = false, this.empty = false, this.partial = !!e.partial, this.nocase = !!this.options.nocase, this.windowsNoMagicRoot = e.windowsNoMagicRoot !== void 0 ? e.windowsNoMagicRoot : !!(this.isWindows && this.nocase), this.globSet = [], this.globParts = [], this.set = [], this.make();
         }
         hasMagic() {
           if (this.options.magicalBraces && this.set.length > 1) return true;
@@ -150581,8 +154316,8 @@ var require_index_min = __commonJS({
           let i = this.globParts.map((r, h, o) => {
             if (this.isWindows && this.windowsNoMagicRoot) {
               let a = r[0] === "" && r[1] === "" && (r[2] === "?" || !ss.test(r[2])) && !ss.test(r[3]), l = /^[a-z]:/i.test(r[0]);
-              if (a) return [...r.slice(0, 4), ...r.slice(4).map((u) => this.parse(u))];
-              if (l) return [r[0], ...r.slice(1).map((u) => this.parse(u))];
+              if (a) return [...r.slice(0, 4), ...r.slice(4).map((f) => this.parse(f))];
+              if (l) return [r[0], ...r.slice(1).map((f) => this.parse(f))];
             }
             return r.map((a) => this.parse(a));
           });
@@ -150646,8 +154381,8 @@ var require_index_min = __commonJS({
                 let o = s[i + 1], a = s[i + 2], l = s[i + 3];
                 if (o !== ".." || !a || a === "." || a === ".." || !l || l === "." || l === "..") continue;
                 e = true, s.splice(i, 1);
-                let u = s.slice(0);
-                u[i] = "**", t.push(u), i--;
+                let f = s.slice(0);
+                f[i] = "**", t.push(f), i--;
               }
               if (!this.preserveMultipleSlashes) {
                 for (let h = 1; h < s.length - 1; h++) {
@@ -150712,30 +154447,30 @@ var require_index_min = __commonJS({
           r >= 2 && (t = this.levelTwoFileOptimize(t)), this.debug("matchOne", this, { file: t, pattern: e }), this.debug("matchOne", t.length, e.length);
           for (var h = 0, o = 0, a = t.length, l = e.length; h < a && o < l; h++, o++) {
             this.debug("matchOne loop");
-            var u = e[o], c = t[h];
-            if (this.debug(e, u, c), u === false) return false;
-            if (u === g.GLOBSTAR) {
-              this.debug("GLOBSTAR", [e, u, c]);
-              var d = h, f = o + 1;
-              if (f === l) {
+            var f = e[o], c = t[h];
+            if (this.debug(e, f, c), f === false) return false;
+            if (f === g.GLOBSTAR) {
+              this.debug("GLOBSTAR", [e, f, c]);
+              var d = h, u = o + 1;
+              if (u === l) {
                 for (this.debug("** at the end"); h < a; h++) if (t[h] === "." || t[h] === ".." || !i.dot && t[h].charAt(0) === ".") return false;
                 return true;
               }
               for (; d < a; ) {
                 var m = t[d];
                 if (this.debug(`
-globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) return this.debug("globstar found match!", d, a, m), true;
+globstar while`, t, d, e, u, m), this.matchOne(t.slice(d), e.slice(u), s)) return this.debug("globstar found match!", d, a, m), true;
                 if (m === "." || m === ".." || !i.dot && m.charAt(0) === ".") {
-                  this.debug("dot detected!", t, d, e, f);
+                  this.debug("dot detected!", t, d, e, u);
                   break;
                 }
                 this.debug("globstar swallow a segment, and continue"), d++;
               }
               return !!(s && (this.debug(`
->>> no match, partial?`, t, d, e, f), d === a));
+>>> no match, partial?`, t, d, e, u), d === a));
             }
             let p;
-            if (typeof u == "string" ? (p = c === u, this.debug("string match", u, c, p)) : (p = u.test(c), this.debug("pattern match", u, c, p)), !p) return false;
+            if (typeof f == "string" ? (p = c === f, this.debug("string match", f, c, p)) : (p = f.test(c), this.debug("pattern match", f, c, p)), !p) return false;
           }
           if (h === a && o === l) return true;
           if (h === a) return s;
@@ -150751,7 +154486,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           if (t === "**") return g.GLOBSTAR;
           if (t === "") return "";
           let s, i = null;
-          (s = t.match(Fi)) ? i = e.dot ? Ni : ji : (s = t.match(Oi)) ? i = (e.nocase ? e.dot ? Ri : xi : e.dot ? Ci : Ti)(s[1]) : (s = t.match(Li)) ? i = (e.nocase ? e.dot ? Bi : Wi : e.dot ? Ii : Gi)(s) : (s = t.match(Ai)) ? i = e.dot ? Mi : ki : (s = t.match(Pi)) && (i = Di);
+          (s = t.match(Fi)) ? i = e.dot ? Ni : ji : (s = t.match(Oi)) ? i = (e.nocase ? e.dot ? Ri : Ci : e.dot ? Ti : xi)(s[1]) : (s = t.match(Li)) ? i = (e.nocase ? e.dot ? Bi : Wi : e.dot ? Ii : Gi)(s) : (s = t.match(Ai)) ? i = e.dot ? Mi : ki : (s = t.match(Pi)) && (i = Di);
           let r = is.AST.fromGlob(t, this.options).toMMPattern();
           return i && typeof r == "object" && Reflect.defineProperty(r, "test", { value: i }), r;
         }
@@ -150765,16 +154500,16 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
               return typeof c == "string" ? Ji(c) : c === g.GLOBSTAR ? g.GLOBSTAR : c._src;
             });
             l.forEach((c, d) => {
-              let f = l[d + 1], m = l[d - 1];
-              c !== g.GLOBSTAR || m === g.GLOBSTAR || (m === void 0 ? f !== void 0 && f !== g.GLOBSTAR ? l[d + 1] = "(?:\\/|" + s + "\\/)?" + f : l[d] = s : f === void 0 ? l[d - 1] = m + "(?:\\/|\\/" + s + ")?" : f !== g.GLOBSTAR && (l[d - 1] = m + "(?:\\/|\\/" + s + "\\/)" + f, l[d + 1] = g.GLOBSTAR));
+              let u = l[d + 1], m = l[d - 1];
+              c !== g.GLOBSTAR || m === g.GLOBSTAR || (m === void 0 ? u !== void 0 && u !== g.GLOBSTAR ? l[d + 1] = "(?:\\/|" + s + "\\/)?" + u : l[d] = s : u === void 0 ? l[d - 1] = m + "(?:\\/|\\/" + s + ")?" : u !== g.GLOBSTAR && (l[d - 1] = m + "(?:\\/|\\/" + s + "\\/)" + u, l[d + 1] = g.GLOBSTAR));
             });
-            let u = l.filter((c) => c !== g.GLOBSTAR);
-            if (this.partial && u.length >= 1) {
+            let f = l.filter((c) => c !== g.GLOBSTAR);
+            if (this.partial && f.length >= 1) {
               let c = [];
-              for (let d = 1; d <= u.length; d++) c.push(u.slice(0, d).join("/"));
+              for (let d = 1; d <= f.length; d++) c.push(f.slice(0, d).join("/"));
               return "(?:" + c.join("|") + ")";
             }
-            return u.join("/");
+            return f.join("/");
           }).join("|"), [h, o] = t.length > 1 ? ["(?:", ")"] : ["", ""];
           r = "^" + h + r + o + "$", this.partial && (r = "^(?:\\/|" + h + r.slice(1, -1) + o + ")$"), this.negate && (r = "^(?!" + r + ").+$");
           try {
@@ -150924,15 +154659,15 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
         #R;
         #m;
         #O;
-        #T;
+        #x;
         #g;
         #b;
         #E;
-        #C;
+        #T;
         #e;
         #F;
         static unsafeExposeInternals(t) {
-          return { starts: t.#T, ttls: t.#g, autopurgeTimers: t.#b, sizes: t.#O, keyMap: t.#u, keyList: t.#a, valList: t.#i, next: t.#d, prev: t.#v, get head() {
+          return { starts: t.#x, ttls: t.#g, autopurgeTimers: t.#b, sizes: t.#O, keyMap: t.#u, keyList: t.#a, valList: t.#i, next: t.#d, prev: t.#v, get head() {
             return t.#y;
           }, get tail() {
             return t.#p;
@@ -150966,7 +154701,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           return this.#h;
         }
         constructor(t) {
-          let { max: e = 0, ttl: s, ttlResolution: i = 1, ttlAutopurge: r, updateAgeOnGet: h, updateAgeOnHas: o, allowStale: a, dispose: l, onInsert: u, disposeAfter: c, noDisposeOnSet: d, noUpdateTTL: f, maxSize: m = 0, maxEntrySize: p = 0, sizeCalculation: b, fetchMethod: w, memoMethod: v, noDeleteOnFetchRejection: E, noDeleteOnStaleGet: y, allowStaleOnFetchRejection: S, allowStaleOnFetchAbort: B, ignoreFetchAbort: U, perf: et } = t;
+          let { max: e = 0, ttl: s, ttlResolution: i = 1, ttlAutopurge: r, updateAgeOnGet: h, updateAgeOnHas: o, allowStale: a, dispose: l, onInsert: f, disposeAfter: c, noDisposeOnSet: d, noUpdateTTL: u, maxSize: m = 0, maxEntrySize: p = 0, sizeCalculation: b, fetchMethod: w, memoMethod: v, noDeleteOnFetchRejection: E, noDeleteOnStaleGet: y, allowStaleOnFetchRejection: S, allowStaleOnFetchAbort: B, ignoreFetchAbort: U, perf: et } = t;
           if (et !== void 0 && typeof et?.now != "function") throw new TypeError("perf option must have a now() method if specified");
           if (this.#c = et ?? er, e !== 0 && !V(e)) throw new TypeError("max option must be a nonnegative integer");
           let st = e ? cs(e) : Array;
@@ -150977,7 +154712,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           }
           if (v !== void 0 && typeof v != "function") throw new TypeError("memoMethod must be a function if defined");
           if (this.#w = v, w !== void 0 && typeof w != "function") throw new TypeError("fetchMethod must be a function if specified");
-          if (this.#S = w, this.#C = !!w, this.#u = /* @__PURE__ */ new Map(), this.#a = new Array(e).fill(void 0), this.#i = new Array(e).fill(void 0), this.#d = new st(e), this.#v = new st(e), this.#y = 0, this.#p = 0, this.#R = ir.create(e), this.#o = 0, this.#f = 0, typeof l == "function" && (this.#n = l), typeof u == "function" && (this.#r = u), typeof c == "function" ? (this.#h = c, this.#m = []) : (this.#h = void 0, this.#m = void 0), this.#E = !!this.#n, this.#F = !!this.#r, this.#e = !!this.#h, this.noDisposeOnSet = !!d, this.noUpdateTTL = !!f, this.noDeleteOnFetchRejection = !!E, this.allowStaleOnFetchRejection = !!S, this.allowStaleOnFetchAbort = !!B, this.ignoreFetchAbort = !!U, this.maxEntrySize !== 0) {
+          if (this.#S = w, this.#T = !!w, this.#u = /* @__PURE__ */ new Map(), this.#a = new Array(e).fill(void 0), this.#i = new Array(e).fill(void 0), this.#d = new st(e), this.#v = new st(e), this.#y = 0, this.#p = 0, this.#R = ir.create(e), this.#o = 0, this.#f = 0, typeof l == "function" && (this.#n = l), typeof f == "function" && (this.#r = f), typeof c == "function" ? (this.#h = c, this.#m = []) : (this.#h = void 0, this.#m = void 0), this.#E = !!this.#n, this.#F = !!this.#r, this.#e = !!this.#h, this.noDisposeOnSet = !!d, this.noUpdateTTL = !!u, this.noDeleteOnFetchRejection = !!E, this.allowStaleOnFetchRejection = !!S, this.allowStaleOnFetchAbort = !!B, this.ignoreFetchAbort = !!U, this.maxEntrySize !== 0) {
             if (this.#s !== 0 && !V(this.#s)) throw new TypeError("maxSize must be a positive integer if specified");
             if (!V(this.maxEntrySize)) throw new TypeError("maxEntrySize must be a positive integer if specified");
             this.#$();
@@ -150997,7 +154732,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
         }
         #P() {
           let t = new Nt(this.#t), e = new Nt(this.#t);
-          this.#g = t, this.#T = e;
+          this.#g = t, this.#x = e;
           let s = this.ttlAutopurge ? new Array(this.#t) : void 0;
           this.#b = s, this.#W = (h, o, a = this.#c.now()) => {
             if (e[h] = o !== 0 ? a : 0, t[h] = o, s?.[h] && (clearTimeout(s[h]), s[h] = void 0), o !== 0 && s) {
@@ -151006,15 +154741,15 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
               }, o + 1);
               l.unref && l.unref(), s[h] = l;
             }
-          }, this.#x = (h) => {
+          }, this.#C = (h) => {
             e[h] = t[h] !== 0 ? this.#c.now() : 0;
           }, this.#D = (h, o) => {
             if (t[o]) {
               let a = t[o], l = e[o];
               if (!a || !l) return;
               h.ttl = a, h.start = l, h.now = i || r();
-              let u = h.now - l;
-              h.remainingTTL = a - u;
+              let f = h.now - l;
+              h.remainingTTL = a - f;
             }
           };
           let i = 0, r = () => {
@@ -151031,14 +154766,14 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
             if (o === void 0) return 0;
             let a = t[o], l = e[o];
             if (!a || !l) return 1 / 0;
-            let u = (i || r()) - l;
-            return a - u;
+            let f = (i || r()) - l;
+            return a - f;
           }, this.#_ = (h) => {
             let o = e[h], a = t[h];
             return !!a && !!o && (i || r()) - o > a;
           };
         }
-        #x = () => {
+        #C = () => {
         };
         #D = () => {
         };
@@ -151138,8 +154873,8 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           let s = this.#i[e], i = this.#l(s) ? s.__staleWhileFetching : s;
           if (i === void 0) return;
           let r = { value: i };
-          if (this.#g && this.#T) {
-            let h = this.#g[e], o = this.#T[e];
+          if (this.#g && this.#x) {
+            let h = this.#g[e], o = this.#x[e];
             if (h && o) {
               let a = h - (this.#c.now() - o);
               r.ttl = a, r.start = Date.now();
@@ -151153,9 +154888,9 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
             let s = this.#a[e], i = this.#i[e], r = this.#l(i) ? i.__staleWhileFetching : i;
             if (r === void 0 || s === void 0) continue;
             let h = { value: r };
-            if (this.#g && this.#T) {
+            if (this.#g && this.#x) {
               h.ttl = this.#g[e];
-              let o = this.#c.now() - this.#T[e];
+              let o = this.#c.now() - this.#x[e];
               h.start = Math.floor(Date.now() - o);
             }
             this.#O && (h.size = this.#O[e]), t.unshift([s, h]);
@@ -151174,30 +154909,30 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
         }
         set(t, e, s = {}) {
           if (e === void 0) return this.delete(t), this;
-          let { ttl: i = this.ttl, start: r, noDisposeOnSet: h = this.noDisposeOnSet, sizeCalculation: o = this.sizeCalculation, status: a } = s, { noUpdateTTL: l = this.noUpdateTTL } = s, u = this.#B(t, e, s.size || 0, o);
-          if (this.maxEntrySize && u > this.maxEntrySize) return a && (a.set = "miss", a.maxEntrySizeExceeded = true), this.#A(t, "set"), this;
+          let { ttl: i = this.ttl, start: r, noDisposeOnSet: h = this.noDisposeOnSet, sizeCalculation: o = this.sizeCalculation, status: a } = s, { noUpdateTTL: l = this.noUpdateTTL } = s, f = this.#B(t, e, s.size || 0, o);
+          if (this.maxEntrySize && f > this.maxEntrySize) return a && (a.set = "miss", a.maxEntrySizeExceeded = true), this.#A(t, "set"), this;
           let c = this.#o === 0 ? void 0 : this.#u.get(t);
-          if (c === void 0) c = this.#o === 0 ? this.#p : this.#R.length !== 0 ? this.#R.pop() : this.#o === this.#t ? this.#G(false) : this.#o, this.#a[c] = t, this.#i[c] = e, this.#u.set(t, c), this.#d[this.#p] = c, this.#v[c] = this.#p, this.#p = c, this.#o++, this.#j(c, u, a), a && (a.set = "add"), l = false, this.#F && this.#r?.(e, t, "add");
+          if (c === void 0) c = this.#o === 0 ? this.#p : this.#R.length !== 0 ? this.#R.pop() : this.#o === this.#t ? this.#G(false) : this.#o, this.#a[c] = t, this.#i[c] = e, this.#u.set(t, c), this.#d[this.#p] = c, this.#v[c] = this.#p, this.#p = c, this.#o++, this.#j(c, f, a), a && (a.set = "add"), l = false, this.#F && this.#r?.(e, t, "add");
           else {
             this.#N(c);
             let d = this.#i[c];
             if (e !== d) {
-              if (this.#C && this.#l(d)) {
+              if (this.#T && this.#l(d)) {
                 d.__abortController.abort(new Error("replaced"));
-                let { __staleWhileFetching: f } = d;
-                f !== void 0 && !h && (this.#E && this.#n?.(f, t, "set"), this.#e && this.#m?.push([f, t, "set"]));
+                let { __staleWhileFetching: u } = d;
+                u !== void 0 && !h && (this.#E && this.#n?.(u, t, "set"), this.#e && this.#m?.push([u, t, "set"]));
               } else h || (this.#E && this.#n?.(d, t, "set"), this.#e && this.#m?.push([d, t, "set"]));
-              if (this.#L(c), this.#j(c, u, a), this.#i[c] = e, a) {
+              if (this.#L(c), this.#j(c, f, a), this.#i[c] = e, a) {
                 a.set = "replace";
-                let f = d && this.#l(d) ? d.__staleWhileFetching : d;
-                f !== void 0 && (a.oldValue = f);
+                let u = d && this.#l(d) ? d.__staleWhileFetching : d;
+                u !== void 0 && (a.oldValue = u);
               }
             } else a && (a.set = "update");
             this.#F && this.onInsert?.(e, t, e === d ? "update" : "replace");
           }
           if (i !== 0 && !this.#g && this.#P(), this.#g && (l || this.#W(c, i, r), a && this.#D(a, c)), !h && this.#e && this.#m) {
-            let d = this.#m, f;
-            for (; f = d?.shift(); ) this.#h?.(...f);
+            let d = this.#m, u;
+            for (; u = d?.shift(); ) this.#h?.(...u);
           }
           return this;
         }
@@ -151218,7 +154953,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
         }
         #G(t) {
           let e = this.#y, s = this.#a[e], i = this.#i[e];
-          return this.#C && this.#l(i) ? i.__abortController.abort(new Error("evicted")) : (this.#E || this.#e) && (this.#E && this.#n?.(i, s, "evict"), this.#e && this.#m?.push([i, s, "evict"])), this.#L(e), this.#b?.[e] && (clearTimeout(this.#b[e]), this.#b[e] = void 0), t && (this.#a[e] = void 0, this.#i[e] = void 0, this.#R.push(e)), this.#o === 1 ? (this.#y = this.#p = 0, this.#R.length = 0) : this.#y = this.#d[e], this.#u.delete(s), this.#o--, e;
+          return this.#T && this.#l(i) ? i.__abortController.abort(new Error("evicted")) : (this.#E || this.#e) && (this.#E && this.#n?.(i, s, "evict"), this.#e && this.#m?.push([i, s, "evict"])), this.#L(e), this.#b?.[e] && (clearTimeout(this.#b[e]), this.#b[e] = void 0), t && (this.#a[e] = void 0, this.#i[e] = void 0, this.#R.push(e)), this.#o === 1 ? (this.#y = this.#p = 0, this.#R.length = 0) : this.#y = this.#d[e], this.#u.delete(s), this.#o--, e;
         }
         has(t, e = {}) {
           let { updateAgeOnHas: s = this.updateAgeOnHas, status: i } = e, r = this.#u.get(t);
@@ -151226,7 +154961,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
             let h = this.#i[r];
             if (this.#l(h) && h.__staleWhileFetching === void 0) return false;
             if (this.#_(r)) i && (i.has = "stale", this.#D(i, r));
-            else return s && this.#x(r), i && (i.has = "hit", this.#D(i, r)), true;
+            else return s && this.#C(r), i && (i.has = "hit", this.#D(i, r)), true;
           } else i && (i.has = "miss");
           return false;
         }
@@ -151244,11 +154979,11 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           let a = { signal: h.signal, options: s, context: i }, l = (p, b = false) => {
             let { aborted: w } = h.signal, v = s.ignoreFetchAbort && p !== void 0, E = s.ignoreFetchAbort || !!(s.allowStaleOnFetchAbort && p !== void 0);
             if (s.status && (w && !b ? (s.status.fetchAborted = true, s.status.fetchError = h.signal.reason, v && (s.status.fetchAbortIgnored = true)) : s.status.fetchResolved = true), w && !v && !b) return c(h.signal.reason, E);
-            let y = f, S = this.#i[e];
-            return (S === f || v && b && S === void 0) && (p === void 0 ? y.__staleWhileFetching !== void 0 ? this.#i[e] = y.__staleWhileFetching : this.#A(t, "fetch") : (s.status && (s.status.fetchUpdated = true), this.set(t, p, a.options))), p;
-          }, u = (p) => (s.status && (s.status.fetchRejected = true, s.status.fetchError = p), c(p, false)), c = (p, b) => {
-            let { aborted: w } = h.signal, v = w && s.allowStaleOnFetchAbort, E = v || s.allowStaleOnFetchRejection, y = E || s.noDeleteOnFetchRejection, S = f;
-            if (this.#i[e] === f && (!y || !b && S.__staleWhileFetching === void 0 ? this.#A(t, "fetch") : v || (this.#i[e] = S.__staleWhileFetching)), E) return s.status && S.__staleWhileFetching !== void 0 && (s.status.returnedStale = true), S.__staleWhileFetching;
+            let y = u, S = this.#i[e];
+            return (S === u || v && b && S === void 0) && (p === void 0 ? y.__staleWhileFetching !== void 0 ? this.#i[e] = y.__staleWhileFetching : this.#A(t, "fetch") : (s.status && (s.status.fetchUpdated = true), this.set(t, p, a.options))), p;
+          }, f = (p) => (s.status && (s.status.fetchRejected = true, s.status.fetchError = p), c(p, false)), c = (p, b) => {
+            let { aborted: w } = h.signal, v = w && s.allowStaleOnFetchAbort, E = v || s.allowStaleOnFetchRejection, y = E || s.noDeleteOnFetchRejection, S = u;
+            if (this.#i[e] === u && (!y || !b && S.__staleWhileFetching === void 0 ? this.#A(t, "fetch") : v || (this.#i[e] = S.__staleWhileFetching)), E) return s.status && S.__staleWhileFetching !== void 0 && (s.status.returnedStale = true), S.__staleWhileFetching;
             if (S.__returned === S) throw p;
           }, d = (p, b) => {
             let w = this.#S?.(t, r, a);
@@ -151257,18 +154992,18 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
             });
           };
           s.status && (s.status.fetchDispatched = true);
-          let f = new Promise(d).then(l, u), m = Object.assign(f, { __abortController: h, __staleWhileFetching: r, __returned: void 0 });
+          let u = new Promise(d).then(l, f), m = Object.assign(u, { __abortController: h, __staleWhileFetching: r, __returned: void 0 });
           return e === void 0 ? (this.set(t, m, { ...a.options, status: void 0 }), e = this.#u.get(t)) : this.#i[e] = m, m;
         }
         #l(t) {
-          if (!this.#C) return false;
+          if (!this.#T) return false;
           let e = t;
           return !!e && e instanceof Promise && e.hasOwnProperty("__staleWhileFetching") && e.__abortController instanceof Lt;
         }
         async fetch(t, e = {}) {
-          let { allowStale: s = this.allowStale, updateAgeOnGet: i = this.updateAgeOnGet, noDeleteOnStaleGet: r = this.noDeleteOnStaleGet, ttl: h = this.ttl, noDisposeOnSet: o = this.noDisposeOnSet, size: a = 0, sizeCalculation: l = this.sizeCalculation, noUpdateTTL: u = this.noUpdateTTL, noDeleteOnFetchRejection: c = this.noDeleteOnFetchRejection, allowStaleOnFetchRejection: d = this.allowStaleOnFetchRejection, ignoreFetchAbort: f = this.ignoreFetchAbort, allowStaleOnFetchAbort: m = this.allowStaleOnFetchAbort, context: p, forceRefresh: b = false, status: w, signal: v } = e;
-          if (!this.#C) return w && (w.fetch = "get"), this.get(t, { allowStale: s, updateAgeOnGet: i, noDeleteOnStaleGet: r, status: w });
-          let E = { allowStale: s, updateAgeOnGet: i, noDeleteOnStaleGet: r, ttl: h, noDisposeOnSet: o, size: a, sizeCalculation: l, noUpdateTTL: u, noDeleteOnFetchRejection: c, allowStaleOnFetchRejection: d, allowStaleOnFetchAbort: m, ignoreFetchAbort: f, status: w, signal: v }, y = this.#u.get(t);
+          let { allowStale: s = this.allowStale, updateAgeOnGet: i = this.updateAgeOnGet, noDeleteOnStaleGet: r = this.noDeleteOnStaleGet, ttl: h = this.ttl, noDisposeOnSet: o = this.noDisposeOnSet, size: a = 0, sizeCalculation: l = this.sizeCalculation, noUpdateTTL: f = this.noUpdateTTL, noDeleteOnFetchRejection: c = this.noDeleteOnFetchRejection, allowStaleOnFetchRejection: d = this.allowStaleOnFetchRejection, ignoreFetchAbort: u = this.ignoreFetchAbort, allowStaleOnFetchAbort: m = this.allowStaleOnFetchAbort, context: p, forceRefresh: b = false, status: w, signal: v } = e;
+          if (!this.#T) return w && (w.fetch = "get"), this.get(t, { allowStale: s, updateAgeOnGet: i, noDeleteOnStaleGet: r, status: w });
+          let E = { allowStale: s, updateAgeOnGet: i, noDeleteOnStaleGet: r, ttl: h, noDisposeOnSet: o, size: a, sizeCalculation: l, noUpdateTTL: f, noDeleteOnFetchRejection: c, allowStaleOnFetchRejection: d, allowStaleOnFetchAbort: m, ignoreFetchAbort: u, status: w, signal: v }, y = this.#u.get(t);
           if (y === void 0) {
             w && (w.fetch = "miss");
             let S = this.#z(t, y, E, p);
@@ -151280,7 +155015,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
               return w && (w.fetch = "inflight", st && (w.returnedStale = true)), st ? S.__staleWhileFetching : S.__returned = S;
             }
             let B = this.#_(y);
-            if (!b && !B) return w && (w.fetch = "hit"), this.#N(y), i && this.#x(y), w && this.#D(w, y), S;
+            if (!b && !B) return w && (w.fetch = "hit"), this.#N(y), i && this.#C(y), w && this.#D(w, y), S;
             let U = this.#z(t, y, E, p), et = U.__staleWhileFetching !== void 0 && s;
             return w && (w.fetch = B ? "stale" : "refresh", et && B && (w.returnedStale = true)), et ? U.__staleWhileFetching : U.__returned = U;
           }
@@ -151302,7 +155037,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           let { allowStale: s = this.allowStale, updateAgeOnGet: i = this.updateAgeOnGet, noDeleteOnStaleGet: r = this.noDeleteOnStaleGet, status: h } = e, o = this.#u.get(t);
           if (o !== void 0) {
             let a = this.#i[o], l = this.#l(a);
-            return h && this.#D(h, o), this.#_(o) ? (h && (h.get = "stale"), l ? (h && s && a.__staleWhileFetching !== void 0 && (h.returnedStale = true), s ? a.__staleWhileFetching : void 0) : (r || this.#A(t, "expire"), h && s && (h.returnedStale = true), s ? a : void 0)) : (h && (h.get = "hit"), l ? a.__staleWhileFetching : (this.#N(o), i && this.#x(o), a));
+            return h && this.#D(h, o), this.#_(o) ? (h && (h.get = "stale"), l ? (h && s && a.__staleWhileFetching !== void 0 && (h.returnedStale = true), s ? a.__staleWhileFetching : void 0) : (r || this.#A(t, "expire"), h && s && (h.returnedStale = true), s ? a : void 0)) : (h && (h.get = "hit"), l ? a.__staleWhileFetching : (this.#N(o), i && this.#C(o), a));
           } else h && (h.get = "miss");
         }
         #U(t, e) {
@@ -151351,8 +155086,8 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
               this.#E && this.#n?.(s, i, t), this.#e && this.#m?.push([s, i, t]);
             }
           }
-          if (this.#u.clear(), this.#i.fill(void 0), this.#a.fill(void 0), this.#g && this.#T) {
-            this.#g.fill(0), this.#T.fill(0);
+          if (this.#u.clear(), this.#i.fill(void 0), this.#a.fill(void 0), this.#g && this.#x) {
+            this.#g.fill(0), this.#x.fill(0);
             for (let e of this.#b ?? []) e !== void 0 && clearTimeout(e);
             this.#b?.fill(void 0);
           }
@@ -151377,7 +155112,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
       P.isReadable = ar;
       var lr = (n) => !!n && typeof n == "object" && n instanceof _e.EventEmitter && typeof n.write == "function" && typeof n.end == "function";
       P.isWritable = lr;
-      var $ = /* @__PURE__ */ Symbol("EOF"), q = /* @__PURE__ */ Symbol("maybeEmitEnd"), K = /* @__PURE__ */ Symbol("emittedEnd"), Bt = /* @__PURE__ */ Symbol("emittingEnd"), lt = /* @__PURE__ */ Symbol("emittedError"), It = /* @__PURE__ */ Symbol("closed"), ps = /* @__PURE__ */ Symbol("read"), Gt = /* @__PURE__ */ Symbol("flush"), ms = /* @__PURE__ */ Symbol("flushChunk"), L = /* @__PURE__ */ Symbol("encoding"), rt = /* @__PURE__ */ Symbol("decoder"), T = /* @__PURE__ */ Symbol("flowing"), ct = /* @__PURE__ */ Symbol("paused"), nt = /* @__PURE__ */ Symbol("resume"), C = /* @__PURE__ */ Symbol("buffer"), M = /* @__PURE__ */ Symbol("pipes"), x = /* @__PURE__ */ Symbol("bufferLength"), we = /* @__PURE__ */ Symbol("bufferPush"), zt = /* @__PURE__ */ Symbol("bufferShift"), k = /* @__PURE__ */ Symbol("objectMode"), O = /* @__PURE__ */ Symbol("destroyed"), be = /* @__PURE__ */ Symbol("error"), ye = /* @__PURE__ */ Symbol("emitData"), gs = /* @__PURE__ */ Symbol("emitEnd"), Se = /* @__PURE__ */ Symbol("emitEnd2"), I = /* @__PURE__ */ Symbol("async"), ve = /* @__PURE__ */ Symbol("abort"), Ut = /* @__PURE__ */ Symbol("aborted"), ut = /* @__PURE__ */ Symbol("signal"), Z = /* @__PURE__ */ Symbol("dataListeners"), D = /* @__PURE__ */ Symbol("discarded"), ft = (n) => Promise.resolve().then(n), cr = (n) => n(), ur = (n) => n === "end" || n === "finish" || n === "prefinish", fr = (n) => n instanceof ArrayBuffer || !!n && typeof n == "object" && n.constructor && n.constructor.name === "ArrayBuffer" && n.byteLength >= 0, dr = (n) => !Buffer.isBuffer(n) && ArrayBuffer.isView(n), $t = class {
+      var $ = /* @__PURE__ */ Symbol("EOF"), q = /* @__PURE__ */ Symbol("maybeEmitEnd"), K = /* @__PURE__ */ Symbol("emittedEnd"), Bt = /* @__PURE__ */ Symbol("emittingEnd"), lt = /* @__PURE__ */ Symbol("emittedError"), It = /* @__PURE__ */ Symbol("closed"), ps = /* @__PURE__ */ Symbol("read"), Gt = /* @__PURE__ */ Symbol("flush"), ms = /* @__PURE__ */ Symbol("flushChunk"), L = /* @__PURE__ */ Symbol("encoding"), rt = /* @__PURE__ */ Symbol("decoder"), x = /* @__PURE__ */ Symbol("flowing"), ct = /* @__PURE__ */ Symbol("paused"), nt = /* @__PURE__ */ Symbol("resume"), T = /* @__PURE__ */ Symbol("buffer"), M = /* @__PURE__ */ Symbol("pipes"), C = /* @__PURE__ */ Symbol("bufferLength"), we = /* @__PURE__ */ Symbol("bufferPush"), zt = /* @__PURE__ */ Symbol("bufferShift"), k = /* @__PURE__ */ Symbol("objectMode"), O = /* @__PURE__ */ Symbol("destroyed"), be = /* @__PURE__ */ Symbol("error"), ye = /* @__PURE__ */ Symbol("emitData"), gs = /* @__PURE__ */ Symbol("emitEnd"), Se = /* @__PURE__ */ Symbol("emitEnd2"), I = /* @__PURE__ */ Symbol("async"), ve = /* @__PURE__ */ Symbol("abort"), Ut = /* @__PURE__ */ Symbol("aborted"), ut = /* @__PURE__ */ Symbol("signal"), Z = /* @__PURE__ */ Symbol("dataListeners"), D = /* @__PURE__ */ Symbol("discarded"), ft = (n) => Promise.resolve().then(n), cr = (n) => n(), ur = (n) => n === "end" || n === "finish" || n === "prefinish", fr = (n) => n instanceof ArrayBuffer || !!n && typeof n == "object" && n.constructor && n.constructor.name === "ArrayBuffer" && n.byteLength >= 0, dr = (n) => !Buffer.isBuffer(n) && ArrayBuffer.isView(n), $t = class {
         src;
         dest;
         opts;
@@ -151398,13 +155133,13 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           this.src.removeListener("error", this.proxyErrors), super.unpipe();
         }
         constructor(t, e, s) {
-          super(t, e, s), this.proxyErrors = (i) => e.emit("error", i), t.on("error", this.proxyErrors);
+          super(t, e, s), this.proxyErrors = (i) => this.dest.emit("error", i), t.on("error", this.proxyErrors);
         }
       }, pr = (n) => !!n.objectMode, mr = (n) => !n.objectMode && !!n.encoding && n.encoding !== "buffer", qt = class extends _e.EventEmitter {
-        [T] = false;
+        [x] = false;
         [ct] = false;
         [M] = [];
-        [C] = [];
+        [T] = [];
         [k];
         [L];
         [I];
@@ -151414,7 +155149,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
         [Bt] = false;
         [It] = false;
         [lt] = null;
-        [x] = 0;
+        [C] = 0;
         [O] = false;
         [ut];
         [Ut] = false;
@@ -151425,12 +155160,12 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
         constructor(...t) {
           let e = t[0] || {};
           if (super(), e.objectMode && typeof e.encoding == "string") throw new TypeError("Encoding and objectMode may not be used together");
-          pr(e) ? (this[k] = true, this[L] = null) : mr(e) ? (this[L] = e.encoding, this[k] = false) : (this[k] = false, this[L] = null), this[I] = !!e.async, this[rt] = this[L] ? new hr.StringDecoder(this[L]) : null, e && e.debugExposeBuffer === true && Object.defineProperty(this, "buffer", { get: () => this[C] }), e && e.debugExposePipes === true && Object.defineProperty(this, "pipes", { get: () => this[M] });
+          pr(e) ? (this[k] = true, this[L] = null) : mr(e) ? (this[L] = e.encoding, this[k] = false) : (this[k] = false, this[L] = null), this[I] = !!e.async, this[rt] = this[L] ? new hr.StringDecoder(this[L]) : null, e && e.debugExposeBuffer === true && Object.defineProperty(this, "buffer", { get: () => this[T] }), e && e.debugExposePipes === true && Object.defineProperty(this, "pipes", { get: () => this[M] });
           let { signal: s } = e;
           s && (this[ut] = s, s.aborted ? this[ve]() : s.addEventListener("abort", () => this[ve]()));
         }
         get bufferLength() {
-          return this[x];
+          return this[C];
         }
         get encoding() {
           return this[L];
@@ -151472,58 +155207,58 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
             else if (fr(t)) t = Buffer.from(t);
             else if (typeof t != "string") throw new Error("Non-contiguous data written to non-objectMode stream");
           }
-          return this[k] ? (this[T] && this[x] !== 0 && this[Gt](true), this[T] ? this.emit("data", t) : this[we](t), this[x] !== 0 && this.emit("readable"), s && i(s), this[T]) : t.length ? (typeof t == "string" && !(e === this[L] && !this[rt]?.lastNeed) && (t = Buffer.from(t, e)), Buffer.isBuffer(t) && this[L] && (t = this[rt].write(t)), this[T] && this[x] !== 0 && this[Gt](true), this[T] ? this.emit("data", t) : this[we](t), this[x] !== 0 && this.emit("readable"), s && i(s), this[T]) : (this[x] !== 0 && this.emit("readable"), s && i(s), this[T]);
+          return this[k] ? (this[x] && this[C] !== 0 && this[Gt](true), this[x] ? this.emit("data", t) : this[we](t), this[C] !== 0 && this.emit("readable"), s && i(s), this[x]) : t.length ? (typeof t == "string" && !(e === this[L] && !this[rt]?.lastNeed) && (t = Buffer.from(t, e)), Buffer.isBuffer(t) && this[L] && (t = this[rt].write(t)), this[x] && this[C] !== 0 && this[Gt](true), this[x] ? this.emit("data", t) : this[we](t), this[C] !== 0 && this.emit("readable"), s && i(s), this[x]) : (this[C] !== 0 && this.emit("readable"), s && i(s), this[x]);
         }
         read(t) {
           if (this[O]) return null;
-          if (this[D] = false, this[x] === 0 || t === 0 || t && t > this[x]) return this[q](), null;
-          this[k] && (t = null), this[C].length > 1 && !this[k] && (this[C] = [this[L] ? this[C].join("") : Buffer.concat(this[C], this[x])]);
-          let e = this[ps](t || null, this[C][0]);
+          if (this[D] = false, this[C] === 0 || t === 0 || t && t > this[C]) return this[q](), null;
+          this[k] && (t = null), this[T].length > 1 && !this[k] && (this[T] = [this[L] ? this[T].join("") : Buffer.concat(this[T], this[C])]);
+          let e = this[ps](t || null, this[T][0]);
           return this[q](), e;
         }
         [ps](t, e) {
           if (this[k]) this[zt]();
           else {
             let s = e;
-            t === s.length || t === null ? this[zt]() : typeof s == "string" ? (this[C][0] = s.slice(t), e = s.slice(0, t), this[x] -= t) : (this[C][0] = s.subarray(t), e = s.subarray(0, t), this[x] -= t);
+            t === s.length || t === null ? this[zt]() : typeof s == "string" ? (this[T][0] = s.slice(t), e = s.slice(0, t), this[C] -= t) : (this[T][0] = s.subarray(t), e = s.subarray(0, t), this[C] -= t);
           }
-          return this.emit("data", e), !this[C].length && !this[$] && this.emit("drain"), e;
+          return this.emit("data", e), !this[T].length && !this[$] && this.emit("drain"), e;
         }
         end(t, e, s) {
-          return typeof t == "function" && (s = t, t = void 0), typeof e == "function" && (s = e, e = "utf8"), t !== void 0 && this.write(t, e), s && this.once("end", s), this[$] = true, this.writable = false, (this[T] || !this[ct]) && this[q](), this;
+          return typeof t == "function" && (s = t, t = void 0), typeof e == "function" && (s = e, e = "utf8"), t !== void 0 && this.write(t, e), s && this.once("end", s), this[$] = true, this.writable = false, (this[x] || !this[ct]) && this[q](), this;
         }
         [nt]() {
-          this[O] || (!this[Z] && !this[M].length && (this[D] = true), this[ct] = false, this[T] = true, this.emit("resume"), this[C].length ? this[Gt]() : this[$] ? this[q]() : this.emit("drain"));
+          this[O] || (!this[Z] && !this[M].length && (this[D] = true), this[ct] = false, this[x] = true, this.emit("resume"), this[T].length ? this[Gt]() : this[$] ? this[q]() : this.emit("drain"));
         }
         resume() {
           return this[nt]();
         }
         pause() {
-          this[T] = false, this[ct] = true, this[D] = false;
+          this[x] = false, this[ct] = true, this[D] = false;
         }
         get destroyed() {
           return this[O];
         }
         get flowing() {
-          return this[T];
+          return this[x];
         }
         get paused() {
           return this[ct];
         }
         [we](t) {
-          this[k] ? this[x] += 1 : this[x] += t.length, this[C].push(t);
+          this[k] ? this[C] += 1 : this[C] += t.length, this[T].push(t);
         }
         [zt]() {
-          return this[k] ? this[x] -= 1 : this[x] -= this[C][0].length, this[C].shift();
+          return this[k] ? this[C] -= 1 : this[C] -= this[T][0].length, this[T].shift();
         }
         [Gt](t = false) {
           do
             ;
-          while (this[ms](this[zt]()) && this[C].length);
-          !t && !this[C].length && !this[$] && this.emit("drain");
+          while (this[ms](this[zt]()) && this[T].length);
+          !t && !this[T].length && !this[$] && this.emit("drain");
         }
         [ms](t) {
-          return this.emit("data", t), this[T];
+          return this.emit("data", t), this[x];
         }
         pipe(t, e) {
           if (this[O]) return t;
@@ -151533,15 +155268,15 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
         }
         unpipe(t) {
           let e = this[M].find((s) => s.dest === t);
-          e && (this[M].length === 1 ? (this[T] && this[Z] === 0 && (this[T] = false), this[M] = []) : this[M].splice(this[M].indexOf(e), 1), e.unpipe());
+          e && (this[M].length === 1 ? (this[x] && this[Z] === 0 && (this[x] = false), this[M] = []) : this[M].splice(this[M].indexOf(e), 1), e.unpipe());
         }
         addListener(t, e) {
           return this.on(t, e);
         }
         on(t, e) {
           let s = super.on(t, e);
-          if (t === "data") this[D] = false, this[Z]++, !this[M].length && !this[T] && this[nt]();
-          else if (t === "readable" && this[x] !== 0) super.emit("readable");
+          if (t === "data") this[D] = false, this[Z]++, !this[M].length && !this[x] && this[nt]();
+          else if (t === "readable" && this[C] !== 0) super.emit("readable");
           else if (ur(t) && this[K]) super.emit(t), this.removeAllListeners(t);
           else if (t === "error" && this[lt]) {
             let i = e;
@@ -151554,17 +155289,17 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
         }
         off(t, e) {
           let s = super.off(t, e);
-          return t === "data" && (this[Z] = this.listeners("data").length, this[Z] === 0 && !this[D] && !this[M].length && (this[T] = false)), s;
+          return t === "data" && (this[Z] = this.listeners("data").length, this[Z] === 0 && !this[D] && !this[M].length && (this[x] = false)), s;
         }
         removeAllListeners(t) {
           let e = super.removeAllListeners(t);
-          return (t === "data" || t === void 0) && (this[Z] = 0, !this[D] && !this[M].length && (this[T] = false)), e;
+          return (t === "data" || t === void 0) && (this[Z] = 0, !this[D] && !this[M].length && (this[x] = false)), e;
         }
         get emittedEnd() {
           return this[K];
         }
         [q]() {
-          !this[Bt] && !this[K] && !this[O] && this[C].length === 0 && this[$] && (this[Bt] = true, this.emit("end"), this.emit("prefinish"), this.emit("finish"), this[It] && this.emit("close"), this[Bt] = false);
+          !this[Bt] && !this[K] && !this[O] && this[T].length === 0 && this[$] && (this[Bt] = true, this.emit("end"), this.emit("prefinish"), this.emit("finish"), this[It] && this.emit("close"), this[Bt] = false);
         }
         emit(t, ...e) {
           let s = e[0];
@@ -151636,17 +155371,18 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
             if (i !== null) return Promise.resolve({ done: false, value: i });
             if (this[$]) return e();
             let r, h, o = (c) => {
-              this.off("data", a), this.off("end", l), this.off(O, u), e(), h(c);
+              this.off("data", a), this.off("end", l), this.off(O, f), e(), h(c);
             }, a = (c) => {
-              this.off("error", o), this.off("end", l), this.off(O, u), this.pause(), r({ value: c, done: !!this[$] });
+              this.off("error", o), this.off("end", l), this.off(O, f), this.pause(), r({ value: c, done: !!this[$] });
             }, l = () => {
-              this.off("error", o), this.off("data", a), this.off(O, u), e(), r({ done: true, value: void 0 });
-            }, u = () => o(new Error("stream destroyed"));
+              this.off("error", o), this.off("data", a), this.off(O, f), e(), r({ done: true, value: void 0 });
+            }, f = () => o(new Error("stream destroyed"));
             return new Promise((c, d) => {
-              h = d, r = c, this.once(O, u), this.once("error", o), this.once("end", l), this.once("data", a);
+              h = d, r = c, this.once(O, f), this.once("error", o), this.once("end", l), this.once("data", a);
             });
           }, throw: e, return: e, [Symbol.asyncIterator]() {
             return this;
+          }, [Symbol.asyncDispose]: async () => {
           } };
         }
         [Symbol.iterator]() {
@@ -151658,11 +155394,12 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           };
           return this.once("end", e), this.once(be, e), this.once(O, e), { next: s, throw: e, return: e, [Symbol.iterator]() {
             return this;
+          }, [Symbol.dispose]: () => {
           } };
         }
         destroy(t) {
           if (this[O]) return t ? this.emit("error", t) : this.emit(O), this;
-          this[O] = true, this[D] = true, this[C].length = 0, this[x] = 0;
+          this[O] = true, this[D] = true, this[T].length = 0, this[C] = 0;
           let e = this;
           return typeof e.close == "function" && !this[It] && e.close(), t ? this.emit("error", t) : this.emit(O), this;
         }
@@ -151694,7 +155431,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
       };
       Object.defineProperty(_, "__esModule", { value: true });
       _.PathScurry = _.Path = _.PathScurryDarwin = _.PathScurryPosix = _.PathScurryWin32 = _.PathScurryBase = _.PathPosix = _.PathWin32 = _.PathBase = _.ChildrenCache = _.ResolveCache = void 0;
-      var Qt = fs(), Yt = require("node:path"), yr = require("node:url"), pt = require("fs"), Sr = br(require("node:fs")), vr = pt.realpathSync.native, Ht = require("node:fs/promises"), bs = Oe(), mt = { lstatSync: pt.lstatSync, readdir: pt.readdir, readdirSync: pt.readdirSync, readlinkSync: pt.readlinkSync, realpathSync: vr, promises: { lstat: Ht.lstat, readdir: Ht.readdir, readlink: Ht.readlink, realpath: Ht.realpath } }, _s = (n) => !n || n === mt || n === Sr ? mt : { ...mt, ...n, promises: { ...mt.promises, ...n.promises || {} } }, Os = /^\\\\\?\\([a-z]:)\\?$/i, Er = (n) => n.replace(/\//g, "\\").replace(Os, "$1\\"), _r = /[\\\/]/, N = 0, Ts = 1, Cs = 2, G = 4, xs = 6, Rs = 8, Q = 10, As = 12, j = 15, dt = ~j, Te = 16, ys = 32, gt = 64, W = 128, Vt = 256, Xt = 512, Ss = gt | W | Xt, Or = 1023, Ce = (n) => n.isFile() ? Rs : n.isDirectory() ? G : n.isSymbolicLink() ? Q : n.isCharacterDevice() ? Cs : n.isBlockDevice() ? xs : n.isSocket() ? As : n.isFIFO() ? Ts : N, vs = new Qt.LRUCache({ max: 2 ** 12 }), wt = (n) => {
+      var Qt = fs(), Yt = require("node:path"), yr = require("node:url"), pt = require("fs"), Sr = br(require("node:fs")), vr = pt.realpathSync.native, Ht = require("node:fs/promises"), bs = Oe(), mt = { lstatSync: pt.lstatSync, readdir: pt.readdir, readdirSync: pt.readdirSync, readlinkSync: pt.readlinkSync, realpathSync: vr, promises: { lstat: Ht.lstat, readdir: Ht.readdir, readlink: Ht.readlink, realpath: Ht.realpath } }, _s = (n) => !n || n === mt || n === Sr ? mt : { ...mt, ...n, promises: { ...mt.promises, ...n.promises || {} } }, Os = /^\\\\\?\\([a-z]:)\\?$/i, Er = (n) => n.replace(/\//g, "\\").replace(Os, "$1\\"), _r = /[\\\/]/, N = 0, xs = 1, Ts = 2, G = 4, Cs = 6, Rs = 8, Q = 10, As = 12, j = 15, dt = ~j, xe = 16, ys = 32, gt = 64, W = 128, Vt = 256, Xt = 512, Ss = gt | W | Xt, Or = 1023, Te = (n) => n.isFile() ? Rs : n.isDirectory() ? G : n.isSymbolicLink() ? Q : n.isCharacterDevice() ? Ts : n.isBlockDevice() ? Cs : n.isSocket() ? As : n.isFIFO() ? xs : N, vs = new Qt.LRUCache({ max: 2 ** 12 }), wt = (n) => {
         let t = vs.get(n);
         if (t) return t;
         let e = n.normalize("NFKD");
@@ -151797,15 +155534,15 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           return this.#m;
         }
         #O;
-        #T;
+        #x;
         #g;
         #b;
         #E;
-        #C;
+        #T;
         #e;
         #F;
         #P;
-        #x;
+        #C;
         get parentPath() {
           return (this.parent || this).fullpath();
         }
@@ -151813,10 +155550,10 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           return this.parentPath;
         }
         constructor(t, e = N, s, i, r, h, o) {
-          this.name = t, this.#O = r ? Kt(t) : wt(t), this.#e = e & Or, this.nocase = r, this.roots = i, this.root = s || this, this.#F = h, this.#g = o.fullpath, this.#E = o.relative, this.#C = o.relativePosix, this.parent = o.parent, this.parent ? this.#t = this.parent.#t : this.#t = _s(o.fs);
+          this.name = t, this.#O = r ? Kt(t) : wt(t), this.#e = e & Or, this.nocase = r, this.roots = i, this.root = s || this, this.#F = h, this.#g = o.fullpath, this.#E = o.relative, this.#T = o.relativePosix, this.parent = o.parent, this.parent ? this.#t = this.parent.#t : this.#t = _s(o.fs);
         }
         depth() {
-          return this.#T !== void 0 ? this.#T : this.parent ? this.#T = this.parent.depth() + 1 : this.#T = 0;
+          return this.#x !== void 0 ? this.#x : this.parent ? this.#x = this.parent.depth() + 1 : this.#x = 0;
         }
         childrenCache() {
           return this.#F;
@@ -151835,7 +155572,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           let t = this.#F.get(this);
           if (t) return t;
           let e = Object.assign([], { provisional: 0 });
-          return this.#F.set(this, e), this.#e &= ~Te, e;
+          return this.#F.set(this, e), this.#e &= ~xe, e;
         }
         child(t, e) {
           if (t === "" || t === ".") return this;
@@ -151856,9 +155593,9 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
         relativePosix() {
           if (this.sep === "/") return this.relative();
           if (this.isCWD) return "";
-          if (this.#C !== void 0) return this.#C;
+          if (this.#T !== void 0) return this.#T;
           let t = this.name, e = this.parent;
-          if (!e) return this.#C = this.fullpathPosix();
+          if (!e) return this.#T = this.fullpathPosix();
           let s = e.relativePosix();
           return s + (!s || !e.parent ? "" : "/") + t;
         }
@@ -151895,13 +155632,13 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           return (this.#e & j) === G;
         }
         isCharacterDevice() {
-          return (this.#e & j) === Cs;
+          return (this.#e & j) === Ts;
         }
         isBlockDevice() {
-          return (this.#e & j) === xs;
+          return (this.#e & j) === Cs;
         }
         isFIFO() {
-          return (this.#e & j) === Ts;
+          return (this.#e & j) === xs;
         }
         isSocket() {
           return (this.#e & j) === As;
@@ -151916,7 +155653,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           return this.#P;
         }
         realpathCached() {
-          return this.#x;
+          return this.#C;
         }
         readdirCached() {
           let t = this.children();
@@ -151929,7 +155666,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           return !(t !== N && t !== Q || this.#e & Vt || this.#e & W);
         }
         calledReaddir() {
-          return !!(this.#e & Te);
+          return !!(this.#e & xe);
         }
         isENOENT() {
           return !!(this.#e & W);
@@ -151960,7 +155697,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           }
         }
         #W(t) {
-          this.#e |= Te;
+          this.#e |= xe;
           for (let e = t.provisional; e < t.length; e++) {
             let s = t[e];
             s && s.#_();
@@ -151996,7 +155733,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           return this.#z(t, e) || this.#G(t, e);
         }
         #G(t, e) {
-          let s = Ce(t), i = this.newChild(t.name, s, { parent: this }), r = i.#e & j;
+          let s = Te(t), i = this.newChild(t.name, s, { parent: this }), r = i.#e & j;
           return r !== G && r !== Q && r !== N && (i.#e |= gt), e.unshift(i), e.provisional++, i;
         }
         #z(t, e) {
@@ -152007,7 +155744,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
         }
         #l(t, e, s, i) {
           let r = e.name;
-          return e.#e = e.#e & dt | Ce(t), r !== t.name && (e.name = t.name), s !== i.provisional && (s === i.length - 1 ? i.pop() : i.splice(s, 1), i.unshift(e)), i.provisional++, e;
+          return e.#e = e.#e & dt | Te(t), r !== t.name && (e.name = t.name), s !== i.provisional && (s === i.length - 1 ? i.pop() : i.splice(s, 1), i.unshift(e)), i.provisional++, e;
         }
         async lstat() {
           if ((this.#e & W) === 0) try {
@@ -152024,9 +155761,9 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           }
         }
         #U(t) {
-          let { atime: e, atimeMs: s, birthtime: i, birthtimeMs: r, blksize: h, blocks: o, ctime: a, ctimeMs: l, dev: u, gid: c, ino: d, mode: f, mtime: m, mtimeMs: p, nlink: b, rdev: w, size: v, uid: E } = t;
-          this.#y = e, this.#a = s, this.#m = i, this.#v = r, this.#c = h, this.#u = o, this.#R = a, this.#d = l, this.#s = u, this.#S = c, this.#o = d, this.#n = f, this.#p = m, this.#i = p, this.#r = b, this.#w = w, this.#f = v, this.#h = E;
-          let y = Ce(t);
+          let { atime: e, atimeMs: s, birthtime: i, birthtimeMs: r, blksize: h, blocks: o, ctime: a, ctimeMs: l, dev: f, gid: c, ino: d, mode: u, mtime: m, mtimeMs: p, nlink: b, rdev: w, size: v, uid: E } = t;
+          this.#y = e, this.#a = s, this.#m = i, this.#v = r, this.#c = h, this.#u = o, this.#R = a, this.#d = l, this.#s = f, this.#S = c, this.#o = d, this.#n = u, this.#p = m, this.#i = p, this.#r = b, this.#w = w, this.#f = v, this.#h = E;
+          let y = Te(t);
           this.#e = this.#e & dt | y | ys, y !== N && y !== G && y !== Q && (this.#e |= gt);
         }
         #N = [];
@@ -152102,19 +155839,19 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           return (this.#e & G) === G && !(this.#e & Ss) && !t.has(this) && (!e || e(this));
         }
         async realpath() {
-          if (this.#x) return this.#x;
+          if (this.#C) return this.#C;
           if (!((Xt | Vt | W) & this.#e)) try {
             let t = await this.#t.promises.realpath(this.fullpath());
-            return this.#x = this.resolve(t);
+            return this.#C = this.resolve(t);
           } catch {
             this.#L();
           }
         }
         realpathSync() {
-          if (this.#x) return this.#x;
+          if (this.#C) return this.#C;
           if (!((Xt | Vt | W) & this.#e)) try {
             let t = this.#t.realpathSync(this.fullpath());
-            return this.#x = this.resolve(t);
+            return this.#C = this.resolve(t);
           } catch {
             this.#L();
           }
@@ -152123,8 +155860,8 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           if (t === this) return;
           t.isCWD = false, this.isCWD = true;
           let e = /* @__PURE__ */ new Set([]), s = [], i = this;
-          for (; i && i.parent; ) e.add(i), i.#E = s.join(this.sep), i.#C = s.join("/"), i = i.parent, s.push("..");
-          for (i = t; i && i.parent && !e.has(i); ) i.#E = void 0, i.#C = void 0, i = i.parent;
+          for (; i && i.parent; ) e.add(i), i.#E = s.join(this.sep), i.#T = s.join("/"), i = i.parent, s.push("..");
+          for (i = t; i && i.parent && !e.has(i); ) i.#E = void 0, i.#T = void 0, i = i.parent;
         }
       };
       _.PathBase = A;
@@ -152184,10 +155921,10 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           let a = o.substring(this.rootPath.length).split(s);
           if (a.length === 1 && !a[0] && a.pop(), i === void 0) throw new TypeError("must provide nocase setting to PathScurryBase ctor");
           this.nocase = i, this.root = this.newRoot(this.#r), this.roots[this.rootPath] = this.root;
-          let l = this.root, u = a.length - 1, c = e.sep, d = this.rootPath, f = false;
+          let l = this.root, f = a.length - 1, c = e.sep, d = this.rootPath, u = false;
           for (let m of a) {
-            let p = u--;
-            l = l.child(m, { relative: new Array(p).fill("..").join(c), relativePosix: new Array(p).fill("..").join("/"), fullpath: d += (f ? "" : c) + m }), f = true;
+            let p = f--;
+            l = l.child(m, { relative: new Array(p).fill("..").join(c), relativePosix: new Array(p).fill("..").join("/"), fullpath: d += (u ? "" : c) + m }), u = true;
           }
           this.cwd = l;
         }
@@ -152275,8 +156012,8 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           let { withFileTypes: s = true, follow: i = false, filter: r, walkFilter: h } = e, o = [];
           (!r || r(t)) && o.push(s ? t : t.fullpath());
           let a = /* @__PURE__ */ new Set(), l = (c, d) => {
-            a.add(c), c.readdirCB((f, m) => {
-              if (f) return d(f);
+            a.add(c), c.readdirCB((u, m) => {
+              if (u) return d(u);
               let p = m.length;
               if (!p) return d();
               let b = () => {
@@ -152284,10 +156021,10 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
               };
               for (let w of m) (!r || r(w)) && o.push(s ? w : w.fullpath()), i && w.isSymbolicLink() ? w.realpath().then((v) => v?.isUnknown() ? v.lstat() : v).then((v) => v?.shouldWalk(a, h) ? l(v, b) : b()) : w.shouldWalk(a, h) ? l(w, b) : b();
             }, true);
-          }, u = t;
+          }, f = t;
           return new Promise((c, d) => {
-            l(u, (f) => {
-              if (f) return d(f);
+            l(f, (u) => {
+              if (u) return d(u);
               c(o);
             });
           });
@@ -152298,8 +156035,8 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           (!r || r(t)) && o.push(s ? t : t.fullpath());
           let a = /* @__PURE__ */ new Set([t]);
           for (let l of a) {
-            let u = l.readdirSync();
-            for (let c of u) {
+            let f = l.readdirSync();
+            for (let c of f) {
               (!r || r(c)) && o.push(s ? c : c.fullpath());
               let d = c;
               if (c.isSymbolicLink()) {
@@ -152327,11 +156064,11 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           let o = /* @__PURE__ */ new Set([t]);
           for (let a of o) {
             let l = a.readdirSync();
-            for (let u of l) {
-              (!r || r(u)) && (yield s ? u : u.fullpath());
-              let c = u;
-              if (u.isSymbolicLink()) {
-                if (!(i && (c = u.realpathSync()))) continue;
+            for (let f of l) {
+              (!r || r(f)) && (yield s ? f : f.fullpath());
+              let c = f;
+              if (f.isSymbolicLink()) {
+                if (!(i && (c = f.realpathSync()))) continue;
                 c.isUnknown() && c.lstatSync();
               }
               c.shouldWalk(o, h) && o.add(c);
@@ -152342,15 +156079,15 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           typeof t == "string" ? t = this.cwd.resolve(t) : t instanceof A || (e = t, t = this.cwd);
           let { withFileTypes: s = true, follow: i = false, filter: r, walkFilter: h } = e, o = new bs.Minipass({ objectMode: true });
           (!r || r(t)) && o.write(s ? t : t.fullpath());
-          let a = /* @__PURE__ */ new Set(), l = [t], u = 0, c = () => {
+          let a = /* @__PURE__ */ new Set(), l = [t], f = 0, c = () => {
             let d = false;
             for (; !d; ) {
-              let f = l.shift();
-              if (!f) {
-                u === 0 && o.end();
+              let u = l.shift();
+              if (!u) {
+                f === 0 && o.end();
                 return;
               }
-              u++, a.add(f);
+              f++, a.add(u);
               let m = (b, w, v = false) => {
                 if (b) return o.emit("error", b);
                 if (i && !v) {
@@ -152362,14 +156099,14 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
                   }
                 }
                 for (let E of w) E && (!r || r(E)) && (o.write(s ? E : E.fullpath()) || (d = true));
-                u--;
+                f--;
                 for (let E of w) {
                   let y = E.realpathCached() || E;
                   y.shouldWalk(a, h) && l.push(y);
                 }
                 d && !o.flowing ? o.once("drain", c) : p || c();
               }, p = true;
-              f.readdirCB(m, true), p = false;
+              u.readdirCB(m, true), p = false;
             }
           };
           return c(), o;
@@ -152378,18 +156115,18 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           typeof t == "string" ? t = this.cwd.resolve(t) : t instanceof A || (e = t, t = this.cwd);
           let { withFileTypes: s = true, follow: i = false, filter: r, walkFilter: h } = e, o = new bs.Minipass({ objectMode: true }), a = /* @__PURE__ */ new Set();
           (!r || r(t)) && o.write(s ? t : t.fullpath());
-          let l = [t], u = 0, c = () => {
+          let l = [t], f = 0, c = () => {
             let d = false;
             for (; !d; ) {
-              let f = l.shift();
-              if (!f) {
-                u === 0 && o.end();
+              let u = l.shift();
+              if (!u) {
+                f === 0 && o.end();
                 return;
               }
-              u++, a.add(f);
-              let m = f.readdirSync();
+              f++, a.add(u);
+              let m = u.readdirSync();
               for (let p of m) (!r || r(p)) && (o.write(s ? p : p.fullpath()) || (d = true));
-              u--;
+              f--;
               for (let p of m) {
                 let b = p;
                 if (p.isSymbolicLink()) {
@@ -152458,7 +156195,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
       "use strict";
       Object.defineProperty(te, "__esModule", { value: true });
       te.Pattern = void 0;
-      var Tr = H(), Cr = (n) => n.length >= 1, xr = (n) => n.length >= 1, xe = class n {
+      var xr = H(), Tr = (n) => n.length >= 1, Cr = (n) => n.length >= 1, Rr = /* @__PURE__ */ Symbol.for("nodejs.util.inspect.custom"), Ce = class n {
         #t;
         #s;
         #n;
@@ -152471,23 +156208,26 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
         #o;
         #f = true;
         constructor(t, e, s, i) {
-          if (!Cr(t)) throw new TypeError("empty pattern list");
-          if (!xr(e)) throw new TypeError("empty glob list");
+          if (!Tr(t)) throw new TypeError("empty pattern list");
+          if (!Cr(e)) throw new TypeError("empty glob list");
           if (e.length !== t.length) throw new TypeError("mismatched pattern list and glob list lengths");
           if (this.length = t.length, s < 0 || s >= this.length) throw new TypeError("index out of range");
           if (this.#t = t, this.#s = e, this.#n = s, this.#r = i, this.#n === 0) {
             if (this.isUNC()) {
-              let [r, h, o, a, ...l] = this.#t, [u, c, d, f, ...m] = this.#s;
+              let [r, h, o, a, ...l] = this.#t, [f, c, d, u, ...m] = this.#s;
               l[0] === "" && (l.shift(), m.shift());
-              let p = [r, h, o, a, ""].join("/"), b = [u, c, d, f, ""].join("/");
+              let p = [r, h, o, a, ""].join("/"), b = [f, c, d, u, ""].join("/");
               this.#t = [p, ...l], this.#s = [b, ...m], this.length = this.#t.length;
             } else if (this.isDrive() || this.isAbsolute()) {
               let [r, ...h] = this.#t, [o, ...a] = this.#s;
               h[0] === "" && (h.shift(), a.shift());
-              let l = r + "/", u = o + "/";
-              this.#t = [l, ...h], this.#s = [u, ...a], this.length = this.#t.length;
+              let l = r + "/", f = o + "/";
+              this.#t = [l, ...h], this.#s = [f, ...a], this.length = this.#t.length;
             }
           }
+        }
+        [Rr]() {
+          return "Pattern <" + this.#s.slice(this.#n).join("/") + ">";
         }
         pattern() {
           return this.#t[this.#n];
@@ -152496,7 +156236,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           return typeof this.#t[this.#n] == "string";
         }
         isGlobstar() {
-          return this.#t[this.#n] === Tr.GLOBSTAR;
+          return this.#t[this.#n] === xr.GLOBSTAR;
         }
         isRegExp() {
           return this.#t[this.#n] instanceof RegExp;
@@ -152533,20 +156273,20 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
           return this.#n === 0 || !this.isGlobstar() || !this.#f ? false : (this.#f = false, true);
         }
       };
-      te.Pattern = xe;
+      te.Pattern = Ce;
     });
     var ke = R((ee) => {
       "use strict";
       Object.defineProperty(ee, "__esModule", { value: true });
       ee.Ignore = void 0;
-      var Ps = H(), Rr = Re(), Ar = typeof process == "object" && process && typeof process.platform == "string" ? process.platform : "linux", Ae = class {
+      var Ps = H(), Ar = Re(), kr = typeof process == "object" && process && typeof process.platform == "string" ? process.platform : "linux", Ae = class {
         relative;
         relativeChildren;
         absolute;
         absoluteChildren;
         platform;
         mmopts;
-        constructor(t, { nobrace: e, nocase: s, noext: i, noglobstar: r, platform: h = Ar }) {
+        constructor(t, { nobrace: e, nocase: s, noext: i, noglobstar: r, platform: h = kr }) {
           this.relative = [], this.absolute = [], this.relativeChildren = [], this.absoluteChildren = [], this.platform = h, this.mmopts = { dot: true, nobrace: e, nocase: s, noext: i, noglobstar: r, optimizationLevel: 2, platform: h, nocomment: true, nonegate: true };
           for (let o of t) this.add(o);
         }
@@ -152556,7 +156296,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
             let i = e.set[s], r = e.globParts[s];
             if (!i || !r) throw new Error("invalid pattern object");
             for (; i[0] === "." && r[0] === "."; ) i.shift(), r.shift();
-            let h = new Rr.Pattern(i, r, 0, this.platform), o = new Ps.Minimatch(h.globString(), this.mmopts), a = r[r.length - 1] === "**", l = h.isAbsolute();
+            let h = new Ar.Pattern(i, r, 0, this.platform), o = new Ps.Minimatch(h.globString(), this.mmopts), a = r[r.length - 1] === "**", l = h.isAbsolute();
             l ? this.absolute.push(o) : this.relative.push(o), a && (l ? this.absoluteChildren.push(o) : this.relativeChildren.push(o));
           }
         }
@@ -152654,9 +156394,9 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
               }
             }
             if (i.isENOENT()) continue;
-            let a, l, u = false;
-            for (; typeof (a = r.pattern()) == "string" && (l = r.rest()); ) i = i.resolve(a), r = l, u = true;
-            if (a = r.pattern(), l = r.rest(), u) {
+            let a, l, f = false;
+            for (; typeof (a = r.pattern()) == "string" && (l = r.rest()); ) i = i.resolve(a), r = l, f = true;
+            if (a = r.pattern(), l = r.rest(), f) {
               if (this.hasWalkedCache.hasWalked(i, r)) continue;
               this.hasWalkedCache.storeWalked(i, r);
             }
@@ -152669,8 +156409,8 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
               let c = l?.pattern(), d = l?.rest();
               if (!l || (c === "" || c === ".") && !d) this.matches.add(i, o, c === "" || c === ".");
               else if (c === "..") {
-                let f = i.parent || i;
-                d ? this.hasWalkedCache.hasWalked(f, d) || this.subwalks.add(f, d) : this.matches.add(f, o, true);
+                let u = i.parent || i;
+                d ? this.hasWalkedCache.hasWalked(u, d) || this.subwalks.add(u, d) : this.matches.add(u, o, true);
               }
             } else a instanceof RegExp && this.subwalks.add(i, r);
           }
@@ -152713,7 +156453,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
       "use strict";
       Object.defineProperty(X, "__esModule", { value: true });
       X.GlobStream = X.GlobWalker = X.GlobUtil = void 0;
-      var kr = Oe(), js = ke(), Ns = Fs(), Mr = (n, t) => typeof n == "string" ? new js.Ignore([n], t) : Array.isArray(n) ? new js.Ignore(n, t) : n, Ot = class {
+      var Mr = Oe(), js = ke(), Ns = Fs(), Pr = (n, t) => typeof n == "string" ? new js.Ignore([n], t) : Array.isArray(n) ? new js.Ignore(n, t) : n, Ot = class {
         path;
         patterns;
         opts;
@@ -152727,7 +156467,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
         maxDepth;
         includeChildMatches;
         constructor(t, e, s) {
-          if (this.patterns = t, this.path = e, this.opts = s, this.#n = !s.posix && s.platform === "win32" ? "\\" : "/", this.includeChildMatches = s.includeChildMatches !== false, (s.ignore || !this.includeChildMatches) && (this.#s = Mr(s.ignore ?? [], s), !this.includeChildMatches && typeof this.#s.add != "function")) {
+          if (this.patterns = t, this.path = e, this.opts = s, this.#n = !s.posix && s.platform === "win32" ? "\\" : "/", this.includeChildMatches = s.includeChildMatches !== false, (s.ignore || !this.includeChildMatches) && (this.#s = Pr(s.ignore ?? [], s), !this.includeChildMatches && typeof this.#s.add != "function")) {
             let i = "cannot ignore child matches, ignore lacks add() method.";
             throw new Error(i);
           }
@@ -152828,7 +156568,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
             if (this.maxDepth !== 1 / 0 && o.depth() >= this.maxDepth) continue;
             r++;
             let a = o.readdirCached();
-            o.calledReaddir() ? this.walkCB3(o, a, s, h) : o.readdirCB((l, u) => this.walkCB3(o, u, s, h), true);
+            o.calledReaddir() ? this.walkCB3(o, a, s, h) : o.readdirCB((l, f) => this.walkCB3(o, f, s, h), true);
           }
           h();
         }
@@ -152901,7 +156641,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
       var De = class extends Ot {
         results;
         constructor(t, e, s) {
-          super(t, e, s), this.results = new kr.Minipass({ signal: this.signal, objectMode: true }), this.results.on("drain", () => this.resume()), this.results.on("resume", () => this.resume());
+          super(t, e, s), this.results = new Mr.Minipass({ signal: this.signal, objectMode: true }), this.results.on("drain", () => this.resume()), this.results.on("resume", () => this.resume());
         }
         matchEmit(t) {
           this.results.write(t), this.results.flowing || this.pause();
@@ -152922,7 +156662,7 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
       "use strict";
       Object.defineProperty(oe, "__esModule", { value: true });
       oe.Glob = void 0;
-      var Pr = H(), Dr = require("node:url"), ne = Ms(), Fr = Re(), he = Ls(), jr = typeof process == "object" && process && typeof process.platform == "string" ? process.platform : "linux", Fe = class {
+      var Dr = H(), Fr = require("node:url"), ne = Ms(), jr = Re(), he = Ls(), Nr = typeof process == "object" && process && typeof process.platform == "string" ? process.platform : "linux", Fe = class {
         absolute;
         cwd;
         root;
@@ -152952,23 +156692,23 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
         patterns;
         constructor(t, e) {
           if (!e) throw new TypeError("glob options required");
-          if (this.withFileTypes = !!e.withFileTypes, this.signal = e.signal, this.follow = !!e.follow, this.dot = !!e.dot, this.dotRelative = !!e.dotRelative, this.nodir = !!e.nodir, this.mark = !!e.mark, e.cwd ? (e.cwd instanceof URL || e.cwd.startsWith("file://")) && (e.cwd = (0, Dr.fileURLToPath)(e.cwd)) : this.cwd = "", this.cwd = e.cwd || "", this.root = e.root, this.magicalBraces = !!e.magicalBraces, this.nobrace = !!e.nobrace, this.noext = !!e.noext, this.realpath = !!e.realpath, this.absolute = e.absolute, this.includeChildMatches = e.includeChildMatches !== false, this.noglobstar = !!e.noglobstar, this.matchBase = !!e.matchBase, this.maxDepth = typeof e.maxDepth == "number" ? e.maxDepth : 1 / 0, this.stat = !!e.stat, this.ignore = e.ignore, this.withFileTypes && this.absolute !== void 0) throw new Error("cannot set absolute and withFileTypes:true");
+          if (this.withFileTypes = !!e.withFileTypes, this.signal = e.signal, this.follow = !!e.follow, this.dot = !!e.dot, this.dotRelative = !!e.dotRelative, this.nodir = !!e.nodir, this.mark = !!e.mark, e.cwd ? (e.cwd instanceof URL || e.cwd.startsWith("file://")) && (e.cwd = (0, Fr.fileURLToPath)(e.cwd)) : this.cwd = "", this.cwd = e.cwd || "", this.root = e.root, this.magicalBraces = !!e.magicalBraces, this.nobrace = !!e.nobrace, this.noext = !!e.noext, this.realpath = !!e.realpath, this.absolute = e.absolute, this.includeChildMatches = e.includeChildMatches !== false, this.noglobstar = !!e.noglobstar, this.matchBase = !!e.matchBase, this.maxDepth = typeof e.maxDepth == "number" ? e.maxDepth : 1 / 0, this.stat = !!e.stat, this.ignore = e.ignore, this.withFileTypes && this.absolute !== void 0) throw new Error("cannot set absolute and withFileTypes:true");
           if (typeof t == "string" && (t = [t]), this.windowsPathsNoEscape = !!e.windowsPathsNoEscape || e.allowWindowsEscape === false, this.windowsPathsNoEscape && (t = t.map((a) => a.replace(/\\/g, "/"))), this.matchBase) {
             if (e.noglobstar) throw new TypeError("base matching requires globstar");
             t = t.map((a) => a.includes("/") ? a : `./**/${a}`);
           }
-          if (this.pattern = t, this.platform = e.platform || jr, this.opts = { ...e, platform: this.platform }, e.scurry) {
+          if (this.pattern = t, this.platform = e.platform || Nr, this.opts = { ...e, platform: this.platform }, e.scurry) {
             if (this.scurry = e.scurry, e.nocase !== void 0 && e.nocase !== e.scurry.nocase) throw new Error("nocase option contradicts provided scurry option");
           } else {
             let a = e.platform === "win32" ? ne.PathScurryWin32 : e.platform === "darwin" ? ne.PathScurryDarwin : e.platform ? ne.PathScurryPosix : ne.PathScurry;
             this.scurry = new a(this.cwd, { nocase: e.nocase, fs: e.fs });
           }
           this.nocase = this.scurry.nocase;
-          let s = this.platform === "darwin" || this.platform === "win32", i = { ...e, dot: this.dot, matchBase: this.matchBase, nobrace: this.nobrace, nocase: this.nocase, nocaseMagicOnly: s, nocomment: true, noext: this.noext, nonegate: true, optimizationLevel: 2, platform: this.platform, windowsPathsNoEscape: this.windowsPathsNoEscape, debug: !!this.opts.debug }, r = this.pattern.map((a) => new Pr.Minimatch(a, i)), [h, o] = r.reduce((a, l) => (a[0].push(...l.set), a[1].push(...l.globParts), a), [[], []]);
+          let s = this.platform === "darwin" || this.platform === "win32", i = { braceExpandMax: 1e4, ...e, dot: this.dot, matchBase: this.matchBase, nobrace: this.nobrace, nocase: this.nocase, nocaseMagicOnly: s, nocomment: true, noext: this.noext, nonegate: true, optimizationLevel: 2, platform: this.platform, windowsPathsNoEscape: this.windowsPathsNoEscape, debug: !!this.opts.debug }, r = this.pattern.map((a) => new Dr.Minimatch(a, i)), [h, o] = r.reduce((a, l) => (a[0].push(...l.set), a[1].push(...l.globParts), a), [[], []]);
           this.patterns = h.map((a, l) => {
-            let u = o[l];
-            if (!u) throw new Error("invalid pattern object");
-            return new Fr.Pattern(a, u, 0, this.platform);
+            let f = o[l];
+            if (!f) throw new Error("invalid pattern object");
+            return new jr.Pattern(a, f, 0, this.platform);
           });
         }
         async walk() {
@@ -153002,23 +156742,23 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
       "use strict";
       Object.defineProperty(ae, "__esModule", { value: true });
       ae.hasMagic = void 0;
-      var Nr = H(), Lr = (n, t = {}) => {
+      var Lr = H(), Wr = (n, t = {}) => {
         Array.isArray(n) || (n = [n]);
-        for (let e of n) if (new Nr.Minimatch(e, t).hasMagic()) return true;
+        for (let e of n) if (new Lr.Minimatch(e, t).hasMagic()) return true;
         return false;
       };
-      ae.hasMagic = Lr;
+      ae.hasMagic = Wr;
     });
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.glob = exports2.sync = exports2.iterate = exports2.iterateSync = exports2.stream = exports2.streamSync = exports2.Ignore = exports2.hasMagic = exports2.Glob = exports2.unescape = exports2.escape = void 0;
-    exports2.globStreamSync = Tt;
+    exports2.globStreamSync = xt;
     exports2.globStream = Le;
     exports2.globSync = We;
-    exports2.globIterateSync = Ct;
+    exports2.globIterateSync = Tt;
     exports2.globIterate = Be;
     var Ws = H();
     var tt = je();
-    var Wr = Ne();
+    var Br = Ne();
     var Is = H();
     Object.defineProperty(exports2, "escape", { enumerable: true, get: function() {
       return Is.escape;
@@ -153026,19 +156766,19 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
     Object.defineProperty(exports2, "unescape", { enumerable: true, get: function() {
       return Is.unescape;
     } });
-    var Br = je();
+    var Ir = je();
     Object.defineProperty(exports2, "Glob", { enumerable: true, get: function() {
-      return Br.Glob;
+      return Ir.Glob;
     } });
-    var Ir = Ne();
+    var Gr = Ne();
     Object.defineProperty(exports2, "hasMagic", { enumerable: true, get: function() {
-      return Ir.hasMagic;
+      return Gr.hasMagic;
     } });
-    var Gr = ke();
+    var zr = ke();
     Object.defineProperty(exports2, "Ignore", { enumerable: true, get: function() {
-      return Gr.Ignore;
+      return zr.Ignore;
     } });
-    function Tt(n, t = {}) {
+    function xt(n, t = {}) {
       return new tt.Glob(n, t).streamSync();
     }
     function Le(n, t = {}) {
@@ -153050,18 +156790,18 @@ globstar while`, t, d, e, f, m), this.matchOne(t.slice(d), e.slice(f), s)) retur
     async function Bs(n, t = {}) {
       return new tt.Glob(n, t).walk();
     }
-    function Ct(n, t = {}) {
+    function Tt(n, t = {}) {
       return new tt.Glob(n, t).iterateSync();
     }
     function Be(n, t = {}) {
       return new tt.Glob(n, t).iterate();
     }
-    exports2.streamSync = Tt;
-    exports2.stream = Object.assign(Le, { sync: Tt });
-    exports2.iterateSync = Ct;
-    exports2.iterate = Object.assign(Be, { sync: Ct });
-    exports2.sync = Object.assign(We, { stream: Tt, iterate: Ct });
-    exports2.glob = Object.assign(Bs, { glob: Bs, globSync: We, sync: exports2.sync, globStream: Le, stream: exports2.stream, globStreamSync: Tt, streamSync: exports2.streamSync, globIterate: Be, iterate: exports2.iterate, globIterateSync: Ct, iterateSync: exports2.iterateSync, Glob: tt.Glob, hasMagic: Wr.hasMagic, escape: Ws.escape, unescape: Ws.unescape });
+    exports2.streamSync = xt;
+    exports2.stream = Object.assign(Le, { sync: xt });
+    exports2.iterateSync = Tt;
+    exports2.iterate = Object.assign(Be, { sync: Tt });
+    exports2.sync = Object.assign(We, { stream: xt, iterate: Tt });
+    exports2.glob = Object.assign(Bs, { glob: Bs, globSync: We, sync: exports2.sync, globStream: Le, stream: exports2.stream, globStreamSync: xt, streamSync: exports2.streamSync, globIterate: Be, iterate: exports2.iterate, globIterateSync: Tt, iterateSync: exports2.iterateSync, Glob: tt.Glob, hasMagic: Br.hasMagic, escape: Ws.escape, unescape: Ws.unescape });
     exports2.glob.glob = exports2.glob;
   }
 });
@@ -153321,7 +157061,16 @@ var require_index = __commonJS({
           context,
           message: `Processing ${sortedMergedPullRequests.length} merged pull requests`
         });
-        const { shouldDraft, version: version2, tag, name, dryRun, attachFiles, resetFiles } = input;
+        const {
+          shouldDraft,
+          version: version2,
+          tag,
+          name,
+          dryRun,
+          attachFiles,
+          resetFiles,
+          notReady
+        } = input;
         let shouldResetFiles;
         if (resetFiles === "true") {
           shouldResetFiles = true;
@@ -153377,6 +157126,19 @@ var require_index = __commonJS({
           shouldDraft,
           targetCommitish
         });
+        if (notReady) {
+          const bannerMessage = typeof notReady === "string" ? notReady : "This release draft is still being prepared. Do not publish until this banner is removed.";
+          releaseInfo.body = `> [!CAUTION]
+> **NOT READY FOR PUBLISHING**
+>
+> ${bannerMessage}
+
+` + releaseInfo.body;
+        }
+        const updatedAt = (/* @__PURE__ */ new Date()).toISOString();
+        releaseInfo.body += `
+<!-- Release draft last updated: ${updatedAt} -->
+`;
         if (dryRun) {
           log({
             context,
@@ -153472,6 +157234,7 @@ var require_index = __commonJS({
         latest: core2.getInput("latest")?.toLowerCase() || void 0,
         attachFiles: core2.getInput("attach-files") || void 0,
         resetFiles: core2.getInput("reset-files").toLowerCase() || "auto",
+        notReady: parseNotReadyInput(core2.getInput("not-ready")),
         allowMajorBumps: core2.getInput("allow-major-bumps") !== "" ? core2.getInput("allow-major-bumps").toLowerCase() === "true" : void 0
       };
     }
@@ -153537,6 +157300,13 @@ var require_index = __commonJS({
       if (tag) core2.setOutput("tag-name", tag);
       if (name) core2.setOutput("name", name);
       core2.setOutput("body", body);
+    }
+    function parseNotReadyInput(raw) {
+      if (!raw) return false;
+      const lower = raw.toLowerCase();
+      if (lower === "false") return false;
+      if (lower === "true") return true;
+      return raw;
     }
   }
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -154466,7 +154466,7 @@ var require_index = __commonJS({
         const pacificTimestamp = formatPacificTimestamp(/* @__PURE__ */ new Date());
         const commitUrl = getCommitUrl();
         releaseInfo.body += `
-<!-- Release draft timestamp: ${pacificTimestamp}` + (commitUrl ? ` | Commit used in draft: ${commitUrl}` : "") + ` -->
+<!-- Release drafted at \`${pacificTimestamp}\`` + (commitUrl ? ` from ${commitUrl}` : "") + ` -->
 `;
         if (dryRun) {
           log({

--- a/dist/index.js
+++ b/dist/index.js
@@ -154463,9 +154463,10 @@ var require_index = __commonJS({
 
 ` + releaseInfo.body;
         }
-        const updatedAt = (/* @__PURE__ */ new Date()).toISOString();
+        const pacificTimestamp = formatPacificTimestamp(/* @__PURE__ */ new Date());
+        const commitUrl = getCommitUrl();
         releaseInfo.body += `
-<!-- Release draft last updated: ${updatedAt} -->
+<!-- Release draft timestamp: ${pacificTimestamp}` + (commitUrl ? ` | Commit used in draft: ${commitUrl}` : "") + ` -->
 `;
         if (dryRun) {
           log({
@@ -154635,6 +154636,33 @@ var require_index = __commonJS({
       if (lower === "false") return false;
       if (lower === "true") return true;
       return raw;
+    }
+    function formatPacificTimestamp(date) {
+      const options2 = {
+        timeZone: "America/Los_Angeles",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "numeric",
+        minute: "2-digit",
+        hour12: true
+      };
+      const parts = new Intl.DateTimeFormat("en-US", options2).formatToParts(date);
+      const get = (type) => parts.find((p) => p.type === type)?.value || "";
+      const year = get("year");
+      const month = get("month");
+      const day = get("day");
+      const hour = get("hour");
+      const minute = get("minute");
+      const dayPeriod = get("dayPeriod").toLowerCase();
+      return `${year}-${month}-${day} ${hour}:${minute}${dayPeriod} Pacific`;
+    }
+    function getCommitUrl() {
+      const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
+      const repository = process.env.GITHUB_REPOSITORY;
+      const sha = process.env.GITHUB_SHA;
+      if (!repository || !sha) return null;
+      return `${serverUrl}/${repository}/commit/${sha}`;
     }
   }
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -19278,9 +19278,9 @@ var require_context = __commonJS({
   }
 });
 
-// node_modules/probot/node_modules/yallist/iterator.js
+// node_modules/yallist/iterator.js
 var require_iterator = __commonJS({
-  "node_modules/probot/node_modules/yallist/iterator.js"(exports2, module2) {
+  "node_modules/yallist/iterator.js"(exports2, module2) {
     "use strict";
     module2.exports = function(Yallist) {
       Yallist.prototype[Symbol.iterator] = function* () {
@@ -19292,9 +19292,9 @@ var require_iterator = __commonJS({
   }
 });
 
-// node_modules/probot/node_modules/yallist/yallist.js
+// node_modules/yallist/yallist.js
 var require_yallist = __commonJS({
-  "node_modules/probot/node_modules/yallist/yallist.js"(exports2, module2) {
+  "node_modules/yallist/yallist.js"(exports2, module2) {
     "use strict";
     module2.exports = Yallist;
     Yallist.Node = Node;
@@ -19661,9 +19661,9 @@ var require_yallist = __commonJS({
   }
 });
 
-// node_modules/probot/node_modules/lru-cache/index.js
+// node_modules/lru-cache/index.js
 var require_lru_cache = __commonJS({
-  "node_modules/probot/node_modules/lru-cache/index.js"(exports2, module2) {
+  "node_modules/lru-cache/index.js"(exports2, module2) {
     "use strict";
     var Yallist = require_yallist();
     var MAX = /* @__PURE__ */ Symbol("max");
@@ -59300,9 +59300,9 @@ var require_ScanStream = __commonJS({
   }
 });
 
-// node_modules/ioredis/node_modules/p-map/index.js
+// node_modules/p-map/index.js
 var require_p_map = __commonJS({
-  "node_modules/ioredis/node_modules/p-map/index.js"(exports2, module2) {
+  "node_modules/p-map/index.js"(exports2, module2) {
     "use strict";
     var pMap = (iterable, mapper, options2) => new Promise((resolve, reject) => {
       options2 = Object.assign({
@@ -66394,9 +66394,162 @@ var require_dist_node6 = __commonJS({
   }
 });
 
-// node_modules/@octokit/request/dist-node/index.js
+// node_modules/@octokit/core/node_modules/@octokit/request/dist-node/index.js
 var require_dist_node7 = __commonJS({
-  "node_modules/@octokit/request/dist-node/index.js"(exports2) {
+  "node_modules/@octokit/core/node_modules/@octokit/request/dist-node/index.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    function _interopDefault(ex) {
+      return ex && typeof ex === "object" && "default" in ex ? ex["default"] : ex;
+    }
+    var endpoint = require_dist_node4();
+    var universalUserAgent = require_dist_node3();
+    var isPlainObject = require_is_plain_object();
+    var nodeFetch = _interopDefault(require_lib6());
+    var requestError = require_dist_node6();
+    var VERSION = "5.6.3";
+    function getBufferResponse(response) {
+      return response.arrayBuffer();
+    }
+    function fetchWrapper(requestOptions) {
+      const log = requestOptions.request && requestOptions.request.log ? requestOptions.request.log : console;
+      if (isPlainObject.isPlainObject(requestOptions.body) || Array.isArray(requestOptions.body)) {
+        requestOptions.body = JSON.stringify(requestOptions.body);
+      }
+      let headers = {};
+      let status;
+      let url;
+      const fetch2 = requestOptions.request && requestOptions.request.fetch || nodeFetch;
+      return fetch2(requestOptions.url, Object.assign(
+        {
+          method: requestOptions.method,
+          body: requestOptions.body,
+          headers: requestOptions.headers,
+          redirect: requestOptions.redirect
+        },
+        // `requestOptions.request.agent` type is incompatible
+        // see https://github.com/octokit/types.ts/pull/264
+        requestOptions.request
+      )).then(async (response) => {
+        url = response.url;
+        status = response.status;
+        for (const keyAndValue of response.headers) {
+          headers[keyAndValue[0]] = keyAndValue[1];
+        }
+        if ("deprecation" in headers) {
+          const matches = headers.link && headers.link.match(/<([^>]+)>; rel="deprecation"/);
+          const deprecationLink = matches && matches.pop();
+          log.warn(`[@octokit/request] "${requestOptions.method} ${requestOptions.url}" is deprecated. It is scheduled to be removed on ${headers.sunset}${deprecationLink ? `. See ${deprecationLink}` : ""}`);
+        }
+        if (status === 204 || status === 205) {
+          return;
+        }
+        if (requestOptions.method === "HEAD") {
+          if (status < 400) {
+            return;
+          }
+          throw new requestError.RequestError(response.statusText, status, {
+            response: {
+              url,
+              status,
+              headers,
+              data: void 0
+            },
+            request: requestOptions
+          });
+        }
+        if (status === 304) {
+          throw new requestError.RequestError("Not modified", status, {
+            response: {
+              url,
+              status,
+              headers,
+              data: await getResponseData(response)
+            },
+            request: requestOptions
+          });
+        }
+        if (status >= 400) {
+          const data = await getResponseData(response);
+          const error = new requestError.RequestError(toErrorMessage(data), status, {
+            response: {
+              url,
+              status,
+              headers,
+              data
+            },
+            request: requestOptions
+          });
+          throw error;
+        }
+        return getResponseData(response);
+      }).then((data) => {
+        return {
+          status,
+          url,
+          headers,
+          data
+        };
+      }).catch((error) => {
+        if (error instanceof requestError.RequestError) throw error;
+        throw new requestError.RequestError(error.message, 500, {
+          request: requestOptions
+        });
+      });
+    }
+    async function getResponseData(response) {
+      const contentType = response.headers.get("content-type");
+      if (/application\/json/.test(contentType)) {
+        return response.json();
+      }
+      if (!contentType || /^text\/|charset=utf-8$/.test(contentType)) {
+        return response.text();
+      }
+      return getBufferResponse(response);
+    }
+    function toErrorMessage(data) {
+      if (typeof data === "string") return data;
+      if ("message" in data) {
+        if (Array.isArray(data.errors)) {
+          return `${data.message}: ${data.errors.map(JSON.stringify).join(", ")}`;
+        }
+        return data.message;
+      }
+      return `Unknown error: ${JSON.stringify(data)}`;
+    }
+    function withDefaults(oldEndpoint, newDefaults) {
+      const endpoint2 = oldEndpoint.defaults(newDefaults);
+      const newApi = function(route, parameters) {
+        const endpointOptions = endpoint2.merge(route, parameters);
+        if (!endpointOptions.request || !endpointOptions.request.hook) {
+          return fetchWrapper(endpoint2.parse(endpointOptions));
+        }
+        const request2 = (route2, parameters2) => {
+          return fetchWrapper(endpoint2.parse(endpoint2.merge(route2, parameters2)));
+        };
+        Object.assign(request2, {
+          endpoint: endpoint2,
+          defaults: withDefaults.bind(null, endpoint2)
+        });
+        return endpointOptions.request.hook(request2, endpointOptions);
+      };
+      return Object.assign(newApi, {
+        endpoint: endpoint2,
+        defaults: withDefaults.bind(null, endpoint2)
+      });
+    }
+    var request = withDefaults(endpoint.endpoint, {
+      headers: {
+        "user-agent": `octokit-request.js/${VERSION} ${universalUserAgent.getUserAgent()}`
+      }
+    });
+    exports2.request = request;
+  }
+});
+
+// node_modules/@octokit/graphql/node_modules/@octokit/request/dist-node/index.js
+var require_dist_node8 = __commonJS({
+  "node_modules/@octokit/graphql/node_modules/@octokit/request/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     function _interopDefault(ex) {
@@ -66548,11 +66701,11 @@ var require_dist_node7 = __commonJS({
 });
 
 // node_modules/@octokit/graphql/dist-node/index.js
-var require_dist_node8 = __commonJS({
+var require_dist_node9 = __commonJS({
   "node_modules/@octokit/graphql/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    var request = require_dist_node7();
+    var request = require_dist_node8();
     var universalUserAgent = require_dist_node3();
     var VERSION = "4.8.0";
     function _buildMessageForResponseErrors(data) {
@@ -66645,7 +66798,7 @@ var require_dist_node8 = __commonJS({
 });
 
 // node_modules/@octokit/auth-token/dist-node/index.js
-var require_dist_node9 = __commonJS({
+var require_dist_node10 = __commonJS({
   "node_modules/@octokit/auth-token/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -66691,15 +66844,15 @@ var require_dist_node9 = __commonJS({
 });
 
 // node_modules/@octokit/core/dist-node/index.js
-var require_dist_node10 = __commonJS({
+var require_dist_node11 = __commonJS({
   "node_modules/@octokit/core/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var universalUserAgent = require_dist_node3();
     var beforeAfterHook = require_before_after_hook();
     var request = require_dist_node7();
-    var graphql = require_dist_node8();
-    var authToken = require_dist_node9();
+    var graphql = require_dist_node9();
+    var authToken = require_dist_node10();
     function _objectWithoutPropertiesLoose(source, excluded) {
       if (source == null) return {};
       var target = {};
@@ -66834,7 +66987,7 @@ var require_dist_node10 = __commonJS({
 });
 
 // node_modules/@octokit/plugin-enterprise-compatibility/dist-node/index.js
-var require_dist_node11 = __commonJS({
+var require_dist_node12 = __commonJS({
   "node_modules/@octokit/plugin-enterprise-compatibility/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -66867,7 +67020,7 @@ var require_dist_node11 = __commonJS({
 });
 
 // node_modules/@octokit/plugin-paginate-rest/dist-node/index.js
-var require_dist_node12 = __commonJS({
+var require_dist_node13 = __commonJS({
   "node_modules/@octokit/plugin-paginate-rest/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -67020,7 +67173,7 @@ var require_dist_node12 = __commonJS({
 });
 
 // node_modules/@octokit/plugin-rest-endpoint-methods/dist-node/index.js
-var require_dist_node13 = __commonJS({
+var require_dist_node14 = __commonJS({
   "node_modules/@octokit/plugin-rest-endpoint-methods/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -69413,7 +69566,7 @@ var require_light = __commonJS({
 });
 
 // node_modules/@octokit/plugin-retry/dist-node/index.js
-var require_dist_node14 = __commonJS({
+var require_dist_node15 = __commonJS({
   "node_modules/@octokit/plugin-retry/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -69475,7 +69628,7 @@ var require_dist_node14 = __commonJS({
 });
 
 // node_modules/@octokit/plugin-throttling/dist-node/index.js
-var require_dist_node15 = __commonJS({
+var require_dist_node16 = __commonJS({
   "node_modules/@octokit/plugin-throttling/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -72723,7 +72876,7 @@ var require_js_yaml = __commonJS({
 });
 
 // node_modules/@probot/octokit-plugin-config/dist-node/index.js
-var require_dist_node16 = __commonJS({
+var require_dist_node17 = __commonJS({
   "node_modules/@probot/octokit-plugin-config/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -72949,7 +73102,7 @@ var require_dist_node16 = __commonJS({
 });
 
 // node_modules/@octokit/auth-unauthenticated/dist-node/index.js
-var require_dist_node17 = __commonJS({
+var require_dist_node18 = __commonJS({
   "node_modules/@octokit/auth-unauthenticated/dist-node/index.js"(exports2, module2) {
     "use strict";
     var __defProp2 = Object.defineProperty;
@@ -73041,7 +73194,7 @@ var require_dist_node17 = __commonJS({
 });
 
 // node_modules/octokit-auth-probot/node_modules/@octokit/auth-token/dist-node/index.js
-var require_dist_node18 = __commonJS({
+var require_dist_node19 = __commonJS({
   "node_modules/octokit-auth-probot/node_modules/@octokit/auth-token/dist-node/index.js"(exports2, module2) {
     "use strict";
     var __defProp2 = Object.defineProperty;
@@ -73111,583 +73264,9 @@ var require_dist_node18 = __commonJS({
   }
 });
 
-// node_modules/@octokit/auth-app/node_modules/@octokit/endpoint/dist-node/index.js
-var require_dist_node19 = __commonJS({
-  "node_modules/@octokit/auth-app/node_modules/@octokit/endpoint/dist-node/index.js"(exports2, module2) {
-    "use strict";
-    var __defProp2 = Object.defineProperty;
-    var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
-    var __getOwnPropNames2 = Object.getOwnPropertyNames;
-    var __hasOwnProp2 = Object.prototype.hasOwnProperty;
-    var __export2 = (target, all) => {
-      for (var name in all)
-        __defProp2(target, name, { get: all[name], enumerable: true });
-    };
-    var __copyProps2 = (to, from, except, desc) => {
-      if (from && typeof from === "object" || typeof from === "function") {
-        for (let key of __getOwnPropNames2(from))
-          if (!__hasOwnProp2.call(to, key) && key !== except)
-            __defProp2(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc2(from, key)) || desc.enumerable });
-      }
-      return to;
-    };
-    var __toCommonJS2 = (mod) => __copyProps2(__defProp2({}, "__esModule", { value: true }), mod);
-    var dist_src_exports = {};
-    __export2(dist_src_exports, {
-      endpoint: () => endpoint
-    });
-    module2.exports = __toCommonJS2(dist_src_exports);
-    function lowercaseKeys(object) {
-      if (!object) {
-        return {};
-      }
-      return Object.keys(object).reduce((newObj, key) => {
-        newObj[key.toLowerCase()] = object[key];
-        return newObj;
-      }, {});
-    }
-    var import_is_plain_object = require_is_plain_object();
-    function mergeDeep(defaults, options2) {
-      const result = Object.assign({}, defaults);
-      Object.keys(options2).forEach((key) => {
-        if ((0, import_is_plain_object.isPlainObject)(options2[key])) {
-          if (!(key in defaults))
-            Object.assign(result, { [key]: options2[key] });
-          else
-            result[key] = mergeDeep(defaults[key], options2[key]);
-        } else {
-          Object.assign(result, { [key]: options2[key] });
-        }
-      });
-      return result;
-    }
-    function removeUndefinedProperties(obj) {
-      for (const key in obj) {
-        if (obj[key] === void 0) {
-          delete obj[key];
-        }
-      }
-      return obj;
-    }
-    function merge(defaults, route, options2) {
-      if (typeof route === "string") {
-        let [method, url] = route.split(" ");
-        options2 = Object.assign(url ? { method, url } : { url: method }, options2);
-      } else {
-        options2 = Object.assign({}, route);
-      }
-      options2.headers = lowercaseKeys(options2.headers);
-      removeUndefinedProperties(options2);
-      removeUndefinedProperties(options2.headers);
-      const mergedOptions = mergeDeep(defaults || {}, options2);
-      if (defaults && defaults.mediaType.previews.length) {
-        mergedOptions.mediaType.previews = defaults.mediaType.previews.filter((preview) => !mergedOptions.mediaType.previews.includes(preview)).concat(mergedOptions.mediaType.previews);
-      }
-      mergedOptions.mediaType.previews = mergedOptions.mediaType.previews.map(
-        (preview) => preview.replace(/-preview/, "")
-      );
-      return mergedOptions;
-    }
-    function addQueryParameters(url, parameters) {
-      const separator = /\?/.test(url) ? "&" : "?";
-      const names = Object.keys(parameters);
-      if (names.length === 0) {
-        return url;
-      }
-      return url + separator + names.map((name) => {
-        if (name === "q") {
-          return "q=" + parameters.q.split("+").map(encodeURIComponent).join("+");
-        }
-        return `${name}=${encodeURIComponent(parameters[name])}`;
-      }).join("&");
-    }
-    var urlVariableRegex = /\{[^}]+\}/g;
-    function removeNonChars(variableName) {
-      return variableName.replace(/^\W+|\W+$/g, "").split(/,/);
-    }
-    function extractUrlVariableNames(url) {
-      const matches = url.match(urlVariableRegex);
-      if (!matches) {
-        return [];
-      }
-      return matches.map(removeNonChars).reduce((a, b) => a.concat(b), []);
-    }
-    function omit(object, keysToOmit) {
-      return Object.keys(object).filter((option) => !keysToOmit.includes(option)).reduce((obj, key) => {
-        obj[key] = object[key];
-        return obj;
-      }, {});
-    }
-    function encodeReserved(str) {
-      return str.split(/(%[0-9A-Fa-f]{2})/g).map(function(part) {
-        if (!/%[0-9A-Fa-f]/.test(part)) {
-          part = encodeURI(part).replace(/%5B/g, "[").replace(/%5D/g, "]");
-        }
-        return part;
-      }).join("");
-    }
-    function encodeUnreserved(str) {
-      return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
-        return "%" + c.charCodeAt(0).toString(16).toUpperCase();
-      });
-    }
-    function encodeValue(operator, value, key) {
-      value = operator === "+" || operator === "#" ? encodeReserved(value) : encodeUnreserved(value);
-      if (key) {
-        return encodeUnreserved(key) + "=" + value;
-      } else {
-        return value;
-      }
-    }
-    function isDefined(value) {
-      return value !== void 0 && value !== null;
-    }
-    function isKeyOperator(operator) {
-      return operator === ";" || operator === "&" || operator === "?";
-    }
-    function getValues(context, operator, key, modifier) {
-      var value = context[key], result = [];
-      if (isDefined(value) && value !== "") {
-        if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-          value = value.toString();
-          if (modifier && modifier !== "*") {
-            value = value.substring(0, parseInt(modifier, 10));
-          }
-          result.push(
-            encodeValue(operator, value, isKeyOperator(operator) ? key : "")
-          );
-        } else {
-          if (modifier === "*") {
-            if (Array.isArray(value)) {
-              value.filter(isDefined).forEach(function(value2) {
-                result.push(
-                  encodeValue(operator, value2, isKeyOperator(operator) ? key : "")
-                );
-              });
-            } else {
-              Object.keys(value).forEach(function(k) {
-                if (isDefined(value[k])) {
-                  result.push(encodeValue(operator, value[k], k));
-                }
-              });
-            }
-          } else {
-            const tmp = [];
-            if (Array.isArray(value)) {
-              value.filter(isDefined).forEach(function(value2) {
-                tmp.push(encodeValue(operator, value2));
-              });
-            } else {
-              Object.keys(value).forEach(function(k) {
-                if (isDefined(value[k])) {
-                  tmp.push(encodeUnreserved(k));
-                  tmp.push(encodeValue(operator, value[k].toString()));
-                }
-              });
-            }
-            if (isKeyOperator(operator)) {
-              result.push(encodeUnreserved(key) + "=" + tmp.join(","));
-            } else if (tmp.length !== 0) {
-              result.push(tmp.join(","));
-            }
-          }
-        }
-      } else {
-        if (operator === ";") {
-          if (isDefined(value)) {
-            result.push(encodeUnreserved(key));
-          }
-        } else if (value === "" && (operator === "&" || operator === "?")) {
-          result.push(encodeUnreserved(key) + "=");
-        } else if (value === "") {
-          result.push("");
-        }
-      }
-      return result;
-    }
-    function parseUrl(template) {
-      return {
-        expand: expand.bind(null, template)
-      };
-    }
-    function expand(template, context) {
-      var operators = ["+", "#", ".", "/", ";", "?", "&"];
-      return template.replace(
-        /\{([^\{\}]+)\}|([^\{\}]+)/g,
-        function(_, expression, literal) {
-          if (expression) {
-            let operator = "";
-            const values = [];
-            if (operators.indexOf(expression.charAt(0)) !== -1) {
-              operator = expression.charAt(0);
-              expression = expression.substr(1);
-            }
-            expression.split(/,/g).forEach(function(variable) {
-              var tmp = /([^:\*]*)(?::(\d+)|(\*))?/.exec(variable);
-              values.push(getValues(context, operator, tmp[1], tmp[2] || tmp[3]));
-            });
-            if (operator && operator !== "+") {
-              var separator = ",";
-              if (operator === "?") {
-                separator = "&";
-              } else if (operator !== "#") {
-                separator = operator;
-              }
-              return (values.length !== 0 ? operator : "") + values.join(separator);
-            } else {
-              return values.join(",");
-            }
-          } else {
-            return encodeReserved(literal);
-          }
-        }
-      );
-    }
-    function parse2(options2) {
-      let method = options2.method.toUpperCase();
-      let url = (options2.url || "/").replace(/:([a-z]\w+)/g, "{$1}");
-      let headers = Object.assign({}, options2.headers);
-      let body;
-      let parameters = omit(options2, [
-        "method",
-        "baseUrl",
-        "url",
-        "headers",
-        "request",
-        "mediaType"
-      ]);
-      const urlVariableNames = extractUrlVariableNames(url);
-      url = parseUrl(url).expand(parameters);
-      if (!/^http/.test(url)) {
-        url = options2.baseUrl + url;
-      }
-      const omittedParameters = Object.keys(options2).filter((option) => urlVariableNames.includes(option)).concat("baseUrl");
-      const remainingParameters = omit(parameters, omittedParameters);
-      const isBinaryRequest = /application\/octet-stream/i.test(headers.accept);
-      if (!isBinaryRequest) {
-        if (options2.mediaType.format) {
-          headers.accept = headers.accept.split(/,/).map(
-            (preview) => preview.replace(
-              /application\/vnd(\.\w+)(\.v3)?(\.\w+)?(\+json)?$/,
-              `application/vnd$1$2.${options2.mediaType.format}`
-            )
-          ).join(",");
-        }
-        if (options2.mediaType.previews.length) {
-          const previewsFromAcceptHeader = headers.accept.match(/[\w-]+(?=-preview)/g) || [];
-          headers.accept = previewsFromAcceptHeader.concat(options2.mediaType.previews).map((preview) => {
-            const format = options2.mediaType.format ? `.${options2.mediaType.format}` : "+json";
-            return `application/vnd.github.${preview}-preview${format}`;
-          }).join(",");
-        }
-      }
-      if (["GET", "HEAD"].includes(method)) {
-        url = addQueryParameters(url, remainingParameters);
-      } else {
-        if ("data" in remainingParameters) {
-          body = remainingParameters.data;
-        } else {
-          if (Object.keys(remainingParameters).length) {
-            body = remainingParameters;
-          }
-        }
-      }
-      if (!headers["content-type"] && typeof body !== "undefined") {
-        headers["content-type"] = "application/json; charset=utf-8";
-      }
-      if (["PATCH", "PUT"].includes(method) && typeof body === "undefined") {
-        body = "";
-      }
-      return Object.assign(
-        { method, url, headers },
-        typeof body !== "undefined" ? { body } : null,
-        options2.request ? { request: options2.request } : null
-      );
-    }
-    function endpointWithDefaults(defaults, route, options2) {
-      return parse2(merge(defaults, route, options2));
-    }
-    function withDefaults(oldDefaults, newDefaults) {
-      const DEFAULTS2 = merge(oldDefaults, newDefaults);
-      const endpoint2 = endpointWithDefaults.bind(null, DEFAULTS2);
-      return Object.assign(endpoint2, {
-        DEFAULTS: DEFAULTS2,
-        defaults: withDefaults.bind(null, DEFAULTS2),
-        merge: merge.bind(null, DEFAULTS2),
-        parse: parse2
-      });
-    }
-    var import_universal_user_agent = require_dist_node3();
-    var VERSION = "7.0.6";
-    var userAgent = `octokit-endpoint.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`;
-    var DEFAULTS = {
-      method: "GET",
-      baseUrl: "https://api.github.com",
-      headers: {
-        accept: "application/vnd.github.v3+json",
-        "user-agent": userAgent
-      },
-      mediaType: {
-        format: "",
-        previews: []
-      }
-    };
-    var endpoint = withDefaults(null, DEFAULTS);
-  }
-});
-
-// node_modules/@octokit/auth-app/node_modules/@octokit/request-error/dist-node/index.js
+// node_modules/@octokit/request/node_modules/@octokit/endpoint/dist-node/index.js
 var require_dist_node20 = __commonJS({
-  "node_modules/@octokit/auth-app/node_modules/@octokit/request-error/dist-node/index.js"(exports2) {
-    "use strict";
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    function _interopDefault(ex) {
-      return ex && typeof ex === "object" && "default" in ex ? ex["default"] : ex;
-    }
-    var deprecation = require_dist_node5();
-    var once = _interopDefault(require_once());
-    var logOnceCode = once((deprecation2) => console.warn(deprecation2));
-    var logOnceHeaders = once((deprecation2) => console.warn(deprecation2));
-    var RequestError = class extends Error {
-      constructor(message, statusCode, options2) {
-        super(message);
-        if (Error.captureStackTrace) {
-          Error.captureStackTrace(this, this.constructor);
-        }
-        this.name = "HttpError";
-        this.status = statusCode;
-        let headers;
-        if ("headers" in options2 && typeof options2.headers !== "undefined") {
-          headers = options2.headers;
-        }
-        if ("response" in options2) {
-          this.response = options2.response;
-          headers = options2.response.headers;
-        }
-        const requestCopy = Object.assign({}, options2.request);
-        if (options2.request.headers.authorization) {
-          requestCopy.headers = Object.assign({}, options2.request.headers, {
-            authorization: options2.request.headers.authorization.replace(/ .*$/, " [REDACTED]")
-          });
-        }
-        requestCopy.url = requestCopy.url.replace(/\bclient_secret=\w+/g, "client_secret=[REDACTED]").replace(/\baccess_token=\w+/g, "access_token=[REDACTED]");
-        this.request = requestCopy;
-        Object.defineProperty(this, "code", {
-          get() {
-            logOnceCode(new deprecation.Deprecation("[@octokit/request-error] `error.code` is deprecated, use `error.status`."));
-            return statusCode;
-          }
-        });
-        Object.defineProperty(this, "headers", {
-          get() {
-            logOnceHeaders(new deprecation.Deprecation("[@octokit/request-error] `error.headers` is deprecated, use `error.response.headers`."));
-            return headers || {};
-          }
-        });
-      }
-    };
-    exports2.RequestError = RequestError;
-  }
-});
-
-// node_modules/@octokit/auth-app/node_modules/@octokit/request/dist-node/index.js
-var require_dist_node21 = __commonJS({
-  "node_modules/@octokit/auth-app/node_modules/@octokit/request/dist-node/index.js"(exports2, module2) {
-    "use strict";
-    var __create2 = Object.create;
-    var __defProp2 = Object.defineProperty;
-    var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
-    var __getOwnPropNames2 = Object.getOwnPropertyNames;
-    var __getProtoOf2 = Object.getPrototypeOf;
-    var __hasOwnProp2 = Object.prototype.hasOwnProperty;
-    var __export2 = (target, all) => {
-      for (var name in all)
-        __defProp2(target, name, { get: all[name], enumerable: true });
-    };
-    var __copyProps2 = (to, from, except, desc) => {
-      if (from && typeof from === "object" || typeof from === "function") {
-        for (let key of __getOwnPropNames2(from))
-          if (!__hasOwnProp2.call(to, key) && key !== except)
-            __defProp2(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc2(from, key)) || desc.enumerable });
-      }
-      return to;
-    };
-    var __toESM2 = (mod, isNodeMode, target) => (target = mod != null ? __create2(__getProtoOf2(mod)) : {}, __copyProps2(
-      // If the importer is in node compatibility mode or this is not an ESM
-      // file that has been converted to a CommonJS file using a Babel-
-      // compatible transform (i.e. "__esModule" has not been set), then set
-      // "default" to the CommonJS "module.exports" for node compatibility.
-      isNodeMode || !mod || !mod.__esModule ? __defProp2(target, "default", { value: mod, enumerable: true }) : target,
-      mod
-    ));
-    var __toCommonJS2 = (mod) => __copyProps2(__defProp2({}, "__esModule", { value: true }), mod);
-    var dist_src_exports = {};
-    __export2(dist_src_exports, {
-      request: () => request
-    });
-    module2.exports = __toCommonJS2(dist_src_exports);
-    var import_endpoint = require_dist_node19();
-    var import_universal_user_agent = require_dist_node3();
-    var VERSION = "6.2.8";
-    var import_is_plain_object = require_is_plain_object();
-    var import_node_fetch = __toESM2(require_lib6());
-    var import_request_error = require_dist_node20();
-    function getBufferResponse(response) {
-      return response.arrayBuffer();
-    }
-    function fetchWrapper(requestOptions) {
-      const log = requestOptions.request && requestOptions.request.log ? requestOptions.request.log : console;
-      if ((0, import_is_plain_object.isPlainObject)(requestOptions.body) || Array.isArray(requestOptions.body)) {
-        requestOptions.body = JSON.stringify(requestOptions.body);
-      }
-      let headers = {};
-      let status;
-      let url;
-      const fetch2 = requestOptions.request && requestOptions.request.fetch || globalThis.fetch || /* istanbul ignore next */
-      import_node_fetch.default;
-      return fetch2(
-        requestOptions.url,
-        Object.assign(
-          {
-            method: requestOptions.method,
-            body: requestOptions.body,
-            headers: requestOptions.headers,
-            redirect: requestOptions.redirect,
-            // duplex must be set if request.body is ReadableStream or Async Iterables.
-            // See https://fetch.spec.whatwg.org/#dom-requestinit-duplex.
-            ...requestOptions.body && { duplex: "half" }
-          },
-          // `requestOptions.request.agent` type is incompatible
-          // see https://github.com/octokit/types.ts/pull/264
-          requestOptions.request
-        )
-      ).then(async (response) => {
-        url = response.url;
-        status = response.status;
-        for (const keyAndValue of response.headers) {
-          headers[keyAndValue[0]] = keyAndValue[1];
-        }
-        if ("deprecation" in headers) {
-          const matches = headers.link && headers.link.match(/<([^>]+)>; rel="deprecation"/);
-          const deprecationLink = matches && matches.pop();
-          log.warn(
-            `[@octokit/request] "${requestOptions.method} ${requestOptions.url}" is deprecated. It is scheduled to be removed on ${headers.sunset}${deprecationLink ? `. See ${deprecationLink}` : ""}`
-          );
-        }
-        if (status === 204 || status === 205) {
-          return;
-        }
-        if (requestOptions.method === "HEAD") {
-          if (status < 400) {
-            return;
-          }
-          throw new import_request_error.RequestError(response.statusText, status, {
-            response: {
-              url,
-              status,
-              headers,
-              data: void 0
-            },
-            request: requestOptions
-          });
-        }
-        if (status === 304) {
-          throw new import_request_error.RequestError("Not modified", status, {
-            response: {
-              url,
-              status,
-              headers,
-              data: await getResponseData(response)
-            },
-            request: requestOptions
-          });
-        }
-        if (status >= 400) {
-          const data = await getResponseData(response);
-          const error = new import_request_error.RequestError(toErrorMessage(data), status, {
-            response: {
-              url,
-              status,
-              headers,
-              data
-            },
-            request: requestOptions
-          });
-          throw error;
-        }
-        return getResponseData(response);
-      }).then((data) => {
-        return {
-          status,
-          url,
-          headers,
-          data
-        };
-      }).catch((error) => {
-        if (error instanceof import_request_error.RequestError)
-          throw error;
-        else if (error.name === "AbortError")
-          throw error;
-        throw new import_request_error.RequestError(error.message, 500, {
-          request: requestOptions
-        });
-      });
-    }
-    async function getResponseData(response) {
-      const contentType = response.headers.get("content-type");
-      if (/application\/json/.test(contentType)) {
-        return response.json();
-      }
-      if (!contentType || /^text\/|charset=utf-8$/.test(contentType)) {
-        return response.text();
-      }
-      return getBufferResponse(response);
-    }
-    function toErrorMessage(data) {
-      if (typeof data === "string")
-        return data;
-      if ("message" in data) {
-        if (Array.isArray(data.errors)) {
-          return `${data.message}: ${data.errors.map(JSON.stringify).join(", ")}`;
-        }
-        return data.message;
-      }
-      return `Unknown error: ${JSON.stringify(data)}`;
-    }
-    function withDefaults(oldEndpoint, newDefaults) {
-      const endpoint2 = oldEndpoint.defaults(newDefaults);
-      const newApi = function(route, parameters) {
-        const endpointOptions = endpoint2.merge(route, parameters);
-        if (!endpointOptions.request || !endpointOptions.request.hook) {
-          return fetchWrapper(endpoint2.parse(endpointOptions));
-        }
-        const request2 = (route2, parameters2) => {
-          return fetchWrapper(
-            endpoint2.parse(endpoint2.merge(route2, parameters2))
-          );
-        };
-        Object.assign(request2, {
-          endpoint: endpoint2,
-          defaults: withDefaults.bind(null, endpoint2)
-        });
-        return endpointOptions.request.hook(request2, endpointOptions);
-      };
-      return Object.assign(newApi, {
-        endpoint: endpoint2,
-        defaults: withDefaults.bind(null, endpoint2)
-      });
-    }
-    var request = withDefaults(import_endpoint.endpoint, {
-      headers: {
-        "user-agent": `octokit-request.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`
-      }
-    });
-  }
-});
-
-// node_modules/@octokit/auth-oauth-app/node_modules/@octokit/endpoint/dist-node/index.js
-var require_dist_node22 = __commonJS({
-  "node_modules/@octokit/auth-oauth-app/node_modules/@octokit/endpoint/dist-node/index.js"(exports2, module2) {
+  "node_modules/@octokit/request/node_modules/@octokit/endpoint/dist-node/index.js"(exports2, module2) {
     "use strict";
     var __defProp2 = Object.defineProperty;
     var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
@@ -74010,9 +73589,9 @@ var require_dist_node22 = __commonJS({
   }
 });
 
-// node_modules/@octokit/auth-oauth-app/node_modules/@octokit/request-error/dist-node/index.js
-var require_dist_node23 = __commonJS({
-  "node_modules/@octokit/auth-oauth-app/node_modules/@octokit/request-error/dist-node/index.js"(exports2) {
+// node_modules/@octokit/request/node_modules/@octokit/request-error/dist-node/index.js
+var require_dist_node21 = __commonJS({
+  "node_modules/@octokit/request/node_modules/@octokit/request-error/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     function _interopDefault(ex) {
@@ -74064,9 +73643,9 @@ var require_dist_node23 = __commonJS({
   }
 });
 
-// node_modules/@octokit/auth-oauth-app/node_modules/@octokit/request/dist-node/index.js
-var require_dist_node24 = __commonJS({
-  "node_modules/@octokit/auth-oauth-app/node_modules/@octokit/request/dist-node/index.js"(exports2, module2) {
+// node_modules/@octokit/request/dist-node/index.js
+var require_dist_node22 = __commonJS({
+  "node_modules/@octokit/request/dist-node/index.js"(exports2, module2) {
     "use strict";
     var __create2 = Object.create;
     var __defProp2 = Object.defineProperty;
@@ -74100,12 +73679,12 @@ var require_dist_node24 = __commonJS({
       request: () => request
     });
     module2.exports = __toCommonJS2(dist_src_exports);
-    var import_endpoint = require_dist_node22();
+    var import_endpoint = require_dist_node20();
     var import_universal_user_agent = require_dist_node3();
     var VERSION = "6.2.8";
     var import_is_plain_object = require_is_plain_object();
     var import_node_fetch = __toESM2(require_lib6());
-    var import_request_error = require_dist_node23();
+    var import_request_error = require_dist_node21();
     function getBufferResponse(response) {
       return response.arrayBuffer();
     }
@@ -74268,1156 +73847,8 @@ var require_btoa_node = __commonJS({
   }
 });
 
-// node_modules/@octokit/auth-oauth-user/node_modules/@octokit/endpoint/dist-node/index.js
-var require_dist_node25 = __commonJS({
-  "node_modules/@octokit/auth-oauth-user/node_modules/@octokit/endpoint/dist-node/index.js"(exports2, module2) {
-    "use strict";
-    var __defProp2 = Object.defineProperty;
-    var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
-    var __getOwnPropNames2 = Object.getOwnPropertyNames;
-    var __hasOwnProp2 = Object.prototype.hasOwnProperty;
-    var __export2 = (target, all) => {
-      for (var name in all)
-        __defProp2(target, name, { get: all[name], enumerable: true });
-    };
-    var __copyProps2 = (to, from, except, desc) => {
-      if (from && typeof from === "object" || typeof from === "function") {
-        for (let key of __getOwnPropNames2(from))
-          if (!__hasOwnProp2.call(to, key) && key !== except)
-            __defProp2(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc2(from, key)) || desc.enumerable });
-      }
-      return to;
-    };
-    var __toCommonJS2 = (mod) => __copyProps2(__defProp2({}, "__esModule", { value: true }), mod);
-    var dist_src_exports = {};
-    __export2(dist_src_exports, {
-      endpoint: () => endpoint
-    });
-    module2.exports = __toCommonJS2(dist_src_exports);
-    function lowercaseKeys(object) {
-      if (!object) {
-        return {};
-      }
-      return Object.keys(object).reduce((newObj, key) => {
-        newObj[key.toLowerCase()] = object[key];
-        return newObj;
-      }, {});
-    }
-    var import_is_plain_object = require_is_plain_object();
-    function mergeDeep(defaults, options2) {
-      const result = Object.assign({}, defaults);
-      Object.keys(options2).forEach((key) => {
-        if ((0, import_is_plain_object.isPlainObject)(options2[key])) {
-          if (!(key in defaults))
-            Object.assign(result, { [key]: options2[key] });
-          else
-            result[key] = mergeDeep(defaults[key], options2[key]);
-        } else {
-          Object.assign(result, { [key]: options2[key] });
-        }
-      });
-      return result;
-    }
-    function removeUndefinedProperties(obj) {
-      for (const key in obj) {
-        if (obj[key] === void 0) {
-          delete obj[key];
-        }
-      }
-      return obj;
-    }
-    function merge(defaults, route, options2) {
-      if (typeof route === "string") {
-        let [method, url] = route.split(" ");
-        options2 = Object.assign(url ? { method, url } : { url: method }, options2);
-      } else {
-        options2 = Object.assign({}, route);
-      }
-      options2.headers = lowercaseKeys(options2.headers);
-      removeUndefinedProperties(options2);
-      removeUndefinedProperties(options2.headers);
-      const mergedOptions = mergeDeep(defaults || {}, options2);
-      if (defaults && defaults.mediaType.previews.length) {
-        mergedOptions.mediaType.previews = defaults.mediaType.previews.filter((preview) => !mergedOptions.mediaType.previews.includes(preview)).concat(mergedOptions.mediaType.previews);
-      }
-      mergedOptions.mediaType.previews = mergedOptions.mediaType.previews.map(
-        (preview) => preview.replace(/-preview/, "")
-      );
-      return mergedOptions;
-    }
-    function addQueryParameters(url, parameters) {
-      const separator = /\?/.test(url) ? "&" : "?";
-      const names = Object.keys(parameters);
-      if (names.length === 0) {
-        return url;
-      }
-      return url + separator + names.map((name) => {
-        if (name === "q") {
-          return "q=" + parameters.q.split("+").map(encodeURIComponent).join("+");
-        }
-        return `${name}=${encodeURIComponent(parameters[name])}`;
-      }).join("&");
-    }
-    var urlVariableRegex = /\{[^}]+\}/g;
-    function removeNonChars(variableName) {
-      return variableName.replace(/^\W+|\W+$/g, "").split(/,/);
-    }
-    function extractUrlVariableNames(url) {
-      const matches = url.match(urlVariableRegex);
-      if (!matches) {
-        return [];
-      }
-      return matches.map(removeNonChars).reduce((a, b) => a.concat(b), []);
-    }
-    function omit(object, keysToOmit) {
-      return Object.keys(object).filter((option) => !keysToOmit.includes(option)).reduce((obj, key) => {
-        obj[key] = object[key];
-        return obj;
-      }, {});
-    }
-    function encodeReserved(str) {
-      return str.split(/(%[0-9A-Fa-f]{2})/g).map(function(part) {
-        if (!/%[0-9A-Fa-f]/.test(part)) {
-          part = encodeURI(part).replace(/%5B/g, "[").replace(/%5D/g, "]");
-        }
-        return part;
-      }).join("");
-    }
-    function encodeUnreserved(str) {
-      return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
-        return "%" + c.charCodeAt(0).toString(16).toUpperCase();
-      });
-    }
-    function encodeValue(operator, value, key) {
-      value = operator === "+" || operator === "#" ? encodeReserved(value) : encodeUnreserved(value);
-      if (key) {
-        return encodeUnreserved(key) + "=" + value;
-      } else {
-        return value;
-      }
-    }
-    function isDefined(value) {
-      return value !== void 0 && value !== null;
-    }
-    function isKeyOperator(operator) {
-      return operator === ";" || operator === "&" || operator === "?";
-    }
-    function getValues(context, operator, key, modifier) {
-      var value = context[key], result = [];
-      if (isDefined(value) && value !== "") {
-        if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-          value = value.toString();
-          if (modifier && modifier !== "*") {
-            value = value.substring(0, parseInt(modifier, 10));
-          }
-          result.push(
-            encodeValue(operator, value, isKeyOperator(operator) ? key : "")
-          );
-        } else {
-          if (modifier === "*") {
-            if (Array.isArray(value)) {
-              value.filter(isDefined).forEach(function(value2) {
-                result.push(
-                  encodeValue(operator, value2, isKeyOperator(operator) ? key : "")
-                );
-              });
-            } else {
-              Object.keys(value).forEach(function(k) {
-                if (isDefined(value[k])) {
-                  result.push(encodeValue(operator, value[k], k));
-                }
-              });
-            }
-          } else {
-            const tmp = [];
-            if (Array.isArray(value)) {
-              value.filter(isDefined).forEach(function(value2) {
-                tmp.push(encodeValue(operator, value2));
-              });
-            } else {
-              Object.keys(value).forEach(function(k) {
-                if (isDefined(value[k])) {
-                  tmp.push(encodeUnreserved(k));
-                  tmp.push(encodeValue(operator, value[k].toString()));
-                }
-              });
-            }
-            if (isKeyOperator(operator)) {
-              result.push(encodeUnreserved(key) + "=" + tmp.join(","));
-            } else if (tmp.length !== 0) {
-              result.push(tmp.join(","));
-            }
-          }
-        }
-      } else {
-        if (operator === ";") {
-          if (isDefined(value)) {
-            result.push(encodeUnreserved(key));
-          }
-        } else if (value === "" && (operator === "&" || operator === "?")) {
-          result.push(encodeUnreserved(key) + "=");
-        } else if (value === "") {
-          result.push("");
-        }
-      }
-      return result;
-    }
-    function parseUrl(template) {
-      return {
-        expand: expand.bind(null, template)
-      };
-    }
-    function expand(template, context) {
-      var operators = ["+", "#", ".", "/", ";", "?", "&"];
-      return template.replace(
-        /\{([^\{\}]+)\}|([^\{\}]+)/g,
-        function(_, expression, literal) {
-          if (expression) {
-            let operator = "";
-            const values = [];
-            if (operators.indexOf(expression.charAt(0)) !== -1) {
-              operator = expression.charAt(0);
-              expression = expression.substr(1);
-            }
-            expression.split(/,/g).forEach(function(variable) {
-              var tmp = /([^:\*]*)(?::(\d+)|(\*))?/.exec(variable);
-              values.push(getValues(context, operator, tmp[1], tmp[2] || tmp[3]));
-            });
-            if (operator && operator !== "+") {
-              var separator = ",";
-              if (operator === "?") {
-                separator = "&";
-              } else if (operator !== "#") {
-                separator = operator;
-              }
-              return (values.length !== 0 ? operator : "") + values.join(separator);
-            } else {
-              return values.join(",");
-            }
-          } else {
-            return encodeReserved(literal);
-          }
-        }
-      );
-    }
-    function parse2(options2) {
-      let method = options2.method.toUpperCase();
-      let url = (options2.url || "/").replace(/:([a-z]\w+)/g, "{$1}");
-      let headers = Object.assign({}, options2.headers);
-      let body;
-      let parameters = omit(options2, [
-        "method",
-        "baseUrl",
-        "url",
-        "headers",
-        "request",
-        "mediaType"
-      ]);
-      const urlVariableNames = extractUrlVariableNames(url);
-      url = parseUrl(url).expand(parameters);
-      if (!/^http/.test(url)) {
-        url = options2.baseUrl + url;
-      }
-      const omittedParameters = Object.keys(options2).filter((option) => urlVariableNames.includes(option)).concat("baseUrl");
-      const remainingParameters = omit(parameters, omittedParameters);
-      const isBinaryRequest = /application\/octet-stream/i.test(headers.accept);
-      if (!isBinaryRequest) {
-        if (options2.mediaType.format) {
-          headers.accept = headers.accept.split(/,/).map(
-            (preview) => preview.replace(
-              /application\/vnd(\.\w+)(\.v3)?(\.\w+)?(\+json)?$/,
-              `application/vnd$1$2.${options2.mediaType.format}`
-            )
-          ).join(",");
-        }
-        if (options2.mediaType.previews.length) {
-          const previewsFromAcceptHeader = headers.accept.match(/[\w-]+(?=-preview)/g) || [];
-          headers.accept = previewsFromAcceptHeader.concat(options2.mediaType.previews).map((preview) => {
-            const format = options2.mediaType.format ? `.${options2.mediaType.format}` : "+json";
-            return `application/vnd.github.${preview}-preview${format}`;
-          }).join(",");
-        }
-      }
-      if (["GET", "HEAD"].includes(method)) {
-        url = addQueryParameters(url, remainingParameters);
-      } else {
-        if ("data" in remainingParameters) {
-          body = remainingParameters.data;
-        } else {
-          if (Object.keys(remainingParameters).length) {
-            body = remainingParameters;
-          }
-        }
-      }
-      if (!headers["content-type"] && typeof body !== "undefined") {
-        headers["content-type"] = "application/json; charset=utf-8";
-      }
-      if (["PATCH", "PUT"].includes(method) && typeof body === "undefined") {
-        body = "";
-      }
-      return Object.assign(
-        { method, url, headers },
-        typeof body !== "undefined" ? { body } : null,
-        options2.request ? { request: options2.request } : null
-      );
-    }
-    function endpointWithDefaults(defaults, route, options2) {
-      return parse2(merge(defaults, route, options2));
-    }
-    function withDefaults(oldDefaults, newDefaults) {
-      const DEFAULTS2 = merge(oldDefaults, newDefaults);
-      const endpoint2 = endpointWithDefaults.bind(null, DEFAULTS2);
-      return Object.assign(endpoint2, {
-        DEFAULTS: DEFAULTS2,
-        defaults: withDefaults.bind(null, DEFAULTS2),
-        merge: merge.bind(null, DEFAULTS2),
-        parse: parse2
-      });
-    }
-    var import_universal_user_agent = require_dist_node3();
-    var VERSION = "7.0.6";
-    var userAgent = `octokit-endpoint.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`;
-    var DEFAULTS = {
-      method: "GET",
-      baseUrl: "https://api.github.com",
-      headers: {
-        accept: "application/vnd.github.v3+json",
-        "user-agent": userAgent
-      },
-      mediaType: {
-        format: "",
-        previews: []
-      }
-    };
-    var endpoint = withDefaults(null, DEFAULTS);
-  }
-});
-
-// node_modules/@octokit/auth-oauth-user/node_modules/@octokit/request-error/dist-node/index.js
-var require_dist_node26 = __commonJS({
-  "node_modules/@octokit/auth-oauth-user/node_modules/@octokit/request-error/dist-node/index.js"(exports2) {
-    "use strict";
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    function _interopDefault(ex) {
-      return ex && typeof ex === "object" && "default" in ex ? ex["default"] : ex;
-    }
-    var deprecation = require_dist_node5();
-    var once = _interopDefault(require_once());
-    var logOnceCode = once((deprecation2) => console.warn(deprecation2));
-    var logOnceHeaders = once((deprecation2) => console.warn(deprecation2));
-    var RequestError = class extends Error {
-      constructor(message, statusCode, options2) {
-        super(message);
-        if (Error.captureStackTrace) {
-          Error.captureStackTrace(this, this.constructor);
-        }
-        this.name = "HttpError";
-        this.status = statusCode;
-        let headers;
-        if ("headers" in options2 && typeof options2.headers !== "undefined") {
-          headers = options2.headers;
-        }
-        if ("response" in options2) {
-          this.response = options2.response;
-          headers = options2.response.headers;
-        }
-        const requestCopy = Object.assign({}, options2.request);
-        if (options2.request.headers.authorization) {
-          requestCopy.headers = Object.assign({}, options2.request.headers, {
-            authorization: options2.request.headers.authorization.replace(/ .*$/, " [REDACTED]")
-          });
-        }
-        requestCopy.url = requestCopy.url.replace(/\bclient_secret=\w+/g, "client_secret=[REDACTED]").replace(/\baccess_token=\w+/g, "access_token=[REDACTED]");
-        this.request = requestCopy;
-        Object.defineProperty(this, "code", {
-          get() {
-            logOnceCode(new deprecation.Deprecation("[@octokit/request-error] `error.code` is deprecated, use `error.status`."));
-            return statusCode;
-          }
-        });
-        Object.defineProperty(this, "headers", {
-          get() {
-            logOnceHeaders(new deprecation.Deprecation("[@octokit/request-error] `error.headers` is deprecated, use `error.response.headers`."));
-            return headers || {};
-          }
-        });
-      }
-    };
-    exports2.RequestError = RequestError;
-  }
-});
-
-// node_modules/@octokit/auth-oauth-user/node_modules/@octokit/request/dist-node/index.js
-var require_dist_node27 = __commonJS({
-  "node_modules/@octokit/auth-oauth-user/node_modules/@octokit/request/dist-node/index.js"(exports2, module2) {
-    "use strict";
-    var __create2 = Object.create;
-    var __defProp2 = Object.defineProperty;
-    var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
-    var __getOwnPropNames2 = Object.getOwnPropertyNames;
-    var __getProtoOf2 = Object.getPrototypeOf;
-    var __hasOwnProp2 = Object.prototype.hasOwnProperty;
-    var __export2 = (target, all) => {
-      for (var name in all)
-        __defProp2(target, name, { get: all[name], enumerable: true });
-    };
-    var __copyProps2 = (to, from, except, desc) => {
-      if (from && typeof from === "object" || typeof from === "function") {
-        for (let key of __getOwnPropNames2(from))
-          if (!__hasOwnProp2.call(to, key) && key !== except)
-            __defProp2(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc2(from, key)) || desc.enumerable });
-      }
-      return to;
-    };
-    var __toESM2 = (mod, isNodeMode, target) => (target = mod != null ? __create2(__getProtoOf2(mod)) : {}, __copyProps2(
-      // If the importer is in node compatibility mode or this is not an ESM
-      // file that has been converted to a CommonJS file using a Babel-
-      // compatible transform (i.e. "__esModule" has not been set), then set
-      // "default" to the CommonJS "module.exports" for node compatibility.
-      isNodeMode || !mod || !mod.__esModule ? __defProp2(target, "default", { value: mod, enumerable: true }) : target,
-      mod
-    ));
-    var __toCommonJS2 = (mod) => __copyProps2(__defProp2({}, "__esModule", { value: true }), mod);
-    var dist_src_exports = {};
-    __export2(dist_src_exports, {
-      request: () => request
-    });
-    module2.exports = __toCommonJS2(dist_src_exports);
-    var import_endpoint = require_dist_node25();
-    var import_universal_user_agent = require_dist_node3();
-    var VERSION = "6.2.8";
-    var import_is_plain_object = require_is_plain_object();
-    var import_node_fetch = __toESM2(require_lib6());
-    var import_request_error = require_dist_node26();
-    function getBufferResponse(response) {
-      return response.arrayBuffer();
-    }
-    function fetchWrapper(requestOptions) {
-      const log = requestOptions.request && requestOptions.request.log ? requestOptions.request.log : console;
-      if ((0, import_is_plain_object.isPlainObject)(requestOptions.body) || Array.isArray(requestOptions.body)) {
-        requestOptions.body = JSON.stringify(requestOptions.body);
-      }
-      let headers = {};
-      let status;
-      let url;
-      const fetch2 = requestOptions.request && requestOptions.request.fetch || globalThis.fetch || /* istanbul ignore next */
-      import_node_fetch.default;
-      return fetch2(
-        requestOptions.url,
-        Object.assign(
-          {
-            method: requestOptions.method,
-            body: requestOptions.body,
-            headers: requestOptions.headers,
-            redirect: requestOptions.redirect,
-            // duplex must be set if request.body is ReadableStream or Async Iterables.
-            // See https://fetch.spec.whatwg.org/#dom-requestinit-duplex.
-            ...requestOptions.body && { duplex: "half" }
-          },
-          // `requestOptions.request.agent` type is incompatible
-          // see https://github.com/octokit/types.ts/pull/264
-          requestOptions.request
-        )
-      ).then(async (response) => {
-        url = response.url;
-        status = response.status;
-        for (const keyAndValue of response.headers) {
-          headers[keyAndValue[0]] = keyAndValue[1];
-        }
-        if ("deprecation" in headers) {
-          const matches = headers.link && headers.link.match(/<([^>]+)>; rel="deprecation"/);
-          const deprecationLink = matches && matches.pop();
-          log.warn(
-            `[@octokit/request] "${requestOptions.method} ${requestOptions.url}" is deprecated. It is scheduled to be removed on ${headers.sunset}${deprecationLink ? `. See ${deprecationLink}` : ""}`
-          );
-        }
-        if (status === 204 || status === 205) {
-          return;
-        }
-        if (requestOptions.method === "HEAD") {
-          if (status < 400) {
-            return;
-          }
-          throw new import_request_error.RequestError(response.statusText, status, {
-            response: {
-              url,
-              status,
-              headers,
-              data: void 0
-            },
-            request: requestOptions
-          });
-        }
-        if (status === 304) {
-          throw new import_request_error.RequestError("Not modified", status, {
-            response: {
-              url,
-              status,
-              headers,
-              data: await getResponseData(response)
-            },
-            request: requestOptions
-          });
-        }
-        if (status >= 400) {
-          const data = await getResponseData(response);
-          const error = new import_request_error.RequestError(toErrorMessage(data), status, {
-            response: {
-              url,
-              status,
-              headers,
-              data
-            },
-            request: requestOptions
-          });
-          throw error;
-        }
-        return getResponseData(response);
-      }).then((data) => {
-        return {
-          status,
-          url,
-          headers,
-          data
-        };
-      }).catch((error) => {
-        if (error instanceof import_request_error.RequestError)
-          throw error;
-        else if (error.name === "AbortError")
-          throw error;
-        throw new import_request_error.RequestError(error.message, 500, {
-          request: requestOptions
-        });
-      });
-    }
-    async function getResponseData(response) {
-      const contentType = response.headers.get("content-type");
-      if (/application\/json/.test(contentType)) {
-        return response.json();
-      }
-      if (!contentType || /^text\/|charset=utf-8$/.test(contentType)) {
-        return response.text();
-      }
-      return getBufferResponse(response);
-    }
-    function toErrorMessage(data) {
-      if (typeof data === "string")
-        return data;
-      if ("message" in data) {
-        if (Array.isArray(data.errors)) {
-          return `${data.message}: ${data.errors.map(JSON.stringify).join(", ")}`;
-        }
-        return data.message;
-      }
-      return `Unknown error: ${JSON.stringify(data)}`;
-    }
-    function withDefaults(oldEndpoint, newDefaults) {
-      const endpoint2 = oldEndpoint.defaults(newDefaults);
-      const newApi = function(route, parameters) {
-        const endpointOptions = endpoint2.merge(route, parameters);
-        if (!endpointOptions.request || !endpointOptions.request.hook) {
-          return fetchWrapper(endpoint2.parse(endpointOptions));
-        }
-        const request2 = (route2, parameters2) => {
-          return fetchWrapper(
-            endpoint2.parse(endpoint2.merge(route2, parameters2))
-          );
-        };
-        Object.assign(request2, {
-          endpoint: endpoint2,
-          defaults: withDefaults.bind(null, endpoint2)
-        });
-        return endpointOptions.request.hook(request2, endpointOptions);
-      };
-      return Object.assign(newApi, {
-        endpoint: endpoint2,
-        defaults: withDefaults.bind(null, endpoint2)
-      });
-    }
-    var request = withDefaults(import_endpoint.endpoint, {
-      headers: {
-        "user-agent": `octokit-request.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`
-      }
-    });
-  }
-});
-
-// node_modules/@octokit/auth-oauth-device/node_modules/@octokit/endpoint/dist-node/index.js
-var require_dist_node28 = __commonJS({
-  "node_modules/@octokit/auth-oauth-device/node_modules/@octokit/endpoint/dist-node/index.js"(exports2, module2) {
-    "use strict";
-    var __defProp2 = Object.defineProperty;
-    var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
-    var __getOwnPropNames2 = Object.getOwnPropertyNames;
-    var __hasOwnProp2 = Object.prototype.hasOwnProperty;
-    var __export2 = (target, all) => {
-      for (var name in all)
-        __defProp2(target, name, { get: all[name], enumerable: true });
-    };
-    var __copyProps2 = (to, from, except, desc) => {
-      if (from && typeof from === "object" || typeof from === "function") {
-        for (let key of __getOwnPropNames2(from))
-          if (!__hasOwnProp2.call(to, key) && key !== except)
-            __defProp2(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc2(from, key)) || desc.enumerable });
-      }
-      return to;
-    };
-    var __toCommonJS2 = (mod) => __copyProps2(__defProp2({}, "__esModule", { value: true }), mod);
-    var dist_src_exports = {};
-    __export2(dist_src_exports, {
-      endpoint: () => endpoint
-    });
-    module2.exports = __toCommonJS2(dist_src_exports);
-    function lowercaseKeys(object) {
-      if (!object) {
-        return {};
-      }
-      return Object.keys(object).reduce((newObj, key) => {
-        newObj[key.toLowerCase()] = object[key];
-        return newObj;
-      }, {});
-    }
-    var import_is_plain_object = require_is_plain_object();
-    function mergeDeep(defaults, options2) {
-      const result = Object.assign({}, defaults);
-      Object.keys(options2).forEach((key) => {
-        if ((0, import_is_plain_object.isPlainObject)(options2[key])) {
-          if (!(key in defaults))
-            Object.assign(result, { [key]: options2[key] });
-          else
-            result[key] = mergeDeep(defaults[key], options2[key]);
-        } else {
-          Object.assign(result, { [key]: options2[key] });
-        }
-      });
-      return result;
-    }
-    function removeUndefinedProperties(obj) {
-      for (const key in obj) {
-        if (obj[key] === void 0) {
-          delete obj[key];
-        }
-      }
-      return obj;
-    }
-    function merge(defaults, route, options2) {
-      if (typeof route === "string") {
-        let [method, url] = route.split(" ");
-        options2 = Object.assign(url ? { method, url } : { url: method }, options2);
-      } else {
-        options2 = Object.assign({}, route);
-      }
-      options2.headers = lowercaseKeys(options2.headers);
-      removeUndefinedProperties(options2);
-      removeUndefinedProperties(options2.headers);
-      const mergedOptions = mergeDeep(defaults || {}, options2);
-      if (defaults && defaults.mediaType.previews.length) {
-        mergedOptions.mediaType.previews = defaults.mediaType.previews.filter((preview) => !mergedOptions.mediaType.previews.includes(preview)).concat(mergedOptions.mediaType.previews);
-      }
-      mergedOptions.mediaType.previews = mergedOptions.mediaType.previews.map(
-        (preview) => preview.replace(/-preview/, "")
-      );
-      return mergedOptions;
-    }
-    function addQueryParameters(url, parameters) {
-      const separator = /\?/.test(url) ? "&" : "?";
-      const names = Object.keys(parameters);
-      if (names.length === 0) {
-        return url;
-      }
-      return url + separator + names.map((name) => {
-        if (name === "q") {
-          return "q=" + parameters.q.split("+").map(encodeURIComponent).join("+");
-        }
-        return `${name}=${encodeURIComponent(parameters[name])}`;
-      }).join("&");
-    }
-    var urlVariableRegex = /\{[^}]+\}/g;
-    function removeNonChars(variableName) {
-      return variableName.replace(/^\W+|\W+$/g, "").split(/,/);
-    }
-    function extractUrlVariableNames(url) {
-      const matches = url.match(urlVariableRegex);
-      if (!matches) {
-        return [];
-      }
-      return matches.map(removeNonChars).reduce((a, b) => a.concat(b), []);
-    }
-    function omit(object, keysToOmit) {
-      return Object.keys(object).filter((option) => !keysToOmit.includes(option)).reduce((obj, key) => {
-        obj[key] = object[key];
-        return obj;
-      }, {});
-    }
-    function encodeReserved(str) {
-      return str.split(/(%[0-9A-Fa-f]{2})/g).map(function(part) {
-        if (!/%[0-9A-Fa-f]/.test(part)) {
-          part = encodeURI(part).replace(/%5B/g, "[").replace(/%5D/g, "]");
-        }
-        return part;
-      }).join("");
-    }
-    function encodeUnreserved(str) {
-      return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
-        return "%" + c.charCodeAt(0).toString(16).toUpperCase();
-      });
-    }
-    function encodeValue(operator, value, key) {
-      value = operator === "+" || operator === "#" ? encodeReserved(value) : encodeUnreserved(value);
-      if (key) {
-        return encodeUnreserved(key) + "=" + value;
-      } else {
-        return value;
-      }
-    }
-    function isDefined(value) {
-      return value !== void 0 && value !== null;
-    }
-    function isKeyOperator(operator) {
-      return operator === ";" || operator === "&" || operator === "?";
-    }
-    function getValues(context, operator, key, modifier) {
-      var value = context[key], result = [];
-      if (isDefined(value) && value !== "") {
-        if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-          value = value.toString();
-          if (modifier && modifier !== "*") {
-            value = value.substring(0, parseInt(modifier, 10));
-          }
-          result.push(
-            encodeValue(operator, value, isKeyOperator(operator) ? key : "")
-          );
-        } else {
-          if (modifier === "*") {
-            if (Array.isArray(value)) {
-              value.filter(isDefined).forEach(function(value2) {
-                result.push(
-                  encodeValue(operator, value2, isKeyOperator(operator) ? key : "")
-                );
-              });
-            } else {
-              Object.keys(value).forEach(function(k) {
-                if (isDefined(value[k])) {
-                  result.push(encodeValue(operator, value[k], k));
-                }
-              });
-            }
-          } else {
-            const tmp = [];
-            if (Array.isArray(value)) {
-              value.filter(isDefined).forEach(function(value2) {
-                tmp.push(encodeValue(operator, value2));
-              });
-            } else {
-              Object.keys(value).forEach(function(k) {
-                if (isDefined(value[k])) {
-                  tmp.push(encodeUnreserved(k));
-                  tmp.push(encodeValue(operator, value[k].toString()));
-                }
-              });
-            }
-            if (isKeyOperator(operator)) {
-              result.push(encodeUnreserved(key) + "=" + tmp.join(","));
-            } else if (tmp.length !== 0) {
-              result.push(tmp.join(","));
-            }
-          }
-        }
-      } else {
-        if (operator === ";") {
-          if (isDefined(value)) {
-            result.push(encodeUnreserved(key));
-          }
-        } else if (value === "" && (operator === "&" || operator === "?")) {
-          result.push(encodeUnreserved(key) + "=");
-        } else if (value === "") {
-          result.push("");
-        }
-      }
-      return result;
-    }
-    function parseUrl(template) {
-      return {
-        expand: expand.bind(null, template)
-      };
-    }
-    function expand(template, context) {
-      var operators = ["+", "#", ".", "/", ";", "?", "&"];
-      return template.replace(
-        /\{([^\{\}]+)\}|([^\{\}]+)/g,
-        function(_, expression, literal) {
-          if (expression) {
-            let operator = "";
-            const values = [];
-            if (operators.indexOf(expression.charAt(0)) !== -1) {
-              operator = expression.charAt(0);
-              expression = expression.substr(1);
-            }
-            expression.split(/,/g).forEach(function(variable) {
-              var tmp = /([^:\*]*)(?::(\d+)|(\*))?/.exec(variable);
-              values.push(getValues(context, operator, tmp[1], tmp[2] || tmp[3]));
-            });
-            if (operator && operator !== "+") {
-              var separator = ",";
-              if (operator === "?") {
-                separator = "&";
-              } else if (operator !== "#") {
-                separator = operator;
-              }
-              return (values.length !== 0 ? operator : "") + values.join(separator);
-            } else {
-              return values.join(",");
-            }
-          } else {
-            return encodeReserved(literal);
-          }
-        }
-      );
-    }
-    function parse2(options2) {
-      let method = options2.method.toUpperCase();
-      let url = (options2.url || "/").replace(/:([a-z]\w+)/g, "{$1}");
-      let headers = Object.assign({}, options2.headers);
-      let body;
-      let parameters = omit(options2, [
-        "method",
-        "baseUrl",
-        "url",
-        "headers",
-        "request",
-        "mediaType"
-      ]);
-      const urlVariableNames = extractUrlVariableNames(url);
-      url = parseUrl(url).expand(parameters);
-      if (!/^http/.test(url)) {
-        url = options2.baseUrl + url;
-      }
-      const omittedParameters = Object.keys(options2).filter((option) => urlVariableNames.includes(option)).concat("baseUrl");
-      const remainingParameters = omit(parameters, omittedParameters);
-      const isBinaryRequest = /application\/octet-stream/i.test(headers.accept);
-      if (!isBinaryRequest) {
-        if (options2.mediaType.format) {
-          headers.accept = headers.accept.split(/,/).map(
-            (preview) => preview.replace(
-              /application\/vnd(\.\w+)(\.v3)?(\.\w+)?(\+json)?$/,
-              `application/vnd$1$2.${options2.mediaType.format}`
-            )
-          ).join(",");
-        }
-        if (options2.mediaType.previews.length) {
-          const previewsFromAcceptHeader = headers.accept.match(/[\w-]+(?=-preview)/g) || [];
-          headers.accept = previewsFromAcceptHeader.concat(options2.mediaType.previews).map((preview) => {
-            const format = options2.mediaType.format ? `.${options2.mediaType.format}` : "+json";
-            return `application/vnd.github.${preview}-preview${format}`;
-          }).join(",");
-        }
-      }
-      if (["GET", "HEAD"].includes(method)) {
-        url = addQueryParameters(url, remainingParameters);
-      } else {
-        if ("data" in remainingParameters) {
-          body = remainingParameters.data;
-        } else {
-          if (Object.keys(remainingParameters).length) {
-            body = remainingParameters;
-          }
-        }
-      }
-      if (!headers["content-type"] && typeof body !== "undefined") {
-        headers["content-type"] = "application/json; charset=utf-8";
-      }
-      if (["PATCH", "PUT"].includes(method) && typeof body === "undefined") {
-        body = "";
-      }
-      return Object.assign(
-        { method, url, headers },
-        typeof body !== "undefined" ? { body } : null,
-        options2.request ? { request: options2.request } : null
-      );
-    }
-    function endpointWithDefaults(defaults, route, options2) {
-      return parse2(merge(defaults, route, options2));
-    }
-    function withDefaults(oldDefaults, newDefaults) {
-      const DEFAULTS2 = merge(oldDefaults, newDefaults);
-      const endpoint2 = endpointWithDefaults.bind(null, DEFAULTS2);
-      return Object.assign(endpoint2, {
-        DEFAULTS: DEFAULTS2,
-        defaults: withDefaults.bind(null, DEFAULTS2),
-        merge: merge.bind(null, DEFAULTS2),
-        parse: parse2
-      });
-    }
-    var import_universal_user_agent = require_dist_node3();
-    var VERSION = "7.0.6";
-    var userAgent = `octokit-endpoint.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`;
-    var DEFAULTS = {
-      method: "GET",
-      baseUrl: "https://api.github.com",
-      headers: {
-        accept: "application/vnd.github.v3+json",
-        "user-agent": userAgent
-      },
-      mediaType: {
-        format: "",
-        previews: []
-      }
-    };
-    var endpoint = withDefaults(null, DEFAULTS);
-  }
-});
-
-// node_modules/@octokit/auth-oauth-device/node_modules/@octokit/request-error/dist-node/index.js
-var require_dist_node29 = __commonJS({
-  "node_modules/@octokit/auth-oauth-device/node_modules/@octokit/request-error/dist-node/index.js"(exports2) {
-    "use strict";
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    function _interopDefault(ex) {
-      return ex && typeof ex === "object" && "default" in ex ? ex["default"] : ex;
-    }
-    var deprecation = require_dist_node5();
-    var once = _interopDefault(require_once());
-    var logOnceCode = once((deprecation2) => console.warn(deprecation2));
-    var logOnceHeaders = once((deprecation2) => console.warn(deprecation2));
-    var RequestError = class extends Error {
-      constructor(message, statusCode, options2) {
-        super(message);
-        if (Error.captureStackTrace) {
-          Error.captureStackTrace(this, this.constructor);
-        }
-        this.name = "HttpError";
-        this.status = statusCode;
-        let headers;
-        if ("headers" in options2 && typeof options2.headers !== "undefined") {
-          headers = options2.headers;
-        }
-        if ("response" in options2) {
-          this.response = options2.response;
-          headers = options2.response.headers;
-        }
-        const requestCopy = Object.assign({}, options2.request);
-        if (options2.request.headers.authorization) {
-          requestCopy.headers = Object.assign({}, options2.request.headers, {
-            authorization: options2.request.headers.authorization.replace(/ .*$/, " [REDACTED]")
-          });
-        }
-        requestCopy.url = requestCopy.url.replace(/\bclient_secret=\w+/g, "client_secret=[REDACTED]").replace(/\baccess_token=\w+/g, "access_token=[REDACTED]");
-        this.request = requestCopy;
-        Object.defineProperty(this, "code", {
-          get() {
-            logOnceCode(new deprecation.Deprecation("[@octokit/request-error] `error.code` is deprecated, use `error.status`."));
-            return statusCode;
-          }
-        });
-        Object.defineProperty(this, "headers", {
-          get() {
-            logOnceHeaders(new deprecation.Deprecation("[@octokit/request-error] `error.headers` is deprecated, use `error.response.headers`."));
-            return headers || {};
-          }
-        });
-      }
-    };
-    exports2.RequestError = RequestError;
-  }
-});
-
-// node_modules/@octokit/auth-oauth-device/node_modules/@octokit/request/dist-node/index.js
-var require_dist_node30 = __commonJS({
-  "node_modules/@octokit/auth-oauth-device/node_modules/@octokit/request/dist-node/index.js"(exports2, module2) {
-    "use strict";
-    var __create2 = Object.create;
-    var __defProp2 = Object.defineProperty;
-    var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
-    var __getOwnPropNames2 = Object.getOwnPropertyNames;
-    var __getProtoOf2 = Object.getPrototypeOf;
-    var __hasOwnProp2 = Object.prototype.hasOwnProperty;
-    var __export2 = (target, all) => {
-      for (var name in all)
-        __defProp2(target, name, { get: all[name], enumerable: true });
-    };
-    var __copyProps2 = (to, from, except, desc) => {
-      if (from && typeof from === "object" || typeof from === "function") {
-        for (let key of __getOwnPropNames2(from))
-          if (!__hasOwnProp2.call(to, key) && key !== except)
-            __defProp2(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc2(from, key)) || desc.enumerable });
-      }
-      return to;
-    };
-    var __toESM2 = (mod, isNodeMode, target) => (target = mod != null ? __create2(__getProtoOf2(mod)) : {}, __copyProps2(
-      // If the importer is in node compatibility mode or this is not an ESM
-      // file that has been converted to a CommonJS file using a Babel-
-      // compatible transform (i.e. "__esModule" has not been set), then set
-      // "default" to the CommonJS "module.exports" for node compatibility.
-      isNodeMode || !mod || !mod.__esModule ? __defProp2(target, "default", { value: mod, enumerable: true }) : target,
-      mod
-    ));
-    var __toCommonJS2 = (mod) => __copyProps2(__defProp2({}, "__esModule", { value: true }), mod);
-    var dist_src_exports = {};
-    __export2(dist_src_exports, {
-      request: () => request
-    });
-    module2.exports = __toCommonJS2(dist_src_exports);
-    var import_endpoint = require_dist_node28();
-    var import_universal_user_agent = require_dist_node3();
-    var VERSION = "6.2.8";
-    var import_is_plain_object = require_is_plain_object();
-    var import_node_fetch = __toESM2(require_lib6());
-    var import_request_error = require_dist_node29();
-    function getBufferResponse(response) {
-      return response.arrayBuffer();
-    }
-    function fetchWrapper(requestOptions) {
-      const log = requestOptions.request && requestOptions.request.log ? requestOptions.request.log : console;
-      if ((0, import_is_plain_object.isPlainObject)(requestOptions.body) || Array.isArray(requestOptions.body)) {
-        requestOptions.body = JSON.stringify(requestOptions.body);
-      }
-      let headers = {};
-      let status;
-      let url;
-      const fetch2 = requestOptions.request && requestOptions.request.fetch || globalThis.fetch || /* istanbul ignore next */
-      import_node_fetch.default;
-      return fetch2(
-        requestOptions.url,
-        Object.assign(
-          {
-            method: requestOptions.method,
-            body: requestOptions.body,
-            headers: requestOptions.headers,
-            redirect: requestOptions.redirect,
-            // duplex must be set if request.body is ReadableStream or Async Iterables.
-            // See https://fetch.spec.whatwg.org/#dom-requestinit-duplex.
-            ...requestOptions.body && { duplex: "half" }
-          },
-          // `requestOptions.request.agent` type is incompatible
-          // see https://github.com/octokit/types.ts/pull/264
-          requestOptions.request
-        )
-      ).then(async (response) => {
-        url = response.url;
-        status = response.status;
-        for (const keyAndValue of response.headers) {
-          headers[keyAndValue[0]] = keyAndValue[1];
-        }
-        if ("deprecation" in headers) {
-          const matches = headers.link && headers.link.match(/<([^>]+)>; rel="deprecation"/);
-          const deprecationLink = matches && matches.pop();
-          log.warn(
-            `[@octokit/request] "${requestOptions.method} ${requestOptions.url}" is deprecated. It is scheduled to be removed on ${headers.sunset}${deprecationLink ? `. See ${deprecationLink}` : ""}`
-          );
-        }
-        if (status === 204 || status === 205) {
-          return;
-        }
-        if (requestOptions.method === "HEAD") {
-          if (status < 400) {
-            return;
-          }
-          throw new import_request_error.RequestError(response.statusText, status, {
-            response: {
-              url,
-              status,
-              headers,
-              data: void 0
-            },
-            request: requestOptions
-          });
-        }
-        if (status === 304) {
-          throw new import_request_error.RequestError("Not modified", status, {
-            response: {
-              url,
-              status,
-              headers,
-              data: await getResponseData(response)
-            },
-            request: requestOptions
-          });
-        }
-        if (status >= 400) {
-          const data = await getResponseData(response);
-          const error = new import_request_error.RequestError(toErrorMessage(data), status, {
-            response: {
-              url,
-              status,
-              headers,
-              data
-            },
-            request: requestOptions
-          });
-          throw error;
-        }
-        return getResponseData(response);
-      }).then((data) => {
-        return {
-          status,
-          url,
-          headers,
-          data
-        };
-      }).catch((error) => {
-        if (error instanceof import_request_error.RequestError)
-          throw error;
-        else if (error.name === "AbortError")
-          throw error;
-        throw new import_request_error.RequestError(error.message, 500, {
-          request: requestOptions
-        });
-      });
-    }
-    async function getResponseData(response) {
-      const contentType = response.headers.get("content-type");
-      if (/application\/json/.test(contentType)) {
-        return response.json();
-      }
-      if (!contentType || /^text\/|charset=utf-8$/.test(contentType)) {
-        return response.text();
-      }
-      return getBufferResponse(response);
-    }
-    function toErrorMessage(data) {
-      if (typeof data === "string")
-        return data;
-      if ("message" in data) {
-        if (Array.isArray(data.errors)) {
-          return `${data.message}: ${data.errors.map(JSON.stringify).join(", ")}`;
-        }
-        return data.message;
-      }
-      return `Unknown error: ${JSON.stringify(data)}`;
-    }
-    function withDefaults(oldEndpoint, newDefaults) {
-      const endpoint2 = oldEndpoint.defaults(newDefaults);
-      const newApi = function(route, parameters) {
-        const endpointOptions = endpoint2.merge(route, parameters);
-        if (!endpointOptions.request || !endpointOptions.request.hook) {
-          return fetchWrapper(endpoint2.parse(endpointOptions));
-        }
-        const request2 = (route2, parameters2) => {
-          return fetchWrapper(
-            endpoint2.parse(endpoint2.merge(route2, parameters2))
-          );
-        };
-        Object.assign(request2, {
-          endpoint: endpoint2,
-          defaults: withDefaults.bind(null, endpoint2)
-        });
-        return endpointOptions.request.hook(request2, endpointOptions);
-      };
-      return Object.assign(newApi, {
-        endpoint: endpoint2,
-        defaults: withDefaults.bind(null, endpoint2)
-      });
-    }
-    var request = withDefaults(import_endpoint.endpoint, {
-      headers: {
-        "user-agent": `octokit-request.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`
-      }
-    });
-  }
-});
-
 // node_modules/@octokit/oauth-authorization-url/dist-node/index.js
-var require_dist_node31 = __commonJS({
+var require_dist_node23 = __commonJS({
   "node_modules/@octokit/oauth-authorization-url/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -75464,333 +73895,8 @@ var require_dist_node31 = __commonJS({
   }
 });
 
-// node_modules/@octokit/oauth-methods/node_modules/@octokit/endpoint/dist-node/index.js
-var require_dist_node32 = __commonJS({
-  "node_modules/@octokit/oauth-methods/node_modules/@octokit/endpoint/dist-node/index.js"(exports2, module2) {
-    "use strict";
-    var __defProp2 = Object.defineProperty;
-    var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
-    var __getOwnPropNames2 = Object.getOwnPropertyNames;
-    var __hasOwnProp2 = Object.prototype.hasOwnProperty;
-    var __export2 = (target, all) => {
-      for (var name in all)
-        __defProp2(target, name, { get: all[name], enumerable: true });
-    };
-    var __copyProps2 = (to, from, except, desc) => {
-      if (from && typeof from === "object" || typeof from === "function") {
-        for (let key of __getOwnPropNames2(from))
-          if (!__hasOwnProp2.call(to, key) && key !== except)
-            __defProp2(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc2(from, key)) || desc.enumerable });
-      }
-      return to;
-    };
-    var __toCommonJS2 = (mod) => __copyProps2(__defProp2({}, "__esModule", { value: true }), mod);
-    var dist_src_exports = {};
-    __export2(dist_src_exports, {
-      endpoint: () => endpoint
-    });
-    module2.exports = __toCommonJS2(dist_src_exports);
-    function lowercaseKeys(object) {
-      if (!object) {
-        return {};
-      }
-      return Object.keys(object).reduce((newObj, key) => {
-        newObj[key.toLowerCase()] = object[key];
-        return newObj;
-      }, {});
-    }
-    var import_is_plain_object = require_is_plain_object();
-    function mergeDeep(defaults, options2) {
-      const result = Object.assign({}, defaults);
-      Object.keys(options2).forEach((key) => {
-        if ((0, import_is_plain_object.isPlainObject)(options2[key])) {
-          if (!(key in defaults))
-            Object.assign(result, { [key]: options2[key] });
-          else
-            result[key] = mergeDeep(defaults[key], options2[key]);
-        } else {
-          Object.assign(result, { [key]: options2[key] });
-        }
-      });
-      return result;
-    }
-    function removeUndefinedProperties(obj) {
-      for (const key in obj) {
-        if (obj[key] === void 0) {
-          delete obj[key];
-        }
-      }
-      return obj;
-    }
-    function merge(defaults, route, options2) {
-      if (typeof route === "string") {
-        let [method, url] = route.split(" ");
-        options2 = Object.assign(url ? { method, url } : { url: method }, options2);
-      } else {
-        options2 = Object.assign({}, route);
-      }
-      options2.headers = lowercaseKeys(options2.headers);
-      removeUndefinedProperties(options2);
-      removeUndefinedProperties(options2.headers);
-      const mergedOptions = mergeDeep(defaults || {}, options2);
-      if (defaults && defaults.mediaType.previews.length) {
-        mergedOptions.mediaType.previews = defaults.mediaType.previews.filter((preview) => !mergedOptions.mediaType.previews.includes(preview)).concat(mergedOptions.mediaType.previews);
-      }
-      mergedOptions.mediaType.previews = mergedOptions.mediaType.previews.map(
-        (preview) => preview.replace(/-preview/, "")
-      );
-      return mergedOptions;
-    }
-    function addQueryParameters(url, parameters) {
-      const separator = /\?/.test(url) ? "&" : "?";
-      const names = Object.keys(parameters);
-      if (names.length === 0) {
-        return url;
-      }
-      return url + separator + names.map((name) => {
-        if (name === "q") {
-          return "q=" + parameters.q.split("+").map(encodeURIComponent).join("+");
-        }
-        return `${name}=${encodeURIComponent(parameters[name])}`;
-      }).join("&");
-    }
-    var urlVariableRegex = /\{[^}]+\}/g;
-    function removeNonChars(variableName) {
-      return variableName.replace(/^\W+|\W+$/g, "").split(/,/);
-    }
-    function extractUrlVariableNames(url) {
-      const matches = url.match(urlVariableRegex);
-      if (!matches) {
-        return [];
-      }
-      return matches.map(removeNonChars).reduce((a, b) => a.concat(b), []);
-    }
-    function omit(object, keysToOmit) {
-      return Object.keys(object).filter((option) => !keysToOmit.includes(option)).reduce((obj, key) => {
-        obj[key] = object[key];
-        return obj;
-      }, {});
-    }
-    function encodeReserved(str) {
-      return str.split(/(%[0-9A-Fa-f]{2})/g).map(function(part) {
-        if (!/%[0-9A-Fa-f]/.test(part)) {
-          part = encodeURI(part).replace(/%5B/g, "[").replace(/%5D/g, "]");
-        }
-        return part;
-      }).join("");
-    }
-    function encodeUnreserved(str) {
-      return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
-        return "%" + c.charCodeAt(0).toString(16).toUpperCase();
-      });
-    }
-    function encodeValue(operator, value, key) {
-      value = operator === "+" || operator === "#" ? encodeReserved(value) : encodeUnreserved(value);
-      if (key) {
-        return encodeUnreserved(key) + "=" + value;
-      } else {
-        return value;
-      }
-    }
-    function isDefined(value) {
-      return value !== void 0 && value !== null;
-    }
-    function isKeyOperator(operator) {
-      return operator === ";" || operator === "&" || operator === "?";
-    }
-    function getValues(context, operator, key, modifier) {
-      var value = context[key], result = [];
-      if (isDefined(value) && value !== "") {
-        if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-          value = value.toString();
-          if (modifier && modifier !== "*") {
-            value = value.substring(0, parseInt(modifier, 10));
-          }
-          result.push(
-            encodeValue(operator, value, isKeyOperator(operator) ? key : "")
-          );
-        } else {
-          if (modifier === "*") {
-            if (Array.isArray(value)) {
-              value.filter(isDefined).forEach(function(value2) {
-                result.push(
-                  encodeValue(operator, value2, isKeyOperator(operator) ? key : "")
-                );
-              });
-            } else {
-              Object.keys(value).forEach(function(k) {
-                if (isDefined(value[k])) {
-                  result.push(encodeValue(operator, value[k], k));
-                }
-              });
-            }
-          } else {
-            const tmp = [];
-            if (Array.isArray(value)) {
-              value.filter(isDefined).forEach(function(value2) {
-                tmp.push(encodeValue(operator, value2));
-              });
-            } else {
-              Object.keys(value).forEach(function(k) {
-                if (isDefined(value[k])) {
-                  tmp.push(encodeUnreserved(k));
-                  tmp.push(encodeValue(operator, value[k].toString()));
-                }
-              });
-            }
-            if (isKeyOperator(operator)) {
-              result.push(encodeUnreserved(key) + "=" + tmp.join(","));
-            } else if (tmp.length !== 0) {
-              result.push(tmp.join(","));
-            }
-          }
-        }
-      } else {
-        if (operator === ";") {
-          if (isDefined(value)) {
-            result.push(encodeUnreserved(key));
-          }
-        } else if (value === "" && (operator === "&" || operator === "?")) {
-          result.push(encodeUnreserved(key) + "=");
-        } else if (value === "") {
-          result.push("");
-        }
-      }
-      return result;
-    }
-    function parseUrl(template) {
-      return {
-        expand: expand.bind(null, template)
-      };
-    }
-    function expand(template, context) {
-      var operators = ["+", "#", ".", "/", ";", "?", "&"];
-      return template.replace(
-        /\{([^\{\}]+)\}|([^\{\}]+)/g,
-        function(_, expression, literal) {
-          if (expression) {
-            let operator = "";
-            const values = [];
-            if (operators.indexOf(expression.charAt(0)) !== -1) {
-              operator = expression.charAt(0);
-              expression = expression.substr(1);
-            }
-            expression.split(/,/g).forEach(function(variable) {
-              var tmp = /([^:\*]*)(?::(\d+)|(\*))?/.exec(variable);
-              values.push(getValues(context, operator, tmp[1], tmp[2] || tmp[3]));
-            });
-            if (operator && operator !== "+") {
-              var separator = ",";
-              if (operator === "?") {
-                separator = "&";
-              } else if (operator !== "#") {
-                separator = operator;
-              }
-              return (values.length !== 0 ? operator : "") + values.join(separator);
-            } else {
-              return values.join(",");
-            }
-          } else {
-            return encodeReserved(literal);
-          }
-        }
-      );
-    }
-    function parse2(options2) {
-      let method = options2.method.toUpperCase();
-      let url = (options2.url || "/").replace(/:([a-z]\w+)/g, "{$1}");
-      let headers = Object.assign({}, options2.headers);
-      let body;
-      let parameters = omit(options2, [
-        "method",
-        "baseUrl",
-        "url",
-        "headers",
-        "request",
-        "mediaType"
-      ]);
-      const urlVariableNames = extractUrlVariableNames(url);
-      url = parseUrl(url).expand(parameters);
-      if (!/^http/.test(url)) {
-        url = options2.baseUrl + url;
-      }
-      const omittedParameters = Object.keys(options2).filter((option) => urlVariableNames.includes(option)).concat("baseUrl");
-      const remainingParameters = omit(parameters, omittedParameters);
-      const isBinaryRequest = /application\/octet-stream/i.test(headers.accept);
-      if (!isBinaryRequest) {
-        if (options2.mediaType.format) {
-          headers.accept = headers.accept.split(/,/).map(
-            (preview) => preview.replace(
-              /application\/vnd(\.\w+)(\.v3)?(\.\w+)?(\+json)?$/,
-              `application/vnd$1$2.${options2.mediaType.format}`
-            )
-          ).join(",");
-        }
-        if (options2.mediaType.previews.length) {
-          const previewsFromAcceptHeader = headers.accept.match(/[\w-]+(?=-preview)/g) || [];
-          headers.accept = previewsFromAcceptHeader.concat(options2.mediaType.previews).map((preview) => {
-            const format = options2.mediaType.format ? `.${options2.mediaType.format}` : "+json";
-            return `application/vnd.github.${preview}-preview${format}`;
-          }).join(",");
-        }
-      }
-      if (["GET", "HEAD"].includes(method)) {
-        url = addQueryParameters(url, remainingParameters);
-      } else {
-        if ("data" in remainingParameters) {
-          body = remainingParameters.data;
-        } else {
-          if (Object.keys(remainingParameters).length) {
-            body = remainingParameters;
-          }
-        }
-      }
-      if (!headers["content-type"] && typeof body !== "undefined") {
-        headers["content-type"] = "application/json; charset=utf-8";
-      }
-      if (["PATCH", "PUT"].includes(method) && typeof body === "undefined") {
-        body = "";
-      }
-      return Object.assign(
-        { method, url, headers },
-        typeof body !== "undefined" ? { body } : null,
-        options2.request ? { request: options2.request } : null
-      );
-    }
-    function endpointWithDefaults(defaults, route, options2) {
-      return parse2(merge(defaults, route, options2));
-    }
-    function withDefaults(oldDefaults, newDefaults) {
-      const DEFAULTS2 = merge(oldDefaults, newDefaults);
-      const endpoint2 = endpointWithDefaults.bind(null, DEFAULTS2);
-      return Object.assign(endpoint2, {
-        DEFAULTS: DEFAULTS2,
-        defaults: withDefaults.bind(null, DEFAULTS2),
-        merge: merge.bind(null, DEFAULTS2),
-        parse: parse2
-      });
-    }
-    var import_universal_user_agent = require_dist_node3();
-    var VERSION = "7.0.6";
-    var userAgent = `octokit-endpoint.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`;
-    var DEFAULTS = {
-      method: "GET",
-      baseUrl: "https://api.github.com",
-      headers: {
-        accept: "application/vnd.github.v3+json",
-        "user-agent": userAgent
-      },
-      mediaType: {
-        format: "",
-        previews: []
-      }
-    };
-    var endpoint = withDefaults(null, DEFAULTS);
-  }
-});
-
 // node_modules/@octokit/oauth-methods/node_modules/@octokit/request-error/dist-node/index.js
-var require_dist_node33 = __commonJS({
+var require_dist_node24 = __commonJS({
   "node_modules/@octokit/oauth-methods/node_modules/@octokit/request-error/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -75843,203 +73949,8 @@ var require_dist_node33 = __commonJS({
   }
 });
 
-// node_modules/@octokit/oauth-methods/node_modules/@octokit/request/dist-node/index.js
-var require_dist_node34 = __commonJS({
-  "node_modules/@octokit/oauth-methods/node_modules/@octokit/request/dist-node/index.js"(exports2, module2) {
-    "use strict";
-    var __create2 = Object.create;
-    var __defProp2 = Object.defineProperty;
-    var __getOwnPropDesc2 = Object.getOwnPropertyDescriptor;
-    var __getOwnPropNames2 = Object.getOwnPropertyNames;
-    var __getProtoOf2 = Object.getPrototypeOf;
-    var __hasOwnProp2 = Object.prototype.hasOwnProperty;
-    var __export2 = (target, all) => {
-      for (var name in all)
-        __defProp2(target, name, { get: all[name], enumerable: true });
-    };
-    var __copyProps2 = (to, from, except, desc) => {
-      if (from && typeof from === "object" || typeof from === "function") {
-        for (let key of __getOwnPropNames2(from))
-          if (!__hasOwnProp2.call(to, key) && key !== except)
-            __defProp2(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc2(from, key)) || desc.enumerable });
-      }
-      return to;
-    };
-    var __toESM2 = (mod, isNodeMode, target) => (target = mod != null ? __create2(__getProtoOf2(mod)) : {}, __copyProps2(
-      // If the importer is in node compatibility mode or this is not an ESM
-      // file that has been converted to a CommonJS file using a Babel-
-      // compatible transform (i.e. "__esModule" has not been set), then set
-      // "default" to the CommonJS "module.exports" for node compatibility.
-      isNodeMode || !mod || !mod.__esModule ? __defProp2(target, "default", { value: mod, enumerable: true }) : target,
-      mod
-    ));
-    var __toCommonJS2 = (mod) => __copyProps2(__defProp2({}, "__esModule", { value: true }), mod);
-    var dist_src_exports = {};
-    __export2(dist_src_exports, {
-      request: () => request
-    });
-    module2.exports = __toCommonJS2(dist_src_exports);
-    var import_endpoint = require_dist_node32();
-    var import_universal_user_agent = require_dist_node3();
-    var VERSION = "6.2.8";
-    var import_is_plain_object = require_is_plain_object();
-    var import_node_fetch = __toESM2(require_lib6());
-    var import_request_error = require_dist_node33();
-    function getBufferResponse(response) {
-      return response.arrayBuffer();
-    }
-    function fetchWrapper(requestOptions) {
-      const log = requestOptions.request && requestOptions.request.log ? requestOptions.request.log : console;
-      if ((0, import_is_plain_object.isPlainObject)(requestOptions.body) || Array.isArray(requestOptions.body)) {
-        requestOptions.body = JSON.stringify(requestOptions.body);
-      }
-      let headers = {};
-      let status;
-      let url;
-      const fetch2 = requestOptions.request && requestOptions.request.fetch || globalThis.fetch || /* istanbul ignore next */
-      import_node_fetch.default;
-      return fetch2(
-        requestOptions.url,
-        Object.assign(
-          {
-            method: requestOptions.method,
-            body: requestOptions.body,
-            headers: requestOptions.headers,
-            redirect: requestOptions.redirect,
-            // duplex must be set if request.body is ReadableStream or Async Iterables.
-            // See https://fetch.spec.whatwg.org/#dom-requestinit-duplex.
-            ...requestOptions.body && { duplex: "half" }
-          },
-          // `requestOptions.request.agent` type is incompatible
-          // see https://github.com/octokit/types.ts/pull/264
-          requestOptions.request
-        )
-      ).then(async (response) => {
-        url = response.url;
-        status = response.status;
-        for (const keyAndValue of response.headers) {
-          headers[keyAndValue[0]] = keyAndValue[1];
-        }
-        if ("deprecation" in headers) {
-          const matches = headers.link && headers.link.match(/<([^>]+)>; rel="deprecation"/);
-          const deprecationLink = matches && matches.pop();
-          log.warn(
-            `[@octokit/request] "${requestOptions.method} ${requestOptions.url}" is deprecated. It is scheduled to be removed on ${headers.sunset}${deprecationLink ? `. See ${deprecationLink}` : ""}`
-          );
-        }
-        if (status === 204 || status === 205) {
-          return;
-        }
-        if (requestOptions.method === "HEAD") {
-          if (status < 400) {
-            return;
-          }
-          throw new import_request_error.RequestError(response.statusText, status, {
-            response: {
-              url,
-              status,
-              headers,
-              data: void 0
-            },
-            request: requestOptions
-          });
-        }
-        if (status === 304) {
-          throw new import_request_error.RequestError("Not modified", status, {
-            response: {
-              url,
-              status,
-              headers,
-              data: await getResponseData(response)
-            },
-            request: requestOptions
-          });
-        }
-        if (status >= 400) {
-          const data = await getResponseData(response);
-          const error = new import_request_error.RequestError(toErrorMessage(data), status, {
-            response: {
-              url,
-              status,
-              headers,
-              data
-            },
-            request: requestOptions
-          });
-          throw error;
-        }
-        return getResponseData(response);
-      }).then((data) => {
-        return {
-          status,
-          url,
-          headers,
-          data
-        };
-      }).catch((error) => {
-        if (error instanceof import_request_error.RequestError)
-          throw error;
-        else if (error.name === "AbortError")
-          throw error;
-        throw new import_request_error.RequestError(error.message, 500, {
-          request: requestOptions
-        });
-      });
-    }
-    async function getResponseData(response) {
-      const contentType = response.headers.get("content-type");
-      if (/application\/json/.test(contentType)) {
-        return response.json();
-      }
-      if (!contentType || /^text\/|charset=utf-8$/.test(contentType)) {
-        return response.text();
-      }
-      return getBufferResponse(response);
-    }
-    function toErrorMessage(data) {
-      if (typeof data === "string")
-        return data;
-      if ("message" in data) {
-        if (Array.isArray(data.errors)) {
-          return `${data.message}: ${data.errors.map(JSON.stringify).join(", ")}`;
-        }
-        return data.message;
-      }
-      return `Unknown error: ${JSON.stringify(data)}`;
-    }
-    function withDefaults(oldEndpoint, newDefaults) {
-      const endpoint2 = oldEndpoint.defaults(newDefaults);
-      const newApi = function(route, parameters) {
-        const endpointOptions = endpoint2.merge(route, parameters);
-        if (!endpointOptions.request || !endpointOptions.request.hook) {
-          return fetchWrapper(endpoint2.parse(endpointOptions));
-        }
-        const request2 = (route2, parameters2) => {
-          return fetchWrapper(
-            endpoint2.parse(endpoint2.merge(route2, parameters2))
-          );
-        };
-        Object.assign(request2, {
-          endpoint: endpoint2,
-          defaults: withDefaults.bind(null, endpoint2)
-        });
-        return endpointOptions.request.hook(request2, endpointOptions);
-      };
-      return Object.assign(newApi, {
-        endpoint: endpoint2,
-        defaults: withDefaults.bind(null, endpoint2)
-      });
-    }
-    var request = withDefaults(import_endpoint.endpoint, {
-      headers: {
-        "user-agent": `octokit-request.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`
-      }
-    });
-  }
-});
-
 // node_modules/@octokit/oauth-methods/dist-node/index.js
-var require_dist_node35 = __commonJS({
+var require_dist_node25 = __commonJS({
   "node_modules/@octokit/oauth-methods/dist-node/index.js"(exports2, module2) {
     "use strict";
     var __create2 = Object.create;
@@ -76085,9 +73996,9 @@ var require_dist_node35 = __commonJS({
     });
     module2.exports = __toCommonJS2(dist_src_exports);
     var VERSION = "2.0.6";
-    var import_oauth_authorization_url = require_dist_node31();
-    var import_request = require_dist_node34();
-    var import_request_error = require_dist_node33();
+    var import_oauth_authorization_url = require_dist_node23();
+    var import_request = require_dist_node22();
+    var import_request_error = require_dist_node24();
     function requestToOAuthBaseUrl(request) {
       const endpointDefaults = request.endpoint.DEFAULTS;
       return /^https:\/\/(api\.)?github\.com$/.test(endpointDefaults.baseUrl) ? "https://github.com" : endpointDefaults.baseUrl.replace("/api/v3", "");
@@ -76128,7 +74039,7 @@ var require_dist_node35 = __commonJS({
         baseUrl
       });
     }
-    var import_request2 = require_dist_node34();
+    var import_request2 = require_dist_node22();
     async function exchangeWebFlowCode(options2) {
       const request = options2.request || /* istanbul ignore next: we always pass a custom request in tests */
       import_request2.request;
@@ -76167,7 +74078,7 @@ var require_dist_node35 = __commonJS({
     function toTimestamp(apiTimeInMs, expirationInSeconds) {
       return new Date(apiTimeInMs + expirationInSeconds * 1e3).toISOString();
     }
-    var import_request3 = require_dist_node34();
+    var import_request3 = require_dist_node22();
     async function createDeviceCode(options2) {
       const request = options2.request || /* istanbul ignore next: we always pass a custom request in tests */
       import_request3.request;
@@ -76179,7 +74090,7 @@ var require_dist_node35 = __commonJS({
       }
       return oauthRequest(request, "POST /login/device/code", parameters);
     }
-    var import_request4 = require_dist_node34();
+    var import_request4 = require_dist_node22();
     async function exchangeDeviceCode(options2) {
       const request = options2.request || /* istanbul ignore next: we always pass a custom request in tests */
       import_request4.request;
@@ -76219,7 +74130,7 @@ var require_dist_node35 = __commonJS({
     function toTimestamp2(apiTimeInMs, expirationInSeconds) {
       return new Date(apiTimeInMs + expirationInSeconds * 1e3).toISOString();
     }
-    var import_request5 = require_dist_node34();
+    var import_request5 = require_dist_node22();
     var import_btoa_lite = __toESM2(require_btoa_node());
     async function checkToken(options2) {
       const request = options2.request || /* istanbul ignore next: we always pass a custom request in tests */
@@ -76247,7 +74158,7 @@ var require_dist_node35 = __commonJS({
       }
       return { ...response, authentication };
     }
-    var import_request6 = require_dist_node34();
+    var import_request6 = require_dist_node22();
     async function refreshToken(options2) {
       const request = options2.request || /* istanbul ignore next: we always pass a custom request in tests */
       import_request6.request;
@@ -76279,7 +74190,7 @@ var require_dist_node35 = __commonJS({
     function toTimestamp3(apiTimeInMs, expirationInSeconds) {
       return new Date(apiTimeInMs + expirationInSeconds * 1e3).toISOString();
     }
-    var import_request7 = require_dist_node34();
+    var import_request7 = require_dist_node22();
     var import_btoa_lite2 = __toESM2(require_btoa_node());
     async function scopeToken(options2) {
       const {
@@ -76314,7 +74225,7 @@ var require_dist_node35 = __commonJS({
       );
       return { ...response, authentication };
     }
-    var import_request8 = require_dist_node34();
+    var import_request8 = require_dist_node22();
     var import_btoa_lite3 = __toESM2(require_btoa_node());
     async function resetToken(options2) {
       const request = options2.request || /* istanbul ignore next: we always pass a custom request in tests */
@@ -76344,7 +74255,7 @@ var require_dist_node35 = __commonJS({
       }
       return { ...response, authentication };
     }
-    var import_request9 = require_dist_node34();
+    var import_request9 = require_dist_node22();
     var import_btoa_lite4 = __toESM2(require_btoa_node());
     async function deleteToken(options2) {
       const request = options2.request || /* istanbul ignore next: we always pass a custom request in tests */
@@ -76361,7 +74272,7 @@ var require_dist_node35 = __commonJS({
         }
       );
     }
-    var import_request10 = require_dist_node34();
+    var import_request10 = require_dist_node22();
     var import_btoa_lite5 = __toESM2(require_btoa_node());
     async function deleteAuthorization(options2) {
       const request = options2.request || /* istanbul ignore next: we always pass a custom request in tests */
@@ -76382,7 +74293,7 @@ var require_dist_node35 = __commonJS({
 });
 
 // node_modules/@octokit/auth-oauth-device/dist-node/index.js
-var require_dist_node36 = __commonJS({
+var require_dist_node26 = __commonJS({
   "node_modules/@octokit/auth-oauth-device/dist-node/index.js"(exports2, module2) {
     "use strict";
     var __defProp2 = Object.defineProperty;
@@ -76408,8 +74319,8 @@ var require_dist_node36 = __commonJS({
     });
     module2.exports = __toCommonJS2(dist_src_exports);
     var import_universal_user_agent = require_dist_node3();
-    var import_request = require_dist_node30();
-    var import_oauth_methods = require_dist_node35();
+    var import_request = require_dist_node22();
+    var import_oauth_methods = require_dist_node25();
     async function getOAuthAccessToken(state, options2) {
       const cachedAuthentication = getCachedAuthentication(state, options2.auth);
       if (cachedAuthentication)
@@ -76539,7 +74450,7 @@ var require_dist_node36 = __commonJS({
 });
 
 // node_modules/@octokit/auth-oauth-user/dist-node/index.js
-var require_dist_node37 = __commonJS({
+var require_dist_node27 = __commonJS({
   "node_modules/@octokit/auth-oauth-user/dist-node/index.js"(exports2, module2) {
     "use strict";
     var __create2 = Object.create;
@@ -76576,10 +74487,10 @@ var require_dist_node37 = __commonJS({
     });
     module2.exports = __toCommonJS2(dist_src_exports);
     var import_universal_user_agent = require_dist_node3();
-    var import_request = require_dist_node27();
+    var import_request = require_dist_node22();
     var VERSION = "2.1.2";
-    var import_auth_oauth_device = require_dist_node36();
-    var import_oauth_methods = require_dist_node35();
+    var import_auth_oauth_device = require_dist_node26();
+    var import_oauth_methods = require_dist_node25();
     async function getAuthentication(state) {
       if ("code" in state.strategyOptions) {
         const { authentication } = await (0, import_oauth_methods.exchangeWebFlowCode)({
@@ -76625,7 +74536,7 @@ var require_dist_node37 = __commonJS({
       }
       throw new Error("[@octokit/auth-oauth-user] Invalid strategy options");
     }
-    var import_oauth_methods2 = require_dist_node35();
+    var import_oauth_methods2 = require_dist_node25();
     async function auth(state, options2 = {}) {
       var _a, _b;
       if (!state.authentication) {
@@ -76767,7 +74678,7 @@ var require_dist_node37 = __commonJS({
 });
 
 // node_modules/@octokit/auth-oauth-app/dist-node/index.js
-var require_dist_node38 = __commonJS({
+var require_dist_node28 = __commonJS({
   "node_modules/@octokit/auth-oauth-app/dist-node/index.js"(exports2, module2) {
     "use strict";
     var __create2 = Object.create;
@@ -76804,9 +74715,9 @@ var require_dist_node38 = __commonJS({
     });
     module2.exports = __toCommonJS2(dist_src_exports);
     var import_universal_user_agent = require_dist_node3();
-    var import_request = require_dist_node24();
+    var import_request = require_dist_node22();
     var import_btoa_lite = __toESM2(require_btoa_node());
-    var import_auth_oauth_user = require_dist_node37();
+    var import_auth_oauth_user = require_dist_node27();
     async function auth(state, authOptions) {
       if (authOptions.type === "oauth-app") {
         return {
@@ -76844,7 +74755,7 @@ var require_dist_node38 = __commonJS({
       return userAuth();
     }
     var import_btoa_lite2 = __toESM2(require_btoa_node());
-    var import_auth_oauth_user2 = require_dist_node37();
+    var import_auth_oauth_user2 = require_dist_node27();
     async function hook(state, request2, route, parameters) {
       let endpoint = request2.endpoint.merge(
         route,
@@ -76870,7 +74781,7 @@ var require_dist_node38 = __commonJS({
       }
     }
     var VERSION = "5.0.6";
-    var import_auth_oauth_user3 = require_dist_node37();
+    var import_auth_oauth_user3 = require_dist_node27();
     function createOAuthAppAuth(options2) {
       const state = Object.assign(
         {
@@ -80646,7 +78557,7 @@ var require_jsonwebtoken = __commonJS({
 });
 
 // node_modules/universal-github-app-jwt/dist-node/index.js
-var require_dist_node39 = __commonJS({
+var require_dist_node29 = __commonJS({
   "node_modules/universal-github-app-jwt/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -81922,7 +79833,7 @@ var require_cjs7 = __commonJS({
 });
 
 // node_modules/@octokit/auth-app/dist-node/index.js
-var require_dist_node40 = __commonJS({
+var require_dist_node30 = __commonJS({
   "node_modules/@octokit/auth-app/dist-node/index.js"(exports2, module2) {
     "use strict";
     var __defProp2 = Object.defineProperty;
@@ -81949,10 +79860,10 @@ var require_dist_node40 = __commonJS({
     });
     module2.exports = __toCommonJS2(dist_src_exports);
     var import_universal_user_agent = require_dist_node3();
-    var import_request = require_dist_node21();
-    var import_auth_oauth_app = require_dist_node38();
+    var import_request = require_dist_node22();
+    var import_auth_oauth_app = require_dist_node28();
     var import_deprecation = require_dist_node5();
-    var import_universal_github_app_jwt = require_dist_node39();
+    var import_universal_github_app_jwt = require_dist_node29();
     async function getAppAuthentication({
       appId,
       privateKey,
@@ -82202,7 +80113,7 @@ var require_dist_node40 = __commonJS({
           throw new Error(`Invalid auth type: ${authOptions.type}`);
       }
     }
-    var import_auth_oauth_user = require_dist_node37();
+    var import_auth_oauth_user = require_dist_node27();
     var PATHS = [
       "/app",
       "/app/hook/config",
@@ -82322,7 +80233,7 @@ var require_dist_node40 = __commonJS({
       }
     }
     var VERSION = "4.0.13";
-    var import_auth_oauth_user2 = require_dist_node37();
+    var import_auth_oauth_user2 = require_dist_node27();
     function createAppAuth(options2) {
       if (!options2.appId) {
         throw new Error("[@octokit/auth-app] appId option is required");
@@ -82376,13 +80287,13 @@ var require_dist_node40 = __commonJS({
 });
 
 // node_modules/octokit-auth-probot/dist-node/index.js
-var require_dist_node41 = __commonJS({
+var require_dist_node31 = __commonJS({
   "node_modules/octokit-auth-probot/dist-node/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    var authUnauthenticated = require_dist_node17();
-    var authToken = require_dist_node18();
-    var authApp = require_dist_node40();
+    var authUnauthenticated = require_dist_node18();
+    var authToken = require_dist_node19();
+    var authApp = require_dist_node30();
     function ownKeys(object, enumerableOnly) {
       var keys = Object.keys(object);
       if (Object.getOwnPropertySymbols) {
@@ -82576,14 +80487,14 @@ var require_probot_octokit = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.ProbotOctokit = void 0;
-    var core_1 = require_dist_node10();
-    var plugin_enterprise_compatibility_1 = require_dist_node11();
-    var plugin_paginate_rest_1 = require_dist_node12();
-    var plugin_rest_endpoint_methods_1 = require_dist_node13();
-    var plugin_retry_1 = require_dist_node14();
-    var plugin_throttling_1 = require_dist_node15();
-    var octokit_plugin_config_1 = require_dist_node16();
-    var octokit_auth_probot_1 = require_dist_node41();
+    var core_1 = require_dist_node11();
+    var plugin_enterprise_compatibility_1 = require_dist_node12();
+    var plugin_paginate_rest_1 = require_dist_node13();
+    var plugin_rest_endpoint_methods_1 = require_dist_node14();
+    var plugin_retry_1 = require_dist_node15();
+    var plugin_throttling_1 = require_dist_node16();
+    var octokit_plugin_config_1 = require_dist_node17();
+    var octokit_auth_probot_1 = require_dist_node31();
     var octokit_plugin_probot_request_logging_1 = require_octokit_plugin_probot_request_logging();
     var version_1 = require_version3();
     var defaultOptions = {
@@ -114609,9 +112520,9 @@ var require_balanced_match = __commonJS({
   }
 });
 
-// node_modules/express-handlebars/node_modules/brace-expansion/index.js
+// node_modules/brace-expansion/index.js
 var require_brace_expansion = __commonJS({
-  "node_modules/express-handlebars/node_modules/brace-expansion/index.js"(exports2, module2) {
+  "node_modules/brace-expansion/index.js"(exports2, module2) {
     var balanced = require_balanced_match();
     module2.exports = expandTop;
     var escSlash = "\0SLASH" + Math.random() + "\0";
@@ -117241,9 +115152,9 @@ var require_server = __commonJS({
   }
 });
 
-// node_modules/pkg-conf/node_modules/path-exists/index.js
+// node_modules/path-exists/index.js
 var require_path_exists = __commonJS({
-  "node_modules/pkg-conf/node_modules/path-exists/index.js"(exports2, module2) {
+  "node_modules/path-exists/index.js"(exports2, module2) {
     "use strict";
     var fs = require("fs");
     module2.exports = (fp) => new Promise((resolve) => {
@@ -117274,9 +115185,9 @@ var require_p_try = __commonJS({
   }
 });
 
-// node_modules/pkg-conf/node_modules/p-limit/index.js
+// node_modules/p-locate/node_modules/p-limit/index.js
 var require_p_limit = __commonJS({
-  "node_modules/pkg-conf/node_modules/p-limit/index.js"(exports2, module2) {
+  "node_modules/p-locate/node_modules/p-limit/index.js"(exports2, module2) {
     "use strict";
     var pTry = require_p_try();
     var pLimit = (concurrency) => {
@@ -117325,9 +115236,9 @@ var require_p_limit = __commonJS({
   }
 });
 
-// node_modules/pkg-conf/node_modules/p-locate/index.js
+// node_modules/p-locate/index.js
 var require_p_locate = __commonJS({
-  "node_modules/pkg-conf/node_modules/p-locate/index.js"(exports2, module2) {
+  "node_modules/p-locate/index.js"(exports2, module2) {
     "use strict";
     var pLimit = require_p_limit();
     var EndError = class extends Error {
@@ -117352,9 +115263,9 @@ var require_p_locate = __commonJS({
   }
 });
 
-// node_modules/pkg-conf/node_modules/locate-path/index.js
+// node_modules/locate-path/index.js
 var require_locate_path = __commonJS({
-  "node_modules/pkg-conf/node_modules/locate-path/index.js"(exports2, module2) {
+  "node_modules/locate-path/index.js"(exports2, module2) {
     "use strict";
     var path = require("path");
     var pathExists = require_path_exists();
@@ -117420,9 +115331,9 @@ var require_find_up = __commonJS({
   }
 });
 
-// node_modules/load-json-file/node_modules/strip-bom/index.js
+// node_modules/strip-bom/index.js
 var require_strip_bom = __commonJS({
-  "node_modules/load-json-file/node_modules/strip-bom/index.js"(exports2, module2) {
+  "node_modules/strip-bom/index.js"(exports2, module2) {
     "use strict";
     module2.exports = (x) => {
       if (typeof x !== "string") {
@@ -120903,9 +118814,9 @@ var require_setup = __commonJS({
   }
 });
 
-// node_modules/probot/node_modules/commander/index.js
+// node_modules/commander/index.js
 var require_commander2 = __commonJS({
-  "node_modules/probot/node_modules/commander/index.js"(exports2, module2) {
+  "node_modules/commander/index.js"(exports2, module2) {
     var EventEmitter = require("events").EventEmitter;
     var spawn = require("child_process").spawn;
     var path = require("path");
@@ -122407,7 +120318,7 @@ Read more on https://git.io/JJc0W`);
 });
 
 // node_modules/@probot/get-private-key/dist-node/index.js
-var require_dist_node42 = __commonJS({
+var require_dist_node32 = __commonJS({
   "node_modules/@probot/get-private-key/dist-node/index.js"(exports2, module2) {
     "use strict";
     var __defProp2 = Object.defineProperty;
@@ -122532,7 +120443,7 @@ var require_read_cli_options = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.readCliOptions = void 0;
     var commander_1 = __importDefault(require_commander2());
-    var get_private_key_1 = require_dist_node42();
+    var get_private_key_1 = require_dist_node32();
     function readCliOptions(argv) {
       commander_1.default.usage("[options] <apps...>").option("-p, --port <n>", "Port to start the server on", String(process.env.PORT || 3e3)).option("-H --host <host>", "Host to start the server on", process.env.HOST).option("-W, --webhook-proxy <url>", "URL of the webhook proxy service.`", process.env.WEBHOOK_PROXY_URL).option("-w, --webhook-path <path>", "URL path which receives webhooks. Ex: `/webhook`", process.env.WEBHOOK_PATH).option("-a, --app <id>", "ID of the GitHub App", process.env.APP_ID).option("-s, --secret <secret>", "Webhook secret of the GitHub App", process.env.WEBHOOK_SECRET).option("-P, --private-key <file>", "Path to private key file (.pem) for the GitHub App", process.env.PRIVATE_KEY_PATH).option("-L, --log-level <level>", 'One of: "trace" | "debug" | "info" | "warn" | "error" | "fatal"', process.env.LOG_LEVEL || "info").option("--log-format <format>", 'One of: "pretty", "json"', process.env.LOG_FORMAT).option("--log-level-in-string", "Set to log levels (trace, debug, info, ...) as words instead of numbers (10, 20, 30, ...)", process.env.LOG_LEVEL_IN_STRING === "true").option("--sentry-dsn <dsn>", 'Set to your Sentry DSN, e.g. "https://1234abcd@sentry.io/12345"', process.env.SENTRY_DSN).option("--redis-url <url>", 'Set to a "redis://" url in order to enable cluster support for request throttling. Example: "redis://:secret@redis-123.redislabs.com:12345/0"', process.env.REDIS_URL).option("--base-url <url>", 'GitHub API base URL. If you use GitHub Enterprise Server, and your hostname is "https://github.acme-inc.com", then the root URL is "https://github.acme-inc.com/api/v3"', process.env.GHE_HOST ? `${process.env.GHE_PROTOCOL || "https"}://${process.env.GHE_HOST}/api/v3` : "https://api.github.com").parse(argv);
       const { app: appId, privateKey: privateKeyPath, redisUrl, ...options2 } = commander_1.default;
@@ -122553,7 +120464,7 @@ var require_read_env_options = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.readEnvOptions = void 0;
-    var get_private_key_1 = require_dist_node42();
+    var get_private_key_1 = require_dist_node32();
     function readEnvOptions(env = process.env) {
       const privateKey = get_private_key_1.getPrivateKey({ env });
       const logFormat = env.LOG_FORMAT || (env.NODE_ENV === "production" ? "json" : "pretty");
@@ -122755,8 +120666,77 @@ var require_node_modules_paths = __commonJS({
 // node_modules/resolve/lib/normalize-options.js
 var require_normalize_options = __commonJS({
   "node_modules/resolve/lib/normalize-options.js"(exports2, module2) {
-    module2.exports = function(x, opts) {
-      return opts || {};
+    var path = require("path");
+    module2.exports = function(_, opts) {
+      opts = opts || {};
+      if (opts.forceNodeResolution || !process.versions.pnp)
+        return opts;
+      const { findPnpApi } = require("module");
+      const runPnpResolution = (request, basedir) => {
+        const parts = request.match(/^((?:@[^/]+\/)?[^/]+)(\/.*)?/);
+        if (!parts)
+          throw new Error(`Assertion failed: Expected the "resolve" package to call the "paths" callback with package names only (got "${request}")`);
+        if (basedir.charAt(basedir.length - 1) !== `/`)
+          basedir = path.join(basedir, `/`);
+        const api = findPnpApi(basedir);
+        if (api === null)
+          return void 0;
+        let manifestPath;
+        try {
+          manifestPath = api.resolveToUnqualified(`${parts[1]}/package.json`, basedir, { considerBuiltins: false });
+        } catch (err) {
+          return null;
+        }
+        if (manifestPath === null)
+          throw new Error(`Assertion failed: The resolution thinks that "${parts[1]}" is a Node builtin`);
+        const packagePath = path.dirname(manifestPath);
+        const unqualifiedPath = typeof parts[2] !== `undefined` ? path.join(packagePath, parts[2]) : packagePath;
+        return { packagePath, unqualifiedPath };
+      };
+      const runPnpResolutionOnArray = (request, paths2) => {
+        for (let i = 0; i < paths2.length; i++) {
+          const resolution = runPnpResolution(request, paths2[i]);
+          if (resolution || i === paths2.length - 1) {
+            return resolution;
+          }
+        }
+        return null;
+      };
+      const originalPaths = Array.isArray(opts.paths) ? opts.paths : [];
+      const packageIterator = (request, basedir, getCandidates, opts2) => {
+        const pathsToTest = [basedir].concat(originalPaths);
+        const resolution = runPnpResolutionOnArray(request, pathsToTest);
+        if (resolution == null)
+          return getCandidates();
+        return [resolution.unqualifiedPath];
+      };
+      const paths = (request, basedir, getNodeModulePaths, opts2) => {
+        const pathsToTest = [basedir].concat(originalPaths);
+        const resolution = runPnpResolutionOnArray(request, pathsToTest);
+        if (resolution == null)
+          return getNodeModulePaths().concat(originalPaths);
+        let nodeModules = path.dirname(resolution.packagePath);
+        if (request.match(/^@[^/]+\//))
+          nodeModules = path.dirname(nodeModules);
+        return [nodeModules];
+      };
+      let isInsideIterator = false;
+      if (!opts.__skipPackageIterator) {
+        opts.packageIterator = function(request, basedir, getCandidates, opts2) {
+          isInsideIterator = true;
+          try {
+            return packageIterator(request, basedir, getCandidates, opts2);
+          } finally {
+            isInsideIterator = false;
+          }
+        };
+      }
+      opts.paths = function(request, basedir, getNodeModulePaths, opts2) {
+        if (isInsideIterator)
+          return getNodeModulePaths().concat(originalPaths);
+        return paths(request, basedir, getNodeModulePaths, opts2);
+      };
+      return opts;
     };
   }
 });
@@ -123883,7 +121863,7 @@ var require_create_probot = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.createProbot = void 0;
-    var get_private_key_1 = require_dist_node42();
+    var get_private_key_1 = require_dist_node32();
     var get_log_1 = require_get_log();
     var probot_1 = require_probot();
     var DEFAULTS = {
@@ -131489,9 +129469,9 @@ var require_strip_ansi = __commonJS({
   }
 });
 
-// node_modules/string-width/node_modules/is-fullwidth-code-point/index.js
+// node_modules/is-fullwidth-code-point/index.js
 var require_is_fullwidth_code_point = __commonJS({
-  "node_modules/string-width/node_modules/is-fullwidth-code-point/index.js"(exports2, module2) {
+  "node_modules/is-fullwidth-code-point/index.js"(exports2, module2) {
     "use strict";
     var isFullwidthCodePoint = (codePoint) => {
       if (Number.isNaN(codePoint)) {
@@ -150653,658 +148633,6 @@ var require_coerce2 = __commonJS({
   }
 });
 
-// node_modules/semver/node_modules/yallist/iterator.js
-var require_iterator2 = __commonJS({
-  "node_modules/semver/node_modules/yallist/iterator.js"(exports2, module2) {
-    "use strict";
-    module2.exports = function(Yallist) {
-      Yallist.prototype[Symbol.iterator] = function* () {
-        for (let walker = this.head; walker; walker = walker.next) {
-          yield walker.value;
-        }
-      };
-    };
-  }
-});
-
-// node_modules/semver/node_modules/yallist/yallist.js
-var require_yallist2 = __commonJS({
-  "node_modules/semver/node_modules/yallist/yallist.js"(exports2, module2) {
-    "use strict";
-    module2.exports = Yallist;
-    Yallist.Node = Node;
-    Yallist.create = Yallist;
-    function Yallist(list) {
-      var self2 = this;
-      if (!(self2 instanceof Yallist)) {
-        self2 = new Yallist();
-      }
-      self2.tail = null;
-      self2.head = null;
-      self2.length = 0;
-      if (list && typeof list.forEach === "function") {
-        list.forEach(function(item) {
-          self2.push(item);
-        });
-      } else if (arguments.length > 0) {
-        for (var i = 0, l = arguments.length; i < l; i++) {
-          self2.push(arguments[i]);
-        }
-      }
-      return self2;
-    }
-    Yallist.prototype.removeNode = function(node) {
-      if (node.list !== this) {
-        throw new Error("removing node which does not belong to this list");
-      }
-      var next = node.next;
-      var prev = node.prev;
-      if (next) {
-        next.prev = prev;
-      }
-      if (prev) {
-        prev.next = next;
-      }
-      if (node === this.head) {
-        this.head = next;
-      }
-      if (node === this.tail) {
-        this.tail = prev;
-      }
-      node.list.length--;
-      node.next = null;
-      node.prev = null;
-      node.list = null;
-      return next;
-    };
-    Yallist.prototype.unshiftNode = function(node) {
-      if (node === this.head) {
-        return;
-      }
-      if (node.list) {
-        node.list.removeNode(node);
-      }
-      var head = this.head;
-      node.list = this;
-      node.next = head;
-      if (head) {
-        head.prev = node;
-      }
-      this.head = node;
-      if (!this.tail) {
-        this.tail = node;
-      }
-      this.length++;
-    };
-    Yallist.prototype.pushNode = function(node) {
-      if (node === this.tail) {
-        return;
-      }
-      if (node.list) {
-        node.list.removeNode(node);
-      }
-      var tail = this.tail;
-      node.list = this;
-      node.prev = tail;
-      if (tail) {
-        tail.next = node;
-      }
-      this.tail = node;
-      if (!this.head) {
-        this.head = node;
-      }
-      this.length++;
-    };
-    Yallist.prototype.push = function() {
-      for (var i = 0, l = arguments.length; i < l; i++) {
-        push(this, arguments[i]);
-      }
-      return this.length;
-    };
-    Yallist.prototype.unshift = function() {
-      for (var i = 0, l = arguments.length; i < l; i++) {
-        unshift(this, arguments[i]);
-      }
-      return this.length;
-    };
-    Yallist.prototype.pop = function() {
-      if (!this.tail) {
-        return void 0;
-      }
-      var res = this.tail.value;
-      this.tail = this.tail.prev;
-      if (this.tail) {
-        this.tail.next = null;
-      } else {
-        this.head = null;
-      }
-      this.length--;
-      return res;
-    };
-    Yallist.prototype.shift = function() {
-      if (!this.head) {
-        return void 0;
-      }
-      var res = this.head.value;
-      this.head = this.head.next;
-      if (this.head) {
-        this.head.prev = null;
-      } else {
-        this.tail = null;
-      }
-      this.length--;
-      return res;
-    };
-    Yallist.prototype.forEach = function(fn, thisp) {
-      thisp = thisp || this;
-      for (var walker = this.head, i = 0; walker !== null; i++) {
-        fn.call(thisp, walker.value, i, this);
-        walker = walker.next;
-      }
-    };
-    Yallist.prototype.forEachReverse = function(fn, thisp) {
-      thisp = thisp || this;
-      for (var walker = this.tail, i = this.length - 1; walker !== null; i--) {
-        fn.call(thisp, walker.value, i, this);
-        walker = walker.prev;
-      }
-    };
-    Yallist.prototype.get = function(n) {
-      for (var i = 0, walker = this.head; walker !== null && i < n; i++) {
-        walker = walker.next;
-      }
-      if (i === n && walker !== null) {
-        return walker.value;
-      }
-    };
-    Yallist.prototype.getReverse = function(n) {
-      for (var i = 0, walker = this.tail; walker !== null && i < n; i++) {
-        walker = walker.prev;
-      }
-      if (i === n && walker !== null) {
-        return walker.value;
-      }
-    };
-    Yallist.prototype.map = function(fn, thisp) {
-      thisp = thisp || this;
-      var res = new Yallist();
-      for (var walker = this.head; walker !== null; ) {
-        res.push(fn.call(thisp, walker.value, this));
-        walker = walker.next;
-      }
-      return res;
-    };
-    Yallist.prototype.mapReverse = function(fn, thisp) {
-      thisp = thisp || this;
-      var res = new Yallist();
-      for (var walker = this.tail; walker !== null; ) {
-        res.push(fn.call(thisp, walker.value, this));
-        walker = walker.prev;
-      }
-      return res;
-    };
-    Yallist.prototype.reduce = function(fn, initial) {
-      var acc;
-      var walker = this.head;
-      if (arguments.length > 1) {
-        acc = initial;
-      } else if (this.head) {
-        walker = this.head.next;
-        acc = this.head.value;
-      } else {
-        throw new TypeError("Reduce of empty list with no initial value");
-      }
-      for (var i = 0; walker !== null; i++) {
-        acc = fn(acc, walker.value, i);
-        walker = walker.next;
-      }
-      return acc;
-    };
-    Yallist.prototype.reduceReverse = function(fn, initial) {
-      var acc;
-      var walker = this.tail;
-      if (arguments.length > 1) {
-        acc = initial;
-      } else if (this.tail) {
-        walker = this.tail.prev;
-        acc = this.tail.value;
-      } else {
-        throw new TypeError("Reduce of empty list with no initial value");
-      }
-      for (var i = this.length - 1; walker !== null; i--) {
-        acc = fn(acc, walker.value, i);
-        walker = walker.prev;
-      }
-      return acc;
-    };
-    Yallist.prototype.toArray = function() {
-      var arr = new Array(this.length);
-      for (var i = 0, walker = this.head; walker !== null; i++) {
-        arr[i] = walker.value;
-        walker = walker.next;
-      }
-      return arr;
-    };
-    Yallist.prototype.toArrayReverse = function() {
-      var arr = new Array(this.length);
-      for (var i = 0, walker = this.tail; walker !== null; i++) {
-        arr[i] = walker.value;
-        walker = walker.prev;
-      }
-      return arr;
-    };
-    Yallist.prototype.slice = function(from, to) {
-      to = to || this.length;
-      if (to < 0) {
-        to += this.length;
-      }
-      from = from || 0;
-      if (from < 0) {
-        from += this.length;
-      }
-      var ret = new Yallist();
-      if (to < from || to < 0) {
-        return ret;
-      }
-      if (from < 0) {
-        from = 0;
-      }
-      if (to > this.length) {
-        to = this.length;
-      }
-      for (var i = 0, walker = this.head; walker !== null && i < from; i++) {
-        walker = walker.next;
-      }
-      for (; walker !== null && i < to; i++, walker = walker.next) {
-        ret.push(walker.value);
-      }
-      return ret;
-    };
-    Yallist.prototype.sliceReverse = function(from, to) {
-      to = to || this.length;
-      if (to < 0) {
-        to += this.length;
-      }
-      from = from || 0;
-      if (from < 0) {
-        from += this.length;
-      }
-      var ret = new Yallist();
-      if (to < from || to < 0) {
-        return ret;
-      }
-      if (from < 0) {
-        from = 0;
-      }
-      if (to > this.length) {
-        to = this.length;
-      }
-      for (var i = this.length, walker = this.tail; walker !== null && i > to; i--) {
-        walker = walker.prev;
-      }
-      for (; walker !== null && i > from; i--, walker = walker.prev) {
-        ret.push(walker.value);
-      }
-      return ret;
-    };
-    Yallist.prototype.splice = function(start, deleteCount, ...nodes) {
-      if (start > this.length) {
-        start = this.length - 1;
-      }
-      if (start < 0) {
-        start = this.length + start;
-      }
-      for (var i = 0, walker = this.head; walker !== null && i < start; i++) {
-        walker = walker.next;
-      }
-      var ret = [];
-      for (var i = 0; walker && i < deleteCount; i++) {
-        ret.push(walker.value);
-        walker = this.removeNode(walker);
-      }
-      if (walker === null) {
-        walker = this.tail;
-      }
-      if (walker !== this.head && walker !== this.tail) {
-        walker = walker.prev;
-      }
-      for (var i = 0; i < nodes.length; i++) {
-        walker = insert(this, walker, nodes[i]);
-      }
-      return ret;
-    };
-    Yallist.prototype.reverse = function() {
-      var head = this.head;
-      var tail = this.tail;
-      for (var walker = head; walker !== null; walker = walker.prev) {
-        var p = walker.prev;
-        walker.prev = walker.next;
-        walker.next = p;
-      }
-      this.head = tail;
-      this.tail = head;
-      return this;
-    };
-    function insert(self2, node, value) {
-      var inserted = node === self2.head ? new Node(value, null, node, self2) : new Node(value, node, node.next, self2);
-      if (inserted.next === null) {
-        self2.tail = inserted;
-      }
-      if (inserted.prev === null) {
-        self2.head = inserted;
-      }
-      self2.length++;
-      return inserted;
-    }
-    function push(self2, item) {
-      self2.tail = new Node(item, self2.tail, null, self2);
-      if (!self2.head) {
-        self2.head = self2.tail;
-      }
-      self2.length++;
-    }
-    function unshift(self2, item) {
-      self2.head = new Node(item, null, self2.head, self2);
-      if (!self2.tail) {
-        self2.tail = self2.head;
-      }
-      self2.length++;
-    }
-    function Node(value, prev, next, list) {
-      if (!(this instanceof Node)) {
-        return new Node(value, prev, next, list);
-      }
-      this.list = list;
-      this.value = value;
-      if (prev) {
-        prev.next = this;
-        this.prev = prev;
-      } else {
-        this.prev = null;
-      }
-      if (next) {
-        next.prev = this;
-        this.next = next;
-      } else {
-        this.next = null;
-      }
-    }
-    try {
-      require_iterator2()(Yallist);
-    } catch (er) {
-    }
-  }
-});
-
-// node_modules/semver/node_modules/lru-cache/index.js
-var require_lru_cache2 = __commonJS({
-  "node_modules/semver/node_modules/lru-cache/index.js"(exports2, module2) {
-    "use strict";
-    var Yallist = require_yallist2();
-    var MAX = /* @__PURE__ */ Symbol("max");
-    var LENGTH = /* @__PURE__ */ Symbol("length");
-    var LENGTH_CALCULATOR = /* @__PURE__ */ Symbol("lengthCalculator");
-    var ALLOW_STALE = /* @__PURE__ */ Symbol("allowStale");
-    var MAX_AGE = /* @__PURE__ */ Symbol("maxAge");
-    var DISPOSE = /* @__PURE__ */ Symbol("dispose");
-    var NO_DISPOSE_ON_SET = /* @__PURE__ */ Symbol("noDisposeOnSet");
-    var LRU_LIST = /* @__PURE__ */ Symbol("lruList");
-    var CACHE = /* @__PURE__ */ Symbol("cache");
-    var UPDATE_AGE_ON_GET = /* @__PURE__ */ Symbol("updateAgeOnGet");
-    var naiveLength = () => 1;
-    var LRUCache = class {
-      constructor(options2) {
-        if (typeof options2 === "number")
-          options2 = { max: options2 };
-        if (!options2)
-          options2 = {};
-        if (options2.max && (typeof options2.max !== "number" || options2.max < 0))
-          throw new TypeError("max must be a non-negative number");
-        const max = this[MAX] = options2.max || Infinity;
-        const lc = options2.length || naiveLength;
-        this[LENGTH_CALCULATOR] = typeof lc !== "function" ? naiveLength : lc;
-        this[ALLOW_STALE] = options2.stale || false;
-        if (options2.maxAge && typeof options2.maxAge !== "number")
-          throw new TypeError("maxAge must be a number");
-        this[MAX_AGE] = options2.maxAge || 0;
-        this[DISPOSE] = options2.dispose;
-        this[NO_DISPOSE_ON_SET] = options2.noDisposeOnSet || false;
-        this[UPDATE_AGE_ON_GET] = options2.updateAgeOnGet || false;
-        this.reset();
-      }
-      // resize the cache when the max changes.
-      set max(mL) {
-        if (typeof mL !== "number" || mL < 0)
-          throw new TypeError("max must be a non-negative number");
-        this[MAX] = mL || Infinity;
-        trim(this);
-      }
-      get max() {
-        return this[MAX];
-      }
-      set allowStale(allowStale) {
-        this[ALLOW_STALE] = !!allowStale;
-      }
-      get allowStale() {
-        return this[ALLOW_STALE];
-      }
-      set maxAge(mA) {
-        if (typeof mA !== "number")
-          throw new TypeError("maxAge must be a non-negative number");
-        this[MAX_AGE] = mA;
-        trim(this);
-      }
-      get maxAge() {
-        return this[MAX_AGE];
-      }
-      // resize the cache when the lengthCalculator changes.
-      set lengthCalculator(lC) {
-        if (typeof lC !== "function")
-          lC = naiveLength;
-        if (lC !== this[LENGTH_CALCULATOR]) {
-          this[LENGTH_CALCULATOR] = lC;
-          this[LENGTH] = 0;
-          this[LRU_LIST].forEach((hit) => {
-            hit.length = this[LENGTH_CALCULATOR](hit.value, hit.key);
-            this[LENGTH] += hit.length;
-          });
-        }
-        trim(this);
-      }
-      get lengthCalculator() {
-        return this[LENGTH_CALCULATOR];
-      }
-      get length() {
-        return this[LENGTH];
-      }
-      get itemCount() {
-        return this[LRU_LIST].length;
-      }
-      rforEach(fn, thisp) {
-        thisp = thisp || this;
-        for (let walker = this[LRU_LIST].tail; walker !== null; ) {
-          const prev = walker.prev;
-          forEachStep(this, fn, walker, thisp);
-          walker = prev;
-        }
-      }
-      forEach(fn, thisp) {
-        thisp = thisp || this;
-        for (let walker = this[LRU_LIST].head; walker !== null; ) {
-          const next = walker.next;
-          forEachStep(this, fn, walker, thisp);
-          walker = next;
-        }
-      }
-      keys() {
-        return this[LRU_LIST].toArray().map((k) => k.key);
-      }
-      values() {
-        return this[LRU_LIST].toArray().map((k) => k.value);
-      }
-      reset() {
-        if (this[DISPOSE] && this[LRU_LIST] && this[LRU_LIST].length) {
-          this[LRU_LIST].forEach((hit) => this[DISPOSE](hit.key, hit.value));
-        }
-        this[CACHE] = /* @__PURE__ */ new Map();
-        this[LRU_LIST] = new Yallist();
-        this[LENGTH] = 0;
-      }
-      dump() {
-        return this[LRU_LIST].map((hit) => isStale(this, hit) ? false : {
-          k: hit.key,
-          v: hit.value,
-          e: hit.now + (hit.maxAge || 0)
-        }).toArray().filter((h) => h);
-      }
-      dumpLru() {
-        return this[LRU_LIST];
-      }
-      set(key, value, maxAge) {
-        maxAge = maxAge || this[MAX_AGE];
-        if (maxAge && typeof maxAge !== "number")
-          throw new TypeError("maxAge must be a number");
-        const now = maxAge ? Date.now() : 0;
-        const len = this[LENGTH_CALCULATOR](value, key);
-        if (this[CACHE].has(key)) {
-          if (len > this[MAX]) {
-            del(this, this[CACHE].get(key));
-            return false;
-          }
-          const node = this[CACHE].get(key);
-          const item = node.value;
-          if (this[DISPOSE]) {
-            if (!this[NO_DISPOSE_ON_SET])
-              this[DISPOSE](key, item.value);
-          }
-          item.now = now;
-          item.maxAge = maxAge;
-          item.value = value;
-          this[LENGTH] += len - item.length;
-          item.length = len;
-          this.get(key);
-          trim(this);
-          return true;
-        }
-        const hit = new Entry(key, value, len, now, maxAge);
-        if (hit.length > this[MAX]) {
-          if (this[DISPOSE])
-            this[DISPOSE](key, value);
-          return false;
-        }
-        this[LENGTH] += hit.length;
-        this[LRU_LIST].unshift(hit);
-        this[CACHE].set(key, this[LRU_LIST].head);
-        trim(this);
-        return true;
-      }
-      has(key) {
-        if (!this[CACHE].has(key)) return false;
-        const hit = this[CACHE].get(key).value;
-        return !isStale(this, hit);
-      }
-      get(key) {
-        return get(this, key, true);
-      }
-      peek(key) {
-        return get(this, key, false);
-      }
-      pop() {
-        const node = this[LRU_LIST].tail;
-        if (!node)
-          return null;
-        del(this, node);
-        return node.value;
-      }
-      del(key) {
-        del(this, this[CACHE].get(key));
-      }
-      load(arr) {
-        this.reset();
-        const now = Date.now();
-        for (let l = arr.length - 1; l >= 0; l--) {
-          const hit = arr[l];
-          const expiresAt = hit.e || 0;
-          if (expiresAt === 0)
-            this.set(hit.k, hit.v);
-          else {
-            const maxAge = expiresAt - now;
-            if (maxAge > 0) {
-              this.set(hit.k, hit.v, maxAge);
-            }
-          }
-        }
-      }
-      prune() {
-        this[CACHE].forEach((value, key) => get(this, key, false));
-      }
-    };
-    var get = (self2, key, doUse) => {
-      const node = self2[CACHE].get(key);
-      if (node) {
-        const hit = node.value;
-        if (isStale(self2, hit)) {
-          del(self2, node);
-          if (!self2[ALLOW_STALE])
-            return void 0;
-        } else {
-          if (doUse) {
-            if (self2[UPDATE_AGE_ON_GET])
-              node.value.now = Date.now();
-            self2[LRU_LIST].unshiftNode(node);
-          }
-        }
-        return hit.value;
-      }
-    };
-    var isStale = (self2, hit) => {
-      if (!hit || !hit.maxAge && !self2[MAX_AGE])
-        return false;
-      const diff = Date.now() - hit.now;
-      return hit.maxAge ? diff > hit.maxAge : self2[MAX_AGE] && diff > self2[MAX_AGE];
-    };
-    var trim = (self2) => {
-      if (self2[LENGTH] > self2[MAX]) {
-        for (let walker = self2[LRU_LIST].tail; self2[LENGTH] > self2[MAX] && walker !== null; ) {
-          const prev = walker.prev;
-          del(self2, walker);
-          walker = prev;
-        }
-      }
-    };
-    var del = (self2, node) => {
-      if (node) {
-        const hit = node.value;
-        if (self2[DISPOSE])
-          self2[DISPOSE](hit.key, hit.value);
-        self2[LENGTH] -= hit.length;
-        self2[CACHE].delete(hit.key);
-        self2[LRU_LIST].removeNode(node);
-      }
-    };
-    var Entry = class {
-      constructor(key, value, length, now, maxAge) {
-        this.key = key;
-        this.value = value;
-        this.length = length;
-        this.now = now;
-        this.maxAge = maxAge || 0;
-      }
-    };
-    var forEachStep = (self2, fn, node, thisp) => {
-      let hit = node.value;
-      if (isStale(self2, hit)) {
-        del(self2, node);
-        if (!self2[ALLOW_STALE])
-          hit = void 0;
-      }
-      if (hit)
-        fn.call(thisp, hit.value, hit.key, self2);
-    };
-    module2.exports = LRUCache;
-  }
-});
-
 // node_modules/semver/classes/range.js
 var require_range3 = __commonJS({
   "node_modules/semver/classes/range.js"(exports2, module2) {
@@ -151432,7 +148760,7 @@ var require_range3 = __commonJS({
       }
     };
     module2.exports = Range;
-    var LRU = require_lru_cache2();
+    var LRU = require_lru_cache();
     var cache = new LRU({ max: 1e3 });
     var parseOptions = require_parse_options2();
     var Comparator = require_comparator2();

--- a/index.js
+++ b/index.js
@@ -140,8 +140,16 @@ module.exports = (app, { getRouter }) => {
       message: `Processing ${sortedMergedPullRequests.length} merged pull requests`,
     })
 
-    const { shouldDraft, version, tag, name, dryRun, attachFiles, resetFiles } =
-      input
+    const {
+      shouldDraft,
+      version,
+      tag,
+      name,
+      dryRun,
+      attachFiles,
+      resetFiles,
+      notReady,
+    } = input
 
     let shouldResetFiles
     if (resetFiles === 'true') {
@@ -221,6 +229,24 @@ module.exports = (app, { getRouter }) => {
       shouldDraft,
       targetCommitish,
     })
+
+    // Apply not-ready banner when truthy
+    if (notReady) {
+      const bannerMessage =
+        typeof notReady === 'string'
+          ? notReady
+          : 'This release draft is still being prepared. Do not publish until this banner is removed.'
+      releaseInfo.body =
+        `> [!CAUTION]\n` +
+        `> **NOT READY FOR PUBLISHING**\n` +
+        `>\n` +
+        `> ${bannerMessage}\n\n` +
+        releaseInfo.body
+    }
+
+    // Append hidden admin timestamp comment
+    const updatedAt = new Date().toISOString()
+    releaseInfo.body += `\n<!-- Release draft last updated: ${updatedAt} -->\n`
 
     // In dry-run mode, skip creating/updating releases but still set outputs
     if (dryRun) {
@@ -335,6 +361,7 @@ function getInput() {
     latest: core.getInput('latest')?.toLowerCase() || undefined,
     attachFiles: core.getInput('attach-files') || undefined,
     resetFiles: core.getInput('reset-files').toLowerCase() || 'auto',
+    notReady: parseNotReadyInput(core.getInput('not-ready')),
     allowMajorBumps:
       core.getInput('allow-major-bumps') !== ''
         ? core.getInput('allow-major-bumps').toLowerCase() === 'true'
@@ -424,4 +451,20 @@ function setDryRunOutput({
   if (tag) core.setOutput('tag-name', tag)
   if (name) core.setOutput('name', name)
   core.setOutput('body', body)
+}
+
+/**
+ * Parses the `not-ready` action input into a normalized value.
+ *
+ * Returns:
+ * - `false` when the input is empty, undefined, or the string "false"
+ * - `true` when the input is the string "true" (use default banner message)
+ * - the original string for any other truthy value (custom banner message)
+ */
+function parseNotReadyInput(raw) {
+  if (!raw) return false
+  const lower = raw.toLowerCase()
+  if (lower === 'false') return false
+  if (lower === 'true') return true
+  return raw
 }

--- a/index.js
+++ b/index.js
@@ -248,8 +248,8 @@ module.exports = (app, { getRouter }) => {
     const pacificTimestamp = formatPacificTimestamp(new Date())
     const commitUrl = getCommitUrl()
     releaseInfo.body +=
-      `\n<!-- Release draft timestamp: ${pacificTimestamp}` +
-      (commitUrl ? ` | Commit used in draft: ${commitUrl}` : '') +
+      `\n<!-- Release drafted at \`${pacificTimestamp}\`` +
+      (commitUrl ? ` from ${commitUrl}` : '') +
       ` -->\n`
 
     // In dry-run mode, skip creating/updating releases but still set outputs

--- a/index.js
+++ b/index.js
@@ -248,7 +248,7 @@ module.exports = (app, { getRouter }) => {
     const pacificTimestamp = formatPacificTimestamp(new Date())
     const commitUrl = getCommitUrl()
     releaseInfo.body +=
-      `\n<!-- Release drafted at \`${pacificTimestamp}\`` +
+      `\n<!-- Release drafted at ${pacificTimestamp}` +
       (commitUrl ? ` from ${commitUrl}` : '') +
       ` -->\n`
 

--- a/index.js
+++ b/index.js
@@ -244,9 +244,13 @@ module.exports = (app, { getRouter }) => {
         releaseInfo.body
     }
 
-    // Append hidden admin timestamp comment
-    const updatedAt = new Date().toISOString()
-    releaseInfo.body += `\n<!-- Release draft last updated: ${updatedAt} -->\n`
+    // Append hidden admin metadata comment (Pacific time + commit link)
+    const pacificTimestamp = formatPacificTimestamp(new Date())
+    const commitUrl = getCommitUrl()
+    releaseInfo.body +=
+      `\n<!-- Release draft timestamp: ${pacificTimestamp}` +
+      (commitUrl ? ` | Commit used in draft: ${commitUrl}` : '') +
+      ` -->\n`
 
     // In dry-run mode, skip creating/updating releases but still set outputs
     if (dryRun) {
@@ -467,4 +471,40 @@ function parseNotReadyInput(raw) {
   if (lower === 'false') return false
   if (lower === 'true') return true
   return raw
+}
+
+/**
+ * Formats a Date as "YYYY-MM-DD h:mmam/pm Pacific" in America/Los_Angeles.
+ */
+function formatPacificTimestamp(date) {
+  const options = {
+    timeZone: 'America/Los_Angeles',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  }
+  const parts = new Intl.DateTimeFormat('en-US', options).formatToParts(date)
+  const get = (type) => parts.find((p) => p.type === type)?.value || ''
+  const year = get('year')
+  const month = get('month')
+  const day = get('day')
+  const hour = get('hour')
+  const minute = get('minute')
+  const dayPeriod = get('dayPeriod').toLowerCase()
+  return `${year}-${month}-${day} ${hour}:${minute}${dayPeriod} Pacific`
+}
+
+/**
+ * Builds the commit URL from GitHub Actions environment variables.
+ * Returns null when not running in GitHub Actions.
+ */
+function getCommitUrl() {
+  const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com'
+  const repository = process.env.GITHUB_REPOSITORY
+  const sha = process.env.GITHUB_SHA
+  if (!repository || !sha) return null
+  return `${serverUrl}/${repository}/commit/${sha}`
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -205,7 +205,7 @@ describe('release-drafter', () => {
 
                   * No changes
 
-                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                  <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -286,7 +286,7 @@ describe('release-drafter', () => {
 
                   * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                  <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -351,7 +351,7 @@ describe('release-drafter', () => {
 
                 Previous tag: ''
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -418,7 +418,7 @@ describe('release-drafter', () => {
 
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -525,7 +525,7 @@ describe('release-drafter', () => {
 
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -572,7 +572,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "Placeholder with example. Automatically calculated values are next major=3.0.0 (major=3, minor=0, patch=0), minor=2.1.0 (major=2, minor=1, patch=0), patch=2.0.1 (major=2, minor=0, patch=1)
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -633,7 +633,7 @@ describe('release-drafter', () => {
                   ## ⚙️ Under the Hood
 
                   * Change: #4 'Update dependencies' @TimonVS
-                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                  <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -695,7 +695,7 @@ describe('release-drafter', () => {
                   ## ⚙️ Under the Hood
 
                   * Change: #4 'Update dependencies'
-                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                  <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -757,7 +757,7 @@ describe('release-drafter', () => {
                   ## ⚙️ Under the Hood
 
                   * Change: #4 'Update dependencies' @TimonVS
-                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                  <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -804,7 +804,7 @@ describe('release-drafter', () => {
                 expect(body).toMatchInlineSnapshot(`
                   Object {
                     "body": "A big thanks to: @TimonVS and Ada Lovelace
-                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                  <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -849,7 +849,7 @@ describe('release-drafter', () => {
                 expect(body).toMatchInlineSnapshot(`
                   Object {
                     "body": "A big thanks to: Nobody
-                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                  <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -896,7 +896,7 @@ describe('release-drafter', () => {
                 expect(body).toMatchInlineSnapshot(`
                   Object {
                     "body": "A big thanks to: Ada Lovelace
-                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                  <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -950,7 +950,7 @@ describe('release-drafter', () => {
 
                 * No changes
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -995,7 +995,7 @@ describe('release-drafter', () => {
                 expect(body).toMatchInlineSnapshot(`
                   Object {
                     "body": "* No changes mmkay
-                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                  <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -1128,7 +1128,7 @@ describe('release-drafter', () => {
 
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1183,7 +1183,7 @@ describe('release-drafter', () => {
 
                 **Full Changelog**: https://github.com/toolmantim/release-drafter-test-project/compare/v2.0.0...v2.1.0
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1236,7 +1236,7 @@ describe('release-drafter', () => {
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/2) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/1)
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1287,7 +1287,7 @@ describe('release-drafter', () => {
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/2) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/1)
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1338,7 +1338,7 @@ describe('release-drafter', () => {
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/2) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/1)
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1389,7 +1389,7 @@ describe('release-drafter', () => {
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/19) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/18)
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1440,7 +1440,7 @@ describe('release-drafter', () => {
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/19) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/18)
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1491,7 +1491,7 @@ describe('release-drafter', () => {
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/2) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/1)
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1555,7 +1555,7 @@ describe('release-drafter', () => {
 
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1601,7 +1601,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "Placeholder with example. Automatically calculated values are next major=3.0.0 (major=3, minor=0, patch=0), minor=2.1.0 (major=2, minor=1, patch=0), patch=2.0.1 (major=2, minor=0, patch=1)
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1645,7 +1645,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "Placeholder with example. Automatically calculated values are next major=3.0 (major=3, minor=0, patch=0), minor=2.1 (major=2, minor=1, patch=0), patch=2.0 (major=2, minor=0, patch=1)
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1689,7 +1689,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "Placeholder with example. Automatically calculated values are next major=3 (major=3, minor=0, patch=0), minor=2 (major=2, minor=1, patch=0), patch=2 (major=2, minor=0, patch=1)
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1737,7 +1737,7 @@ describe('release-drafter', () => {
                   "body": "This is at top
                 This is the template in the middle
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1782,7 +1782,7 @@ describe('release-drafter', () => {
                   "body": "This is the template in the middle
                 This is at bottom
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1828,7 +1828,7 @@ describe('release-drafter', () => {
                 This is the template in the middle
                 This is at bottom
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1873,7 +1873,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "This is at topThis is the template in the middleThis is at bottom
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1922,7 +1922,7 @@ describe('release-drafter', () => {
                 Object {
                   "body": "I AM AWESOME_mockenv_strips_newline_and_trailing_spaces_This is the template in the middle
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1990,7 +1990,7 @@ describe('release-drafter', () => {
 
                   * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                  <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -2061,7 +2061,7 @@ describe('release-drafter', () => {
                   * Update Mongoose to 5.5.4 (https://github.com/toolmantim/release-drafter-test-project/pull/9) 
                   * Update Express to 4.16.4 (https://github.com/toolmantim/release-drafter-test-project/pull/9)
 
-                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                  <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -2128,7 +2128,7 @@ describe('release-drafter', () => {
 
                   * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/14)
 
-                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                  <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -2192,7 +2192,7 @@ describe('release-drafter', () => {
 
                   * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/14)
 
-                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                  <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -2270,7 +2270,7 @@ describe('release-drafter', () => {
                   * Update Express to 4.16.4 (https://github.com/toolmantim/release-drafter-test-project/pull/4) 
                   </details>
 
-                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                  <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -2325,7 +2325,7 @@ describe('release-drafter', () => {
 
                 * No changes
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -2392,7 +2392,7 @@ describe('release-drafter', () => {
 
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -2449,7 +2449,7 @@ describe('release-drafter', () => {
 
               * No changes
 
-              <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+              <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
               ",
                 "draft": true,
                 "make_latest": "true",
@@ -2505,7 +2505,7 @@ describe('release-drafter', () => {
 
               * No changes
 
-              <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+              <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
               ",
                 "draft": true,
                 "make_latest": "true",
@@ -2575,7 +2575,7 @@ describe('release-drafter', () => {
 
               * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-              <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+              <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
               ",
                 "draft": true,
                 "make_latest": "true",
@@ -2628,7 +2628,7 @@ describe('release-drafter', () => {
                 "body": "# What's Changed
               * No changes
 
-              <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+              <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
               ",
                 "draft": true,
                 "make_latest": "true",
@@ -2801,7 +2801,7 @@ describe('release-drafter', () => {
               Object {
                 "body": "# There's new stuff!
 
-              <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+              <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
               ",
                 "draft": true,
                 "make_latest": "true",
@@ -2932,7 +2932,7 @@ describe('release-drafter', () => {
           const expected = { ...expectedBody }
           if (expected.body) {
             expected.body +=
-              '\n<!-- Release drafted at `2024-12-31 4:00pm Pacific` -->\n'
+              '\n<!-- Release drafted at 2024-12-31 4:00pm Pacific -->\n'
           }
           expect(body).toMatchObject(expected)
           return true
@@ -3230,7 +3230,7 @@ describe('release-drafter', () => {
 
 
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3289,7 +3289,7 @@ describe('release-drafter', () => {
 
                 v2.0.0
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3346,7 +3346,7 @@ describe('release-drafter', () => {
 
 
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3401,7 +3401,7 @@ describe('release-drafter', () => {
 
                 v2.0.0
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3456,7 +3456,7 @@ describe('release-drafter', () => {
 
                 static-tag-prefix-v2.1.4-RC3
 
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3506,7 +3506,7 @@ describe('release-drafter', () => {
                   'Major tag: static-tag-prefix-v2\n' +
                   'Releases: https://github.com/toolmantim/release-drafter-test-project/releases?q=tag:static-tag-prefix-v2\n' +
                   'Compare: https://github.com/toolmantim/release-drafter-test-project/compare/static-tag-prefix-v2.1.4...static-tag-prefix-v2.1.5\n' +
-                  '\n<!-- Release drafted at `2024-12-31 4:00pm Pacific` -->\n',
+                  '\n<!-- Release drafted at 2024-12-31 4:00pm Pacific -->\n',
                 name: 'static-tag-prefix-v2.1.5 🌈',
                 tag_name: 'static-tag-prefix-v2.1.5',
               })
@@ -3546,7 +3546,7 @@ describe('release-drafter', () => {
                   'Major tag: v2\n' +
                   'Releases: https://github.com/toolmantim/release-drafter-test-project/releases?q=tag:v2\n' +
                   'Compare: https://github.com/toolmantim/release-drafter-test-project/compare/v2.0.0...v2.0.1\n' +
-                  '\n<!-- Release drafted at `2024-12-31 4:00pm Pacific` -->\n',
+                  '\n<!-- Release drafted at 2024-12-31 4:00pm Pacific -->\n',
                 name: 'v2.0.1 🌈',
                 tag_name: 'v2.0.1',
               })
@@ -3587,7 +3587,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "dummy
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3631,7 +3631,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "dummy
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3675,7 +3675,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "dummy
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3719,7 +3719,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "dummy
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3764,7 +3764,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "dummy
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3811,7 +3811,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "dummy
-                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
+                <!-- Release drafted at 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -70,6 +70,11 @@ describe('release-drafter', () => {
   beforeEach(() => {
     logger = []
 
+    // Fix Date.toISOString so the admin timestamp comment is deterministic
+    jest
+      .spyOn(Date.prototype, 'toISOString')
+      .mockReturnValue('2025-01-01T00:00:00.000Z')
+
     nock('https://api.github.com')
       .post('/app/installations/179208/access_tokens')
       .reply(200, { token: 'test' })
@@ -92,6 +97,7 @@ describe('release-drafter', () => {
   afterAll(nock.restore)
 
   afterEach(() => {
+    jest.restoreAllMocks()
     nock.cleanAll()
     restoreEnvironment()
   })
@@ -188,6 +194,8 @@ describe('release-drafter', () => {
                     "body": "# What's Changed
 
                   * No changes
+
+                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -267,6 +275,8 @@ describe('release-drafter', () => {
                   ## ⚙️ Under the Hood
 
                   * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
+
+                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -330,6 +340,8 @@ describe('release-drafter', () => {
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
                 Previous tag: ''
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -395,6 +407,8 @@ describe('release-drafter', () => {
                 ## ⚙️ Under the Hood
 
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -500,6 +514,8 @@ describe('release-drafter', () => {
                 ## ⚙️ Under the Hood
 
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -545,7 +561,9 @@ describe('release-drafter', () => {
             (body) => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
-                  "body": "Placeholder with example. Automatically calculated values are next major=3.0.0 (major=3, minor=0, patch=0), minor=2.1.0 (major=2, minor=1, patch=0), patch=2.0.1 (major=2, minor=0, patch=1)",
+                  "body": "Placeholder with example. Automatically calculated values are next major=3.0.0 (major=3, minor=0, patch=0), minor=2.1.0 (major=2, minor=1, patch=0), patch=2.0.1 (major=2, minor=0, patch=1)
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                ",
                   "draft": true,
                   "make_latest": "true",
                   "name": "v2.0.1 (Code name: Placeholder)",
@@ -604,7 +622,9 @@ describe('release-drafter', () => {
 
                   ## ⚙️ Under the Hood
 
-                  * Change: #4 'Update dependencies' @TimonVS",
+                  * Change: #4 'Update dependencies' @TimonVS
+                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  ",
                     "draft": true,
                     "make_latest": "true",
                     "name": "v2.1.0",
@@ -664,7 +684,9 @@ describe('release-drafter', () => {
 
                   ## ⚙️ Under the Hood
 
-                  * Change: #4 'Update dependencies'",
+                  * Change: #4 'Update dependencies'
+                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  ",
                     "draft": true,
                     "make_latest": "true",
                     "name": "v2.1.0",
@@ -724,7 +746,9 @@ describe('release-drafter', () => {
 
                   ## ⚙️ Under the Hood
 
-                  * Change: #4 'Update dependencies' @TimonVS",
+                  * Change: #4 'Update dependencies' @TimonVS
+                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  ",
                     "draft": true,
                     "make_latest": "true",
                     "name": "v2.1.0",
@@ -769,7 +793,9 @@ describe('release-drafter', () => {
               (body) => {
                 expect(body).toMatchInlineSnapshot(`
                   Object {
-                    "body": "A big thanks to: @TimonVS and Ada Lovelace",
+                    "body": "A big thanks to: @TimonVS and Ada Lovelace
+                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  ",
                     "draft": true,
                     "make_latest": "true",
                     "name": "v2.1.0",
@@ -812,7 +838,9 @@ describe('release-drafter', () => {
               (body) => {
                 expect(body).toMatchInlineSnapshot(`
                   Object {
-                    "body": "A big thanks to: Nobody",
+                    "body": "A big thanks to: Nobody
+                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  ",
                     "draft": true,
                     "make_latest": "true",
                     "name": "v2.0.1",
@@ -857,7 +885,9 @@ describe('release-drafter', () => {
               (body) => {
                 expect(body).toMatchInlineSnapshot(`
                   Object {
-                    "body": "A big thanks to: Ada Lovelace",
+                    "body": "A big thanks to: Ada Lovelace
+                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  ",
                     "draft": true,
                     "make_latest": "true",
                     "name": "v2.1.0",
@@ -909,6 +939,8 @@ describe('release-drafter', () => {
                   "body": "# What's Changed
 
                 * No changes
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -952,7 +984,9 @@ describe('release-drafter', () => {
               (body) => {
                 expect(body).toMatchInlineSnapshot(`
                   Object {
-                    "body": "* No changes mmkay",
+                    "body": "* No changes mmkay
+                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  ",
                     "draft": true,
                     "make_latest": "true",
                     "name": "v0.1.0",
@@ -1083,6 +1117,8 @@ describe('release-drafter', () => {
                 ## ⚙️ Under the Hood
 
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1136,6 +1172,8 @@ describe('release-drafter', () => {
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/1)
 
                 **Full Changelog**: https://github.com/toolmantim/release-drafter-test-project/compare/v2.0.0...v2.1.0
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1187,6 +1225,8 @@ describe('release-drafter', () => {
                 * Bug fixes (https://github.com/toolmantim/release-drafter-test-project/pull/3) 
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/2) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/1)
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1236,6 +1276,8 @@ describe('release-drafter', () => {
                 * Bug fixes (https://github.com/toolmantim/release-drafter-test-project/pull/3) 
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/2) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/1)
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1285,6 +1327,8 @@ describe('release-drafter', () => {
                 * Bug fixes (https://github.com/toolmantim/release-drafter-test-project/pull/3) 
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/2) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/1)
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1334,6 +1378,8 @@ describe('release-drafter', () => {
                 * Bug fixes (https://github.com/toolmantim/release-drafter-test-project/pull/20) 
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/19) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/18)
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1383,6 +1429,8 @@ describe('release-drafter', () => {
                 * Bug fixes (https://github.com/toolmantim/release-drafter-test-project/pull/20) 
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/19) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/18)
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1432,6 +1480,8 @@ describe('release-drafter', () => {
                 * Bug fixes (https://github.com/toolmantim/release-drafter-test-project/pull/3) 
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/2) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/1)
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1494,6 +1544,8 @@ describe('release-drafter', () => {
                 ## ⚙️ Under the Hood
 
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1538,7 +1590,9 @@ describe('release-drafter', () => {
             (body) => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
-                  "body": "Placeholder with example. Automatically calculated values are next major=3.0.0 (major=3, minor=0, patch=0), minor=2.1.0 (major=2, minor=1, patch=0), patch=2.0.1 (major=2, minor=0, patch=1)",
+                  "body": "Placeholder with example. Automatically calculated values are next major=3.0.0 (major=3, minor=0, patch=0), minor=2.1.0 (major=2, minor=1, patch=0), patch=2.0.1 (major=2, minor=0, patch=1)
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                ",
                   "draft": true,
                   "make_latest": "true",
                   "name": "v2.0.1 (Code name: Placeholder)",
@@ -1580,7 +1634,9 @@ describe('release-drafter', () => {
             (body) => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
-                  "body": "Placeholder with example. Automatically calculated values are next major=3.0 (major=3, minor=0, patch=0), minor=2.1 (major=2, minor=1, patch=0), patch=2.0 (major=2, minor=0, patch=1)",
+                  "body": "Placeholder with example. Automatically calculated values are next major=3.0 (major=3, minor=0, patch=0), minor=2.1 (major=2, minor=1, patch=0), patch=2.0 (major=2, minor=0, patch=1)
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                ",
                   "draft": true,
                   "make_latest": "true",
                   "name": "v2.1 (Code name: Placeholder)",
@@ -1622,7 +1678,9 @@ describe('release-drafter', () => {
             (body) => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
-                  "body": "Placeholder with example. Automatically calculated values are next major=3 (major=3, minor=0, patch=0), minor=2 (major=2, minor=1, patch=0), patch=2 (major=2, minor=0, patch=1)",
+                  "body": "Placeholder with example. Automatically calculated values are next major=3 (major=3, minor=0, patch=0), minor=2 (major=2, minor=1, patch=0), patch=2 (major=2, minor=0, patch=1)
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                ",
                   "draft": true,
                   "make_latest": "true",
                   "name": "v3 (Code name: Placeholder)",
@@ -1668,6 +1726,8 @@ describe('release-drafter', () => {
                 Object {
                   "body": "This is at top
                 This is the template in the middle
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1711,6 +1771,8 @@ describe('release-drafter', () => {
                 Object {
                   "body": "This is the template in the middle
                 This is at bottom
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1755,6 +1817,8 @@ describe('release-drafter', () => {
                   "body": "This is at top
                 This is the template in the middle
                 This is at bottom
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1798,7 +1862,9 @@ describe('release-drafter', () => {
             (body) => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
-                  "body": "This is at topThis is the template in the middleThis is at bottom",
+                  "body": "This is at topThis is the template in the middleThis is at bottom
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                ",
                   "draft": true,
                   "make_latest": "true",
                   "name": "v2.1.0",
@@ -1845,6 +1911,8 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "I AM AWESOME_mockenv_strips_newline_and_trailing_spaces_This is the template in the middle
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1911,6 +1979,8 @@ describe('release-drafter', () => {
                   ## ⚙️ Under the Hood
 
                   * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
+
+                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -1980,6 +2050,8 @@ describe('release-drafter', () => {
 
                   * Update Mongoose to 5.5.4 (https://github.com/toolmantim/release-drafter-test-project/pull/9) 
                   * Update Express to 4.16.4 (https://github.com/toolmantim/release-drafter-test-project/pull/9)
+
+                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -2045,6 +2117,8 @@ describe('release-drafter', () => {
                   ## ⚙️ Under the Hood
 
                   * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/14)
+
+                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -2107,6 +2181,8 @@ describe('release-drafter', () => {
                   ## ⚙️ Under the Hood
 
                   * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/14)
+
+                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -2183,6 +2259,8 @@ describe('release-drafter', () => {
                   * Update Mongoose to 5.5.4 (https://github.com/toolmantim/release-drafter-test-project/pull/4) 
                   * Update Express to 4.16.4 (https://github.com/toolmantim/release-drafter-test-project/pull/4) 
                   </details>
+
+                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -2236,6 +2314,8 @@ describe('release-drafter', () => {
                   "body": "# What's Changed
 
                 * No changes
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -2301,6 +2381,8 @@ describe('release-drafter', () => {
                 ## ⚙️ Under the Hood
 
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -2356,6 +2438,8 @@ describe('release-drafter', () => {
                 "body": "# What's Changed
 
               * No changes
+
+              <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
               ",
                 "draft": true,
                 "make_latest": "true",
@@ -2410,6 +2494,8 @@ describe('release-drafter', () => {
                 "body": "# What's Changed
 
               * No changes
+
+              <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
               ",
                 "draft": true,
                 "make_latest": "true",
@@ -2478,6 +2564,8 @@ describe('release-drafter', () => {
               ## ⚙️ Under the Hood
 
               * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
+
+              <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
               ",
                 "draft": true,
                 "make_latest": "true",
@@ -2529,6 +2617,8 @@ describe('release-drafter', () => {
               Object {
                 "body": "# What's Changed
               * No changes
+
+              <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
               ",
                 "draft": true,
                 "make_latest": "true",
@@ -2700,6 +2790,8 @@ describe('release-drafter', () => {
             expect(body).toMatchInlineSnapshot(`
               Object {
                 "body": "# There's new stuff!
+
+              <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
               ",
                 "draft": true,
                 "make_latest": "true",
@@ -2826,7 +2918,13 @@ describe('release-drafter', () => {
       .post(
         '/repos/toolmantim/release-drafter-test-project/releases',
         (body) => {
-          expect(body).toMatchObject(expectedBody)
+          // Append the deterministic admin timestamp to the expected body
+          const expected = { ...expectedBody }
+          if (expected.body) {
+            expected.body +=
+              '\n<!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->\n'
+          }
+          expect(body).toMatchObject(expected)
           return true
         }
       )
@@ -3121,6 +3219,8 @@ describe('release-drafter', () => {
                 ## Previous release
 
 
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3178,6 +3278,8 @@ describe('release-drafter', () => {
                 ## Previous release
 
                 v2.0.0
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3233,6 +3335,8 @@ describe('release-drafter', () => {
                 ## Previous release
 
 
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3286,6 +3390,8 @@ describe('release-drafter', () => {
                 ## Previous release
 
                 v2.0.0
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3339,6 +3445,8 @@ describe('release-drafter', () => {
                   "body": "## Previous release
 
                 static-tag-prefix-v2.1.4-RC3
+
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3387,7 +3495,8 @@ describe('release-drafter', () => {
                   'Resolved tag: static-tag-prefix-v2.1.5\n' +
                   'Major tag: static-tag-prefix-v2\n' +
                   'Releases: https://github.com/toolmantim/release-drafter-test-project/releases?q=tag:static-tag-prefix-v2\n' +
-                  'Compare: https://github.com/toolmantim/release-drafter-test-project/compare/static-tag-prefix-v2.1.4...static-tag-prefix-v2.1.5\n',
+                  'Compare: https://github.com/toolmantim/release-drafter-test-project/compare/static-tag-prefix-v2.1.4...static-tag-prefix-v2.1.5\n' +
+                  '\n<!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->\n',
                 name: 'static-tag-prefix-v2.1.5 🌈',
                 tag_name: 'static-tag-prefix-v2.1.5',
               })
@@ -3426,7 +3535,8 @@ describe('release-drafter', () => {
                   'Resolved tag: v2.0.1\n' +
                   'Major tag: v2\n' +
                   'Releases: https://github.com/toolmantim/release-drafter-test-project/releases?q=tag:v2\n' +
-                  'Compare: https://github.com/toolmantim/release-drafter-test-project/compare/v2.0.0...v2.0.1\n',
+                  'Compare: https://github.com/toolmantim/release-drafter-test-project/compare/v2.0.0...v2.0.1\n' +
+                  '\n<!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->\n',
                 name: 'v2.0.1 🌈',
                 tag_name: 'v2.0.1',
               })
@@ -3466,7 +3576,9 @@ describe('release-drafter', () => {
             (body) => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
-                  "body": "dummy",
+                  "body": "dummy
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                ",
                   "draft": true,
                   "make_latest": "true",
                   "name": "v2.1.0",
@@ -3508,7 +3620,9 @@ describe('release-drafter', () => {
             (body) => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
-                  "body": "dummy",
+                  "body": "dummy
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                ",
                   "draft": true,
                   "make_latest": "true",
                   "name": "v2.1.0",
@@ -3550,7 +3664,9 @@ describe('release-drafter', () => {
             (body) => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
-                  "body": "dummy",
+                  "body": "dummy
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                ",
                   "draft": true,
                   "make_latest": "true",
                   "name": "v2.1.0",
@@ -3592,7 +3708,9 @@ describe('release-drafter', () => {
             (body) => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
-                  "body": "dummy",
+                  "body": "dummy
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                ",
                   "draft": true,
                   "make_latest": "true",
                   "name": "v2.1.0",
@@ -3635,7 +3753,9 @@ describe('release-drafter', () => {
             (body) => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
-                  "body": "dummy",
+                  "body": "dummy
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                ",
                   "draft": true,
                   "make_latest": "true",
                   "name": "v2.1.0",
@@ -3680,7 +3800,9 @@ describe('release-drafter', () => {
             (body) => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
-                  "body": "dummy",
+                  "body": "dummy
+                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                ",
                   "draft": true,
                   "make_latest": "true",
                   "name": "v2.1.0",
@@ -3689,6 +3811,176 @@ describe('release-drafter', () => {
                   "target_commitish": "staging",
                 }
               `)
+              return true
+            }
+          )
+          .reply(200, releasePayload)
+
+        await probot.receive({
+          name: 'push',
+          payload: pushPayload,
+        })
+
+        expect.assertions(1)
+      })
+    })
+
+    describe('with not-ready input', () => {
+      it('prepends default banner when not-ready is true', async () => {
+        let restoreEnvironment = mockedEnv({
+          'INPUT_NOT-READY': 'true',
+        })
+
+        getConfigMock()
+
+        nock('https://api.github.com')
+          .get(
+            '/repos/toolmantim/release-drafter-test-project/releases?per_page=100'
+          )
+          .reply(200, [releasePayload])
+
+        nock('https://api.github.com')
+          .post('/graphql', (body) =>
+            body.query.includes('query findCommitsWithAssociatedPullRequests')
+          )
+          .reply(200, graphqlCommitsMergeCommit)
+
+        nock('https://api.github.com')
+          .post(
+            '/repos/toolmantim/release-drafter-test-project/releases',
+            (body) => {
+              expect(body.body).toMatch(/^> \[!CAUTION\]/)
+              expect(body.body).toContain(
+                '> **NOT READY FOR PUBLISHING**'
+              )
+              expect(body.body).toContain(
+                '> This release draft is still being prepared. Do not publish until this banner is removed.'
+              )
+              expect(body.body).toContain(
+                '<!-- Release draft last updated:'
+              )
+              return true
+            }
+          )
+          .reply(200, releasePayload)
+
+        await probot.receive({
+          name: 'push',
+          payload: pushPayload,
+        })
+
+        expect.assertions(4)
+
+        restoreEnvironment()
+      })
+
+      it('prepends custom banner when not-ready is a custom string', async () => {
+        let restoreEnvironment = mockedEnv({
+          'INPUT_NOT-READY': 'Assets are still being uploaded. Please wait.',
+        })
+
+        getConfigMock()
+
+        nock('https://api.github.com')
+          .get(
+            '/repos/toolmantim/release-drafter-test-project/releases?per_page=100'
+          )
+          .reply(200, [releasePayload])
+
+        nock('https://api.github.com')
+          .post('/graphql', (body) =>
+            body.query.includes('query findCommitsWithAssociatedPullRequests')
+          )
+          .reply(200, graphqlCommitsMergeCommit)
+
+        nock('https://api.github.com')
+          .post(
+            '/repos/toolmantim/release-drafter-test-project/releases',
+            (body) => {
+              expect(body.body).toContain(
+                '> **NOT READY FOR PUBLISHING**'
+              )
+              expect(body.body).toContain(
+                '> Assets are still being uploaded. Please wait.'
+              )
+              return true
+            }
+          )
+          .reply(200, releasePayload)
+
+        await probot.receive({
+          name: 'push',
+          payload: pushPayload,
+        })
+
+        expect.assertions(2)
+
+        restoreEnvironment()
+      })
+
+      it('does not add banner when not-ready is false', async () => {
+        let restoreEnvironment = mockedEnv({
+          'INPUT_NOT-READY': 'false',
+        })
+
+        getConfigMock()
+
+        nock('https://api.github.com')
+          .get(
+            '/repos/toolmantim/release-drafter-test-project/releases?per_page=100'
+          )
+          .reply(200, [releasePayload])
+
+        nock('https://api.github.com')
+          .post('/graphql', (body) =>
+            body.query.includes('query findCommitsWithAssociatedPullRequests')
+          )
+          .reply(200, graphqlCommitsMergeCommit)
+
+        nock('https://api.github.com')
+          .post(
+            '/repos/toolmantim/release-drafter-test-project/releases',
+            (body) => {
+              expect(body.body).not.toContain('NOT READY FOR PUBLISHING')
+              expect(body.body).not.toContain('[!CAUTION]')
+              expect(body.body).toContain(
+                '<!-- Release draft last updated:'
+              )
+              return true
+            }
+          )
+          .reply(200, releasePayload)
+
+        await probot.receive({
+          name: 'push',
+          payload: pushPayload,
+        })
+
+        expect.assertions(3)
+
+        restoreEnvironment()
+      })
+
+      it('does not add banner when not-ready is empty', async () => {
+        getConfigMock()
+
+        nock('https://api.github.com')
+          .get(
+            '/repos/toolmantim/release-drafter-test-project/releases?per_page=100'
+          )
+          .reply(200, [releasePayload])
+
+        nock('https://api.github.com')
+          .post('/graphql', (body) =>
+            body.query.includes('query findCommitsWithAssociatedPullRequests')
+          )
+          .reply(200, graphqlCommitsMergeCommit)
+
+        nock('https://api.github.com')
+          .post(
+            '/repos/toolmantim/release-drafter-test-project/releases',
+            (body) => {
+              expect(body.body).not.toContain('NOT READY FOR PUBLISHING')
               return true
             }
           )

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -205,7 +205,7 @@ describe('release-drafter', () => {
 
                   * No changes
 
-                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -286,7 +286,7 @@ describe('release-drafter', () => {
 
                   * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -351,7 +351,7 @@ describe('release-drafter', () => {
 
                 Previous tag: ''
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -418,7 +418,7 @@ describe('release-drafter', () => {
 
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -525,7 +525,7 @@ describe('release-drafter', () => {
 
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -572,7 +572,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "Placeholder with example. Automatically calculated values are next major=3.0.0 (major=3, minor=0, patch=0), minor=2.1.0 (major=2, minor=1, patch=0), patch=2.0.1 (major=2, minor=0, patch=1)
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -633,7 +633,7 @@ describe('release-drafter', () => {
                   ## ⚙️ Under the Hood
 
                   * Change: #4 'Update dependencies' @TimonVS
-                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -695,7 +695,7 @@ describe('release-drafter', () => {
                   ## ⚙️ Under the Hood
 
                   * Change: #4 'Update dependencies'
-                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -757,7 +757,7 @@ describe('release-drafter', () => {
                   ## ⚙️ Under the Hood
 
                   * Change: #4 'Update dependencies' @TimonVS
-                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -804,7 +804,7 @@ describe('release-drafter', () => {
                 expect(body).toMatchInlineSnapshot(`
                   Object {
                     "body": "A big thanks to: @TimonVS and Ada Lovelace
-                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -849,7 +849,7 @@ describe('release-drafter', () => {
                 expect(body).toMatchInlineSnapshot(`
                   Object {
                     "body": "A big thanks to: Nobody
-                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -896,7 +896,7 @@ describe('release-drafter', () => {
                 expect(body).toMatchInlineSnapshot(`
                   Object {
                     "body": "A big thanks to: Ada Lovelace
-                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -950,7 +950,7 @@ describe('release-drafter', () => {
 
                 * No changes
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -995,7 +995,7 @@ describe('release-drafter', () => {
                 expect(body).toMatchInlineSnapshot(`
                   Object {
                     "body": "* No changes mmkay
-                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -1128,7 +1128,7 @@ describe('release-drafter', () => {
 
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1183,7 +1183,7 @@ describe('release-drafter', () => {
 
                 **Full Changelog**: https://github.com/toolmantim/release-drafter-test-project/compare/v2.0.0...v2.1.0
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1236,7 +1236,7 @@ describe('release-drafter', () => {
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/2) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/1)
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1287,7 +1287,7 @@ describe('release-drafter', () => {
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/2) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/1)
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1338,7 +1338,7 @@ describe('release-drafter', () => {
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/2) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/1)
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1389,7 +1389,7 @@ describe('release-drafter', () => {
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/19) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/18)
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1440,7 +1440,7 @@ describe('release-drafter', () => {
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/19) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/18)
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1491,7 +1491,7 @@ describe('release-drafter', () => {
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/2) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/1)
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1555,7 +1555,7 @@ describe('release-drafter', () => {
 
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1601,7 +1601,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "Placeholder with example. Automatically calculated values are next major=3.0.0 (major=3, minor=0, patch=0), minor=2.1.0 (major=2, minor=1, patch=0), patch=2.0.1 (major=2, minor=0, patch=1)
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1645,7 +1645,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "Placeholder with example. Automatically calculated values are next major=3.0 (major=3, minor=0, patch=0), minor=2.1 (major=2, minor=1, patch=0), patch=2.0 (major=2, minor=0, patch=1)
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1689,7 +1689,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "Placeholder with example. Automatically calculated values are next major=3 (major=3, minor=0, patch=0), minor=2 (major=2, minor=1, patch=0), patch=2 (major=2, minor=0, patch=1)
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1737,7 +1737,7 @@ describe('release-drafter', () => {
                   "body": "This is at top
                 This is the template in the middle
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1782,7 +1782,7 @@ describe('release-drafter', () => {
                   "body": "This is the template in the middle
                 This is at bottom
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1828,7 +1828,7 @@ describe('release-drafter', () => {
                 This is the template in the middle
                 This is at bottom
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1873,7 +1873,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "This is at topThis is the template in the middleThis is at bottom
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1922,7 +1922,7 @@ describe('release-drafter', () => {
                 Object {
                   "body": "I AM AWESOME_mockenv_strips_newline_and_trailing_spaces_This is the template in the middle
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1990,7 +1990,7 @@ describe('release-drafter', () => {
 
                   * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -2061,7 +2061,7 @@ describe('release-drafter', () => {
                   * Update Mongoose to 5.5.4 (https://github.com/toolmantim/release-drafter-test-project/pull/9) 
                   * Update Express to 4.16.4 (https://github.com/toolmantim/release-drafter-test-project/pull/9)
 
-                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -2128,7 +2128,7 @@ describe('release-drafter', () => {
 
                   * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/14)
 
-                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -2192,7 +2192,7 @@ describe('release-drafter', () => {
 
                   * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/14)
 
-                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -2270,7 +2270,7 @@ describe('release-drafter', () => {
                   * Update Express to 4.16.4 (https://github.com/toolmantim/release-drafter-test-project/pull/4) 
                   </details>
 
-                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                  <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -2325,7 +2325,7 @@ describe('release-drafter', () => {
 
                 * No changes
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -2392,7 +2392,7 @@ describe('release-drafter', () => {
 
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -2449,7 +2449,7 @@ describe('release-drafter', () => {
 
               * No changes
 
-              <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+              <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
               ",
                 "draft": true,
                 "make_latest": "true",
@@ -2505,7 +2505,7 @@ describe('release-drafter', () => {
 
               * No changes
 
-              <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+              <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
               ",
                 "draft": true,
                 "make_latest": "true",
@@ -2575,7 +2575,7 @@ describe('release-drafter', () => {
 
               * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-              <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+              <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
               ",
                 "draft": true,
                 "make_latest": "true",
@@ -2628,7 +2628,7 @@ describe('release-drafter', () => {
                 "body": "# What's Changed
               * No changes
 
-              <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+              <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
               ",
                 "draft": true,
                 "make_latest": "true",
@@ -2801,7 +2801,7 @@ describe('release-drafter', () => {
               Object {
                 "body": "# There's new stuff!
 
-              <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+              <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
               ",
                 "draft": true,
                 "make_latest": "true",
@@ -2932,7 +2932,7 @@ describe('release-drafter', () => {
           const expected = { ...expectedBody }
           if (expected.body) {
             expected.body +=
-              '\n<!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->\n'
+              '\n<!-- Release drafted at `2024-12-31 4:00pm Pacific` -->\n'
           }
           expect(body).toMatchObject(expected)
           return true
@@ -3230,7 +3230,7 @@ describe('release-drafter', () => {
 
 
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3289,7 +3289,7 @@ describe('release-drafter', () => {
 
                 v2.0.0
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3346,7 +3346,7 @@ describe('release-drafter', () => {
 
 
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3401,7 +3401,7 @@ describe('release-drafter', () => {
 
                 v2.0.0
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3456,7 +3456,7 @@ describe('release-drafter', () => {
 
                 static-tag-prefix-v2.1.4-RC3
 
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3506,7 +3506,7 @@ describe('release-drafter', () => {
                   'Major tag: static-tag-prefix-v2\n' +
                   'Releases: https://github.com/toolmantim/release-drafter-test-project/releases?q=tag:static-tag-prefix-v2\n' +
                   'Compare: https://github.com/toolmantim/release-drafter-test-project/compare/static-tag-prefix-v2.1.4...static-tag-prefix-v2.1.5\n' +
-                  '\n<!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->\n',
+                  '\n<!-- Release drafted at `2024-12-31 4:00pm Pacific` -->\n',
                 name: 'static-tag-prefix-v2.1.5 🌈',
                 tag_name: 'static-tag-prefix-v2.1.5',
               })
@@ -3546,7 +3546,7 @@ describe('release-drafter', () => {
                   'Major tag: v2\n' +
                   'Releases: https://github.com/toolmantim/release-drafter-test-project/releases?q=tag:v2\n' +
                   'Compare: https://github.com/toolmantim/release-drafter-test-project/compare/v2.0.0...v2.0.1\n' +
-                  '\n<!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->\n',
+                  '\n<!-- Release drafted at `2024-12-31 4:00pm Pacific` -->\n',
                 name: 'v2.0.1 🌈',
                 tag_name: 'v2.0.1',
               })
@@ -3587,7 +3587,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "dummy
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3631,7 +3631,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "dummy
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3675,7 +3675,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "dummy
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3719,7 +3719,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "dummy
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3764,7 +3764,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "dummy
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3811,7 +3811,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "dummy
-                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
+                <!-- Release drafted at \`2024-12-31 4:00pm Pacific\` -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3864,7 +3864,7 @@ describe('release-drafter', () => {
               expect(body.body).toContain(
                 '> This release draft is still being prepared. Do not publish until this banner is removed.'
               )
-              expect(body.body).toContain('<!-- Release draft timestamp:')
+              expect(body.body).toContain('<!-- Release drafted at')
               return true
             }
           )
@@ -3947,7 +3947,7 @@ describe('release-drafter', () => {
             (body) => {
               expect(body.body).not.toContain('NOT READY FOR PUBLISHING')
               expect(body.body).not.toContain('[!CAUTION]')
-              expect(body.body).toContain('<!-- Release draft timestamp:')
+              expect(body.body).toContain('<!-- Release drafted at')
               return true
             }
           )

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -28,6 +28,8 @@ const graphqlCommitsPaginated2 = require('./fixtures/graphql-commits-paginated-2
 
 nock.disableNetConnect()
 
+const _OriginalDate = global.Date
+
 const privateKey = `-----BEGIN RSA PRIVATE KEY-----
 MIICXQIBAAKBgQC2RTg7dNjQMwPzFwF0gXFRCcRHha4H24PeK7ey6Ij39ay1hy2o
 H9NEZOxrmAb0bEBDuECImTsJdpgI6F3OwkJGsOkIH09xTk5tC4fkfY8N7LklK+uM
@@ -70,10 +72,17 @@ describe('release-drafter', () => {
   beforeEach(() => {
     logger = []
 
-    // Fix Date.toISOString so the admin timestamp comment is deterministic
-    jest
-      .spyOn(Date.prototype, 'toISOString')
-      .mockReturnValue('2025-01-01T00:00:00.000Z')
+    // Fix Date so the admin timestamp comment is deterministic
+    const fixedDate = new _OriginalDate('2025-01-01T00:00:00.000Z')
+    const MockDate = function (...args) {
+      if (args.length === 0) return fixedDate
+      return new _OriginalDate(...args)
+    }
+    MockDate.prototype = _OriginalDate.prototype
+    MockDate.now = () => fixedDate.getTime()
+    MockDate.parse = _OriginalDate.parse
+    MockDate.UTC = _OriginalDate.UTC
+    global.Date = MockDate
 
     nock('https://api.github.com')
       .post('/app/installations/179208/access_tokens')
@@ -97,6 +106,7 @@ describe('release-drafter', () => {
   afterAll(nock.restore)
 
   afterEach(() => {
+    global.Date = _OriginalDate
     jest.restoreAllMocks()
     nock.cleanAll()
     restoreEnvironment()
@@ -195,7 +205,7 @@ describe('release-drafter', () => {
 
                   * No changes
 
-                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -276,7 +286,7 @@ describe('release-drafter', () => {
 
                   * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -341,7 +351,7 @@ describe('release-drafter', () => {
 
                 Previous tag: ''
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -408,7 +418,7 @@ describe('release-drafter', () => {
 
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -515,7 +525,7 @@ describe('release-drafter', () => {
 
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -562,7 +572,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "Placeholder with example. Automatically calculated values are next major=3.0.0 (major=3, minor=0, patch=0), minor=2.1.0 (major=2, minor=1, patch=0), patch=2.0.1 (major=2, minor=0, patch=1)
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -623,7 +633,7 @@ describe('release-drafter', () => {
                   ## ⚙️ Under the Hood
 
                   * Change: #4 'Update dependencies' @TimonVS
-                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -685,7 +695,7 @@ describe('release-drafter', () => {
                   ## ⚙️ Under the Hood
 
                   * Change: #4 'Update dependencies'
-                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -747,7 +757,7 @@ describe('release-drafter', () => {
                   ## ⚙️ Under the Hood
 
                   * Change: #4 'Update dependencies' @TimonVS
-                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -794,7 +804,7 @@ describe('release-drafter', () => {
                 expect(body).toMatchInlineSnapshot(`
                   Object {
                     "body": "A big thanks to: @TimonVS and Ada Lovelace
-                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -839,7 +849,7 @@ describe('release-drafter', () => {
                 expect(body).toMatchInlineSnapshot(`
                   Object {
                     "body": "A big thanks to: Nobody
-                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -886,7 +896,7 @@ describe('release-drafter', () => {
                 expect(body).toMatchInlineSnapshot(`
                   Object {
                     "body": "A big thanks to: Ada Lovelace
-                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -940,7 +950,7 @@ describe('release-drafter', () => {
 
                 * No changes
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -985,7 +995,7 @@ describe('release-drafter', () => {
                 expect(body).toMatchInlineSnapshot(`
                   Object {
                     "body": "* No changes mmkay
-                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -1118,7 +1128,7 @@ describe('release-drafter', () => {
 
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1173,7 +1183,7 @@ describe('release-drafter', () => {
 
                 **Full Changelog**: https://github.com/toolmantim/release-drafter-test-project/compare/v2.0.0...v2.1.0
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1226,7 +1236,7 @@ describe('release-drafter', () => {
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/2) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/1)
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1277,7 +1287,7 @@ describe('release-drafter', () => {
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/2) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/1)
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1328,7 +1338,7 @@ describe('release-drafter', () => {
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/2) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/1)
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1379,7 +1389,7 @@ describe('release-drafter', () => {
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/19) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/18)
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1430,7 +1440,7 @@ describe('release-drafter', () => {
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/19) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/18)
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1481,7 +1491,7 @@ describe('release-drafter', () => {
                 * Add big feature (https://github.com/toolmantim/release-drafter-test-project/pull/2) 
                 * Add alien technology (https://github.com/toolmantim/release-drafter-test-project/pull/1)
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1545,7 +1555,7 @@ describe('release-drafter', () => {
 
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1591,7 +1601,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "Placeholder with example. Automatically calculated values are next major=3.0.0 (major=3, minor=0, patch=0), minor=2.1.0 (major=2, minor=1, patch=0), patch=2.0.1 (major=2, minor=0, patch=1)
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1635,7 +1645,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "Placeholder with example. Automatically calculated values are next major=3.0 (major=3, minor=0, patch=0), minor=2.1 (major=2, minor=1, patch=0), patch=2.0 (major=2, minor=0, patch=1)
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1679,7 +1689,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "Placeholder with example. Automatically calculated values are next major=3 (major=3, minor=0, patch=0), minor=2 (major=2, minor=1, patch=0), patch=2 (major=2, minor=0, patch=1)
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1727,7 +1737,7 @@ describe('release-drafter', () => {
                   "body": "This is at top
                 This is the template in the middle
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1772,7 +1782,7 @@ describe('release-drafter', () => {
                   "body": "This is the template in the middle
                 This is at bottom
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1818,7 +1828,7 @@ describe('release-drafter', () => {
                 This is the template in the middle
                 This is at bottom
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1863,7 +1873,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "This is at topThis is the template in the middleThis is at bottom
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1912,7 +1922,7 @@ describe('release-drafter', () => {
                 Object {
                   "body": "I AM AWESOME_mockenv_strips_newline_and_trailing_spaces_This is the template in the middle
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -1980,7 +1990,7 @@ describe('release-drafter', () => {
 
                   * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -2051,7 +2061,7 @@ describe('release-drafter', () => {
                   * Update Mongoose to 5.5.4 (https://github.com/toolmantim/release-drafter-test-project/pull/9) 
                   * Update Express to 4.16.4 (https://github.com/toolmantim/release-drafter-test-project/pull/9)
 
-                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -2118,7 +2128,7 @@ describe('release-drafter', () => {
 
                   * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/14)
 
-                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -2182,7 +2192,7 @@ describe('release-drafter', () => {
 
                   * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/14)
 
-                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -2260,7 +2270,7 @@ describe('release-drafter', () => {
                   * Update Express to 4.16.4 (https://github.com/toolmantim/release-drafter-test-project/pull/4) 
                   </details>
 
-                  <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                  <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                   ",
                     "draft": true,
                     "make_latest": "true",
@@ -2315,7 +2325,7 @@ describe('release-drafter', () => {
 
                 * No changes
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -2382,7 +2392,7 @@ describe('release-drafter', () => {
 
                 * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -2439,7 +2449,7 @@ describe('release-drafter', () => {
 
               * No changes
 
-              <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+              <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
               ",
                 "draft": true,
                 "make_latest": "true",
@@ -2495,7 +2505,7 @@ describe('release-drafter', () => {
 
               * No changes
 
-              <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+              <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
               ",
                 "draft": true,
                 "make_latest": "true",
@@ -2565,7 +2575,7 @@ describe('release-drafter', () => {
 
               * Update dependencies (https://github.com/toolmantim/release-drafter-test-project/pull/4)
 
-              <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+              <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
               ",
                 "draft": true,
                 "make_latest": "true",
@@ -2618,7 +2628,7 @@ describe('release-drafter', () => {
                 "body": "# What's Changed
               * No changes
 
-              <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+              <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
               ",
                 "draft": true,
                 "make_latest": "true",
@@ -2791,7 +2801,7 @@ describe('release-drafter', () => {
               Object {
                 "body": "# There's new stuff!
 
-              <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+              <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
               ",
                 "draft": true,
                 "make_latest": "true",
@@ -2922,7 +2932,7 @@ describe('release-drafter', () => {
           const expected = { ...expectedBody }
           if (expected.body) {
             expected.body +=
-              '\n<!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->\n'
+              '\n<!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->\n'
           }
           expect(body).toMatchObject(expected)
           return true
@@ -3220,7 +3230,7 @@ describe('release-drafter', () => {
 
 
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3279,7 +3289,7 @@ describe('release-drafter', () => {
 
                 v2.0.0
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3336,7 +3346,7 @@ describe('release-drafter', () => {
 
 
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3391,7 +3401,7 @@ describe('release-drafter', () => {
 
                 v2.0.0
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3446,7 +3456,7 @@ describe('release-drafter', () => {
 
                 static-tag-prefix-v2.1.4-RC3
 
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3496,7 +3506,7 @@ describe('release-drafter', () => {
                   'Major tag: static-tag-prefix-v2\n' +
                   'Releases: https://github.com/toolmantim/release-drafter-test-project/releases?q=tag:static-tag-prefix-v2\n' +
                   'Compare: https://github.com/toolmantim/release-drafter-test-project/compare/static-tag-prefix-v2.1.4...static-tag-prefix-v2.1.5\n' +
-                  '\n<!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->\n',
+                  '\n<!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->\n',
                 name: 'static-tag-prefix-v2.1.5 🌈',
                 tag_name: 'static-tag-prefix-v2.1.5',
               })
@@ -3536,7 +3546,7 @@ describe('release-drafter', () => {
                   'Major tag: v2\n' +
                   'Releases: https://github.com/toolmantim/release-drafter-test-project/releases?q=tag:v2\n' +
                   'Compare: https://github.com/toolmantim/release-drafter-test-project/compare/v2.0.0...v2.0.1\n' +
-                  '\n<!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->\n',
+                  '\n<!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->\n',
                 name: 'v2.0.1 🌈',
                 tag_name: 'v2.0.1',
               })
@@ -3577,7 +3587,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "dummy
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3621,7 +3631,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "dummy
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3665,7 +3675,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "dummy
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3709,7 +3719,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "dummy
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3754,7 +3764,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "dummy
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3801,7 +3811,7 @@ describe('release-drafter', () => {
               expect(body).toMatchInlineSnapshot(`
                 Object {
                   "body": "dummy
-                <!-- Release draft last updated: 2025-01-01T00:00:00.000Z -->
+                <!-- Release draft timestamp: 2024-12-31 4:00pm Pacific -->
                 ",
                   "draft": true,
                   "make_latest": "true",
@@ -3854,7 +3864,7 @@ describe('release-drafter', () => {
               expect(body.body).toContain(
                 '> This release draft is still being prepared. Do not publish until this banner is removed.'
               )
-              expect(body.body).toContain('<!-- Release draft last updated:')
+              expect(body.body).toContain('<!-- Release draft timestamp:')
               return true
             }
           )
@@ -3937,7 +3947,7 @@ describe('release-drafter', () => {
             (body) => {
               expect(body.body).not.toContain('NOT READY FOR PUBLISHING')
               expect(body.body).not.toContain('[!CAUTION]')
-              expect(body.body).toContain('<!-- Release draft last updated:')
+              expect(body.body).toContain('<!-- Release draft timestamp:')
               return true
             }
           )

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3849,16 +3849,12 @@ describe('release-drafter', () => {
           .post(
             '/repos/toolmantim/release-drafter-test-project/releases',
             (body) => {
-              expect(body.body).toMatch(/^> \[!CAUTION\]/)
-              expect(body.body).toContain(
-                '> **NOT READY FOR PUBLISHING**'
-              )
+              expect(body.body).toMatch(/^> \[!CAUTION]/)
+              expect(body.body).toContain('> **NOT READY FOR PUBLISHING**')
               expect(body.body).toContain(
                 '> This release draft is still being prepared. Do not publish until this banner is removed.'
               )
-              expect(body.body).toContain(
-                '<!-- Release draft last updated:'
-              )
+              expect(body.body).toContain('<!-- Release draft last updated:')
               return true
             }
           )
@@ -3897,9 +3893,7 @@ describe('release-drafter', () => {
           .post(
             '/repos/toolmantim/release-drafter-test-project/releases',
             (body) => {
-              expect(body.body).toContain(
-                '> **NOT READY FOR PUBLISHING**'
-              )
+              expect(body.body).toContain('> **NOT READY FOR PUBLISHING**')
               expect(body.body).toContain(
                 '> Assets are still being uploaded. Please wait.'
               )
@@ -3943,9 +3937,7 @@ describe('release-drafter', () => {
             (body) => {
               expect(body.body).not.toContain('NOT READY FOR PUBLISHING')
               expect(body.body).not.toContain('[!CAUTION]')
-              expect(body.body).toContain(
-                '<!-- Release draft last updated:'
-              )
+              expect(body.body).toContain('<!-- Release draft last updated:')
               return true
             }
           )

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,149 +25,149 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.28.6, @babel/code-frame@npm:^7.29.0":
-  version: 7.29.0
-  resolution: "@babel/code-frame@npm:7.29.0"
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/code-frame@npm:7.29.7"
   dependencies:
-    "@babel/helper-validator-identifier": "npm:^7.28.5"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
     js-tokens: "npm:^4.0.0"
     picocolors: "npm:^1.1.1"
-  checksum: 10c0/d34cc504e7765dfb576a663d97067afb614525806b5cad1a5cc1a7183b916fec8ff57fa233585e3926fd5a9e6b31aae6df91aa81ae9775fb7a28f658d3346f0d
+  checksum: 10c0/169fc2080169a40c1760155eaaaf739bcb882df0bec76a83adbda5493645bc17270a3434b8848c494b1933e96fe1d147370001e3cda09a39f43ae30f08ef2069
   languageName: node
   linkType: hard
 
-"@babel/compat-data@npm:^7.28.6":
-  version: 7.29.0
-  resolution: "@babel/compat-data@npm:7.29.0"
-  checksum: 10c0/08f348554989d23aa801bf1405aa34b15e841c0d52d79da7e524285c77a5f9d298e70e11d91cc578d8e2c9542efc586d50c5f5cf8e1915b254a9dcf786913a94
+"@babel/compat-data@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/compat-data@npm:7.29.7"
+  checksum: 10c0/47913f05e08a45a1c9df38c02b4b49e391005085b489432647a1abe112e5d9c75e3be8ea5972b7f6da4ec5d1339922ceb9ea02b8a25d4ed1cb8636e5261f344e
   languageName: node
   linkType: hard
 
 "@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3":
-  version: 7.29.0
-  resolution: "@babel/core@npm:7.29.0"
+  version: 7.29.7
+  resolution: "@babel/core@npm:7.29.7"
   dependencies:
-    "@babel/code-frame": "npm:^7.29.0"
-    "@babel/generator": "npm:^7.29.0"
-    "@babel/helper-compilation-targets": "npm:^7.28.6"
-    "@babel/helper-module-transforms": "npm:^7.28.6"
-    "@babel/helpers": "npm:^7.28.6"
-    "@babel/parser": "npm:^7.29.0"
-    "@babel/template": "npm:^7.28.6"
-    "@babel/traverse": "npm:^7.29.0"
-    "@babel/types": "npm:^7.29.0"
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/generator": "npm:^7.29.7"
+    "@babel/helper-compilation-targets": "npm:^7.29.7"
+    "@babel/helper-module-transforms": "npm:^7.29.7"
+    "@babel/helpers": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/template": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
     "@jridgewell/remapping": "npm:^2.3.5"
     convert-source-map: "npm:^2.0.0"
     debug: "npm:^4.1.0"
     gensync: "npm:^1.0.0-beta.2"
     json5: "npm:^2.2.3"
     semver: "npm:^6.3.1"
-  checksum: 10c0/5127d2e8e842ae409e11bcbb5c2dff9874abf5415e8026925af7308e903f4f43397341467a130490d1a39884f461bc2b67f3063bce0be44340db89687fd852aa
+  checksum: 10c0/112fb09c24de7a1de64d1de2c31fe65c4e6af4cb2fb6e6d99ea5373e6fc51e75b88581c0efae4c4c68f119a02a988c7106e95011a41530a2fb8ed793c7eaa07b
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.29.0, @babel/generator@npm:^7.7.2":
-  version: 7.29.1
-  resolution: "@babel/generator@npm:7.29.1"
+"@babel/generator@npm:^7.29.7, @babel/generator@npm:^7.7.2":
+  version: 7.29.7
+  resolution: "@babel/generator@npm:7.29.7"
   dependencies:
-    "@babel/parser": "npm:^7.29.0"
-    "@babel/types": "npm:^7.29.0"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
     "@jridgewell/gen-mapping": "npm:^0.3.12"
     "@jridgewell/trace-mapping": "npm:^0.3.28"
     jsesc: "npm:^3.0.2"
-  checksum: 10c0/349086e6876258ef3fb2823030fee0f6c0eb9c3ebe35fc572e16997f8c030d765f636ddc6299edae63e760ea6658f8ee9a2edfa6d6b24c9a80c917916b973551
+  checksum: 10c0/9bf72b01b5bd0ea5b1288a0e37dbd360bff2f2b1ce73342c0d40fb3db2ec3dc004ada5ffa925c5e12939a416eed59e600d562b8ecd938ce0d27dfd0eb6c6c2b7
   languageName: node
   linkType: hard
 
-"@babel/helper-compilation-targets@npm:^7.28.6":
-  version: 7.28.6
-  resolution: "@babel/helper-compilation-targets@npm:7.28.6"
+"@babel/helper-compilation-targets@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-compilation-targets@npm:7.29.7"
   dependencies:
-    "@babel/compat-data": "npm:^7.28.6"
-    "@babel/helper-validator-option": "npm:^7.27.1"
+    "@babel/compat-data": "npm:^7.29.7"
+    "@babel/helper-validator-option": "npm:^7.29.7"
     browserslist: "npm:^4.24.0"
     lru-cache: "npm:^5.1.1"
     semver: "npm:^6.3.1"
-  checksum: 10c0/3fcdf3b1b857a1578e99d20508859dbd3f22f3c87b8a0f3dc540627b4be539bae7f6e61e49d931542fe5b557545347272bbdacd7f58a5c77025a18b745593a50
+  checksum: 10c0/4c15fd4c69a0a7047799a28a88460c19cede0a0ee8af994ea169114986f4af48b92c7393a4a3fee0456c11a656eece3448a6ed06354453d6c27cccf17195453b
   languageName: node
   linkType: hard
 
-"@babel/helper-globals@npm:^7.28.0":
-  version: 7.28.0
-  resolution: "@babel/helper-globals@npm:7.28.0"
-  checksum: 10c0/5a0cd0c0e8c764b5f27f2095e4243e8af6fa145daea2b41b53c0c1414fe6ff139e3640f4e2207ae2b3d2153a1abd346f901c26c290ee7cb3881dd922d4ee9232
+"@babel/helper-globals@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-globals@npm:7.29.7"
+  checksum: 10c0/f38417c40b1129a1b2b519ca961b9040c8827d1444fd74068702286b91b77089431dc76b6b9d5c1496e5da2a4f3ad329c6946e688ba3fa0d1d0b3d2b4f34f36a
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.28.6":
-  version: 7.28.6
-  resolution: "@babel/helper-module-imports@npm:7.28.6"
+"@babel/helper-module-imports@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-module-imports@npm:7.29.7"
   dependencies:
-    "@babel/traverse": "npm:^7.28.6"
-    "@babel/types": "npm:^7.28.6"
-  checksum: 10c0/b49d8d8f204d9dbfd5ac70c54e533e5269afb3cea966a9d976722b13e9922cc773a653405f53c89acb247d5aebdae4681d631a3ae3df77ec046b58da76eda2ac
+    "@babel/traverse": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10c0/6adf60d97356027413342a092f818d9678c4f5caff716a33e3284b5ae14e47a9e88059d421dde4ee4894691260039a12602c0e7becadc175602194b40dfa345d
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.28.6":
-  version: 7.28.6
-  resolution: "@babel/helper-module-transforms@npm:7.28.6"
+"@babel/helper-module-transforms@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-module-transforms@npm:7.29.7"
   dependencies:
-    "@babel/helper-module-imports": "npm:^7.28.6"
-    "@babel/helper-validator-identifier": "npm:^7.28.5"
-    "@babel/traverse": "npm:^7.28.6"
+    "@babel/helper-module-imports": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.7"
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 10c0/6f03e14fc30b287ce0b839474b5f271e72837d0cafe6b172d759184d998fbee3903a035e81e07c2c596449e504f453463d58baa65b6f40a37ded5bec74620b2b
+  checksum: 10c0/ee5a2172c24a42be696836f4b0d947489c9729d8adf5821885cf77d1ad5333e3c447368e9a71f67df1099570490553dccf9f888ef0a92a48aa63cb086bd8c7e1
   languageName: node
   linkType: hard
 
-"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.28.6, @babel/helper-plugin-utils@npm:^7.8.0":
-  version: 7.28.6
-  resolution: "@babel/helper-plugin-utils@npm:7.28.6"
-  checksum: 10c0/3f5f8acc152fdbb69a84b8624145ff4f9b9f6e776cb989f9f968f8606eb7185c5c3cfcf3ba08534e37e1e0e1c118ac67080610333f56baa4f7376c99b5f1143d
+"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.29.7, @babel/helper-plugin-utils@npm:^7.8.0":
+  version: 7.29.7
+  resolution: "@babel/helper-plugin-utils@npm:7.29.7"
+  checksum: 10c0/380477a06133274a2759f9355929cb60a95e8b8fee624a1ae1fa349e1d1645b89daca456f72833f6d1062bffa12ee4271c5bf0cc5a61c0166cdc24c7591e2408
   languageName: node
   linkType: hard
 
-"@babel/helper-string-parser@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/helper-string-parser@npm:7.27.1"
-  checksum: 10c0/8bda3448e07b5583727c103560bcf9c4c24b3c1051a4c516d4050ef69df37bb9a4734a585fe12725b8c2763de0a265aa1e909b485a4e3270b7cfd3e4dbe4b602
+"@babel/helper-string-parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-string-parser@npm:7.29.7"
+  checksum: 10c0/194bc0f1716e396d5ffde56ad6119745fb9557662c98611590e5e454906783a4ccb21ce93056b8eb69a4909044834e45d96e50ac695bbe9e3221648fe033c06c
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.18.6, @babel/helper-validator-identifier@npm:^7.28.5":
-  version: 7.28.5
-  resolution: "@babel/helper-validator-identifier@npm:7.28.5"
-  checksum: 10c0/42aaebed91f739a41f3d80b72752d1f95fd7c72394e8e4bd7cdd88817e0774d80a432451bcba17c2c642c257c483bf1d409dd4548883429ea9493a3bc4ab0847
+"@babel/helper-validator-identifier@npm:^7.18.6, @babel/helper-validator-identifier@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-identifier@npm:7.29.7"
+  checksum: 10c0/4795354e7ae0dcafa72de1cd04ec51252dc1498517170beaf019e03effc5b7bf13c6b21a3949a77e07b8125be7f106ed1131350d8ebd4566ae874094a726d62b
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-option@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/helper-validator-option@npm:7.27.1"
-  checksum: 10c0/6fec5f006eba40001a20f26b1ef5dbbda377b7b68c8ad518c05baa9af3f396e780bdfded24c4eef95d14bb7b8fd56192a6ed38d5d439b97d10efc5f1a191d148
+"@babel/helper-validator-option@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-option@npm:7.29.7"
+  checksum: 10c0/d2a06c6d0ac40ba4a2f219fc2cab249c7a94bacdb2686273b7f9598571c908809b48468ff588915a346e6cc7296f60b581023d1d498b747fed06f779d335c2cc
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.28.6":
-  version: 7.28.6
-  resolution: "@babel/helpers@npm:7.28.6"
+"@babel/helpers@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helpers@npm:7.29.7"
   dependencies:
-    "@babel/template": "npm:^7.28.6"
-    "@babel/types": "npm:^7.28.6"
-  checksum: 10c0/c4a779c66396bb0cf619402d92f1610601ff3832db2d3b86b9c9dd10983bf79502270e97ac6d5280cea1b1a37de2f06ecbac561bd2271545270407fbe64027cb
+    "@babel/template": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10c0/218e8d10953647c9f44775f5a022b227a182674853b5ea8631889deb7e1a3e4bc870388aaecf59bb8bd92a87f9a96220ed3f70a35bffec6bcf9169ecb67891ac
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.28.6, @babel/parser@npm:^7.29.0":
-  version: 7.29.0
-  resolution: "@babel/parser@npm:7.29.0"
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/parser@npm:7.29.7"
   dependencies:
-    "@babel/types": "npm:^7.29.0"
+    "@babel/types": "npm:^7.29.7"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 10c0/333b2aa761264b91577a74bee86141ef733f9f9f6d4fc52548e4847dc35dfbf821f58c46832c637bfa761a6d9909d6a68f7d1ed59e17e4ffbb958dc510c17b62
+  checksum: 10c0/65133038f80b54a714d6027cb77cee3f9a6b5c4c6842ce674301e13947cbcbfa8055e63acaf1b84c085d34226a14425b2c2b97b829e0e226d2e8f1299942a51d
   languageName: node
   linkType: hard
 
@@ -216,13 +216,13 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-syntax-import-attributes@npm:^7.24.7":
-  version: 7.28.6
-  resolution: "@babel/plugin-syntax-import-attributes@npm:7.28.6"
+  version: 7.29.7
+  resolution: "@babel/plugin-syntax-import-attributes@npm:7.29.7"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.28.6"
+    "@babel/helper-plugin-utils": "npm:^7.29.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/1be160e2c426faa74e5be2e30e39e8d0d8c543063bd5d06cd804f8751b8fbcb82ce824ca7f9ce4b09c003693f6c06a11ce503b7e34d85e1a259631e4c3f72ad2
+  checksum: 10c0/b9a47e869d8c06676297069895ae34e2bd244ec4c3bdf15002f1e69aed32eef0361044af22a43f271b8de5e23a40534fe6a74a63e7ab98e3d60a74b322444b49
   languageName: node
   linkType: hard
 
@@ -337,49 +337,49 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-syntax-typescript@npm:^7.7.2":
-  version: 7.28.6
-  resolution: "@babel/plugin-syntax-typescript@npm:7.28.6"
+  version: 7.29.7
+  resolution: "@babel/plugin-syntax-typescript@npm:7.29.7"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.28.6"
+    "@babel/helper-plugin-utils": "npm:^7.29.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/b0c392a35624883ac480277401ac7d92d8646b66e33639f5d350de7a6723924265985ae11ab9ebd551740ded261c443eaa9a87ea19def9763ca1e0d78c97dea8
+  checksum: 10c0/c49883b0327e8683b770dc823205af5c697da216e590dcf5bf53f3f031e7e381de450b164f8f99853f0837a3de5cb793298e2be6697a0f6e452bb9dd34b5165e
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.28.6, @babel/template@npm:^7.3.3":
-  version: 7.28.6
-  resolution: "@babel/template@npm:7.28.6"
+"@babel/template@npm:^7.29.7, @babel/template@npm:^7.3.3":
+  version: 7.29.7
+  resolution: "@babel/template@npm:7.29.7"
   dependencies:
-    "@babel/code-frame": "npm:^7.28.6"
-    "@babel/parser": "npm:^7.28.6"
-    "@babel/types": "npm:^7.28.6"
-  checksum: 10c0/66d87225ed0bc77f888181ae2d97845021838c619944877f7c4398c6748bcf611f216dfd6be74d39016af502bca876e6ce6873db3c49e4ac354c56d34d57e9f5
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10c0/8bb7f900dcab0e9e1c5ffbc33ca10e0d26b7b2e2ca804becb73ee771b9c4ed6e2908a4ae4a14c08560febb45d2b6b9a173955e42ad404d05f8b04840a14d9c58
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.28.6, @babel/traverse@npm:^7.29.0, @babel/traverse@npm:^7.7.2":
-  version: 7.29.0
-  resolution: "@babel/traverse@npm:7.29.0"
+"@babel/traverse@npm:^7.29.7, @babel/traverse@npm:^7.7.2":
+  version: 7.29.7
+  resolution: "@babel/traverse@npm:7.29.7"
   dependencies:
-    "@babel/code-frame": "npm:^7.29.0"
-    "@babel/generator": "npm:^7.29.0"
-    "@babel/helper-globals": "npm:^7.28.0"
-    "@babel/parser": "npm:^7.29.0"
-    "@babel/template": "npm:^7.28.6"
-    "@babel/types": "npm:^7.29.0"
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/generator": "npm:^7.29.7"
+    "@babel/helper-globals": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/template": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
     debug: "npm:^4.3.1"
-  checksum: 10c0/f63ef6e58d02a9fbf3c0e2e5f1c877da3e0bc57f91a19d2223d53e356a76859cbaf51171c9211c71816d94a0e69efa2732fd27ffc0e1bbc84b636e60932333eb
+  checksum: 10c0/e256a1fbdb956555b76f3c285b1e453f6bedec8b3afb61751d99d933efd11c7d79caf5ddf2493570058a9f7deaa1b48324380d7c1aa1443fd9508becbf56331a
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.28.2, @babel/types@npm:^7.28.6, @babel/types@npm:^7.29.0, @babel/types@npm:^7.3.3":
-  version: 7.29.0
-  resolution: "@babel/types@npm:7.29.0"
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.28.2, @babel/types@npm:^7.29.7, @babel/types@npm:^7.3.3":
+  version: 7.29.7
+  resolution: "@babel/types@npm:7.29.7"
   dependencies:
-    "@babel/helper-string-parser": "npm:^7.27.1"
-    "@babel/helper-validator-identifier": "npm:^7.28.5"
-  checksum: 10c0/23cc3466e83bcbfab8b9bd0edaafdb5d4efdb88b82b3be6728bbade5ba2f0996f84f63b1c5f7a8c0d67efded28300898a5f930b171bb40b311bca2029c4e9b4f
+    "@babel/helper-string-parser": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+  checksum: 10c0/b6623994c69717fa27294f5fa46d59140338e2d86c6c1c13085c84ef7d53086ee357fbf4fe9abe3dd3da75734dc77c4c0df2f90fb29e667558bb3b3fb705e88f
   languageName: node
   linkType: hard
 
@@ -397,184 +397,184 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/aix-ppc64@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/aix-ppc64@npm:0.27.3"
+"@esbuild/aix-ppc64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/aix-ppc64@npm:0.27.7"
   conditions: os=aix & cpu=ppc64
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm64@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/android-arm64@npm:0.27.3"
+"@esbuild/android-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-arm64@npm:0.27.7"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/android-arm@npm:0.27.3"
+"@esbuild/android-arm@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-arm@npm:0.27.7"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@esbuild/android-x64@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/android-x64@npm:0.27.3"
+"@esbuild/android-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-x64@npm:0.27.7"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-arm64@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/darwin-arm64@npm:0.27.3"
+"@esbuild/darwin-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/darwin-arm64@npm:0.27.7"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-x64@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/darwin-x64@npm:0.27.3"
+"@esbuild/darwin-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/darwin-x64@npm:0.27.7"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-arm64@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/freebsd-arm64@npm:0.27.3"
+"@esbuild/freebsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/freebsd-arm64@npm:0.27.7"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-x64@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/freebsd-x64@npm:0.27.3"
+"@esbuild/freebsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/freebsd-x64@npm:0.27.7"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm64@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/linux-arm64@npm:0.27.3"
+"@esbuild/linux-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-arm64@npm:0.27.7"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/linux-arm@npm:0.27.3"
+"@esbuild/linux-arm@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-arm@npm:0.27.7"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ia32@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/linux-ia32@npm:0.27.3"
+"@esbuild/linux-ia32@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-ia32@npm:0.27.7"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
 
-"@esbuild/linux-loong64@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/linux-loong64@npm:0.27.3"
+"@esbuild/linux-loong64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-loong64@npm:0.27.7"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-mips64el@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/linux-mips64el@npm:0.27.3"
+"@esbuild/linux-mips64el@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-mips64el@npm:0.27.7"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ppc64@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/linux-ppc64@npm:0.27.3"
+"@esbuild/linux-ppc64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-ppc64@npm:0.27.7"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-riscv64@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/linux-riscv64@npm:0.27.3"
+"@esbuild/linux-riscv64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-riscv64@npm:0.27.7"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-s390x@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/linux-s390x@npm:0.27.3"
+"@esbuild/linux-s390x@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-s390x@npm:0.27.7"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
 
-"@esbuild/linux-x64@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/linux-x64@npm:0.27.3"
+"@esbuild/linux-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-x64@npm:0.27.7"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-arm64@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/netbsd-arm64@npm:0.27.3"
+"@esbuild/netbsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/netbsd-arm64@npm:0.27.7"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-x64@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/netbsd-x64@npm:0.27.3"
+"@esbuild/netbsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/netbsd-x64@npm:0.27.7"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-arm64@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/openbsd-arm64@npm:0.27.3"
+"@esbuild/openbsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openbsd-arm64@npm:0.27.7"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-x64@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/openbsd-x64@npm:0.27.3"
+"@esbuild/openbsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openbsd-x64@npm:0.27.7"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/openharmony-arm64@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/openharmony-arm64@npm:0.27.3"
+"@esbuild/openharmony-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openharmony-arm64@npm:0.27.7"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/sunos-x64@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/sunos-x64@npm:0.27.3"
+"@esbuild/sunos-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/sunos-x64@npm:0.27.7"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/win32-arm64@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/win32-arm64@npm:0.27.3"
+"@esbuild/win32-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-arm64@npm:0.27.7"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/win32-ia32@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/win32-ia32@npm:0.27.3"
+"@esbuild/win32-ia32@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-ia32@npm:0.27.7"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@esbuild/win32-x64@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@esbuild/win32-x64@npm:0.27.3"
+"@esbuild/win32-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-x64@npm:0.27.7"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -645,25 +645,9 @@ __metadata:
   linkType: hard
 
 "@ioredis/commands@npm:^1.0.2":
-  version: 1.5.0
-  resolution: "@ioredis/commands@npm:1.5.0"
-  checksum: 10c0/2d192d967a21f0192e17310d27ead02b0bdd504e834c782714abe641190ebfb548ad307fd89fd2d80db97c462afdc69ab4a4383831ab64ce61fe92f130d8b466
-  languageName: node
-  linkType: hard
-
-"@isaacs/balanced-match@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@isaacs/balanced-match@npm:4.0.1"
-  checksum: 10c0/7da011805b259ec5c955f01cee903da72ad97c5e6f01ca96197267d3f33103d5b2f8a1af192140f3aa64526c593c8d098ae366c2b11f7f17645d12387c2fd420
-  languageName: node
-  linkType: hard
-
-"@isaacs/brace-expansion@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "@isaacs/brace-expansion@npm:5.0.1"
-  dependencies:
-    "@isaacs/balanced-match": "npm:^4.0.1"
-  checksum: 10c0/e5d67c7bbf1f17b88132a35bc638af306d48acbb72810d48fa6e6edd8ab375854773108e8bf70f021f7ef6a8273455a6d1f0c3b5aa2aff06ce7894049ab77fb8
+  version: 1.10.0
+  resolution: "@ioredis/commands@npm:1.10.0"
+  checksum: 10c0/baf91e62d0e64ef2b5f7ca4413dc2456fe250e87483beac4a1c8ef1fe5ad0d2fcdeb9b89d4556d8ef6c7455c64a964359d729601fdb06b2f4c76c35dd59afa99
   languageName: node
   linkType: hard
 
@@ -690,9 +674,9 @@ __metadata:
   linkType: hard
 
 "@istanbuljs/schema@npm:^0.1.2":
-  version: 0.1.3
-  resolution: "@istanbuljs/schema@npm:0.1.3"
-  checksum: 10c0/61c5286771676c9ca3eb2bd8a7310a9c063fb6e0e9712225c8471c582d157392c88f5353581c8c9adbe0dff98892317d2fdfc56c3499aa42e0194405206a963a
+  version: 0.1.6
+  resolution: "@istanbuljs/schema@npm:0.1.6"
+  checksum: 10c0/bb0d370bf3dd454d2f37f1bccb8921e2da99adacef2da56ef47850e25d7a4de69cf639ead8c189755aef38921369024b4afea3535a5c2ac9082b3e1171bcbc3a
   languageName: node
   linkType: hard
 
@@ -968,28 +952,6 @@ __metadata:
     "@jridgewell/resolve-uri": "npm:^3.1.0"
     "@jridgewell/sourcemap-codec": "npm:^1.4.14"
   checksum: 10c0/4b30ec8cd56c5fd9a661f088230af01e0c1a3888d11ffb6b47639700f71225be21d1f7e168048d6d4f9449207b978a235c07c8f15c07705685d16dc06280e9d9
-  languageName: node
-  linkType: hard
-
-"@npmcli/agent@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@npmcli/agent@npm:4.0.0"
-  dependencies:
-    agent-base: "npm:^7.1.0"
-    http-proxy-agent: "npm:^7.0.0"
-    https-proxy-agent: "npm:^7.0.1"
-    lru-cache: "npm:^11.2.1"
-    socks-proxy-agent: "npm:^8.0.3"
-  checksum: 10c0/f7b5ce0f3dd42c3f8c6546e8433573d8049f67ef11ec22aa4704bc41483122f68bf97752e06302c455ead667af5cb753e6a09bff06632bc465c1cfd4c4b75a53
-  languageName: node
-  linkType: hard
-
-"@npmcli/fs@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@npmcli/fs@npm:5.0.0"
-  dependencies:
-    semver: "npm:^7.3.5"
-  checksum: 10c0/26e376d780f60ff16e874a0ac9bc3399186846baae0b6e1352286385ac134d900cc5dafaded77f38d77f86898fc923ae1cee9d7399f0275b1aa24878915d722b
   languageName: node
   linkType: hard
 
@@ -1653,11 +1615,11 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 25.2.3
-  resolution: "@types/node@npm:25.2.3"
+  version: 26.0.1
+  resolution: "@types/node@npm:26.0.1"
   dependencies:
-    undici-types: "npm:~7.16.0"
-  checksum: 10c0/925833029ce0bb4a72c36f90b93287184d3511aeb0fa60a994ae94b5430c22f9be6693d67d210df79267cb54c6f6978caaefb149d99ab5f83af5827ba7cb9822
+    undici-types: "npm:~8.3.0"
+  checksum: 10c0/31d204333c70124da6bcac7d1f27d8980149fe3f95a8419bfcd19c3e5823705c0e370d71ac34399352e1263b2d5fc41c87af964ec81e5a05a32224d65d8d224e
   languageName: node
   linkType: hard
 
@@ -1716,9 +1678,9 @@ __metadata:
   linkType: hard
 
 "@types/qs@npm:*":
-  version: 6.14.0
-  resolution: "@types/qs@npm:6.14.0"
-  checksum: 10c0/5b3036df6e507483869cdb3858201b2e0b64b4793dc4974f188caa5b5732f2333ab9db45c08157975054d3b070788b35088b4bc60257ae263885016ee2131310
+  version: 6.15.1
+  resolution: "@types/qs@npm:6.15.1"
+  checksum: 10c0/1dfdbcb4cf2a8f66d57f0b9a9fe6b1c7091cb816687b6698c1351eaf31f62e412cea9b7453a9637b570cd5fad8dced527e5a9e69b4fcc6e318daacd8b749f094
   languageName: node
   linkType: hard
 
@@ -1782,10 +1744,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abbrev@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "abbrev@npm:4.0.0"
-  checksum: 10c0/b4cc16935235e80702fc90192e349e32f8ef0ed151ef506aa78c81a7c455ec18375c4125414b99f84b2e055199d66383e787675f0bcd87da7a4dbd59f9eac1d5
+"abbrev@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "abbrev@npm:5.0.0"
+  checksum: 10c0/8e88f5c798ea4562d28c5a3e9ad69e3879890bc5d695d8f2dffb8609be4c890aacc8f80ef4553fdd2c6a62d70c2ce8bc57b38074e383beb7487bdafa9ed42ea5
   languageName: node
   linkType: hard
 
@@ -1809,18 +1771,11 @@ __metadata:
   linkType: hard
 
 "acorn@npm:^8.9.0":
-  version: 8.15.0
-  resolution: "acorn@npm:8.15.0"
+  version: 8.17.0
+  resolution: "acorn@npm:8.17.0"
   bin:
     acorn: bin/acorn
-  checksum: 10c0/dec73ff59b7d6628a01eebaece7f2bdb8bb62b9b5926dcad0f8931f2b8b79c2be21f6c68ac095592adb5adb15831a3635d9343e6a91d028bbe85d564875ec3ec
-  languageName: node
-  linkType: hard
-
-"agent-base@npm:^7.1.0, agent-base@npm:^7.1.2":
-  version: 7.1.4
-  resolution: "agent-base@npm:7.1.4"
-  checksum: 10c0/c2c9ab7599692d594b6a161559ada307b7a624fa4c7b03e3afdb5a5e31cd0e53269115b620fcab024c5ac6a6f37fa5eb2e004f076ad30f5f7e6b8b671f7b35fe
+  checksum: 10c0/5dcefea5f8f023b6cc24cbe71fb5a8112b601d36c4fa07d14e4e6ffc2ee47383332c46b36c766d9437725aa6660156eae50efa0c838719823b50d7c327c4ed42
   languageName: node
   linkType: hard
 
@@ -1835,14 +1790,14 @@ __metadata:
   linkType: hard
 
 "ajv@npm:^6.10.0, ajv@npm:^6.12.4":
-  version: 6.12.6
-  resolution: "ajv@npm:6.12.6"
+  version: 6.15.0
+  resolution: "ajv@npm:6.15.0"
   dependencies:
     fast-deep-equal: "npm:^3.1.1"
     fast-json-stable-stringify: "npm:^2.0.0"
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
-  checksum: 10c0/41e23642cbe545889245b9d2a45854ebba51cda6c778ebced9649420d9205f2efb39cb43dbc41e358409223b1ea43303ae4839db682c848b891e4811da1a5a71
+  checksum: 10c0/67966499dd272ecde1c2e467084411132891523d057487587879d39ac04207f4351b7b2324c83198013967fbfa632c1612adc960114a30770fbe07a0773b32c2
   languageName: node
   linkType: hard
 
@@ -1862,7 +1817,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^6.0.1":
+"ansi-regex@npm:^6.2.2":
   version: 6.2.2
   resolution: "ansi-regex@npm:6.2.2"
   checksum: 10c0/05d4acb1d2f59ab2cf4b794339c7b168890d44dda4bf0ce01152a8da0213aca207802f930442ce8cd22d7a92f44907664aac6508904e75e038fa944d2601b30f
@@ -2046,12 +2001,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"baseline-browser-mapping@npm:^2.9.0":
-  version: 2.9.19
-  resolution: "baseline-browser-mapping@npm:2.9.19"
+"balanced-match@npm:^4.0.2":
+  version: 4.0.4
+  resolution: "balanced-match@npm:4.0.4"
+  checksum: 10c0/07e86102a3eb2ee2a6a1a89164f29d0dbaebd28f2ca3f5ca786f36b8b23d9e417eb3be45a4acf754f837be5ac0a2317de90d3fcb7f4f4dc95720a1f36b26a17b
+  languageName: node
+  linkType: hard
+
+"baseline-browser-mapping@npm:^2.10.38":
+  version: 2.10.40
+  resolution: "baseline-browser-mapping@npm:2.10.40"
   bin:
-    baseline-browser-mapping: dist/cli.js
-  checksum: 10c0/569928db78bcd081953d7db79e4243a59a579a34b4ae1806b9b42d3b7f84e5bc40e6e82ae4fa06e7bef8291bf747b33b3f9ef5d3c6e1e420cb129d9295536129
+    baseline-browser-mapping: dist/cli.cjs
+  checksum: 10c0/5d3547aa9333b71f6239db89ef9d4aaf32ec0ee6cfa307025842722b5d225026995185ae4fc1e12e84a22199c905411bf3cce8076ae0a445b342982eb025171e
   languageName: node
   linkType: hard
 
@@ -2062,9 +2024,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:~1.20.3":
-  version: 1.20.4
-  resolution: "body-parser@npm:1.20.4"
+"body-parser@npm:~1.20.5":
+  version: 1.20.5
+  resolution: "body-parser@npm:1.20.5"
   dependencies:
     bytes: "npm:~3.1.2"
     content-type: "npm:~1.0.5"
@@ -2074,11 +2036,11 @@ __metadata:
     http-errors: "npm:~2.0.1"
     iconv-lite: "npm:~0.4.24"
     on-finished: "npm:~2.4.1"
-    qs: "npm:~6.14.0"
+    qs: "npm:~6.15.1"
     raw-body: "npm:~2.5.3"
     type-is: "npm:~1.6.18"
     unpipe: "npm:~1.0.0"
-  checksum: 10c0/569c1e896297d1fcd8f34026c8d0ab70b90d45343c15c5d8dff5de2bad08125fc1e2f8c2f3f4c1ac6c0caaad115218202594d37dcb8d89d9b5dcae1c2b736aa9
+  checksum: 10c0/ad777ca5e4711eae253c93f50fdc4608c60b76a9710d79e5e5b84581c76691e6ad21ecc9158986d9ea2b365df73e403ca33c27a8bccc1a7cfc2ccc248548118d
   languageName: node
   linkType: hard
 
@@ -2090,21 +2052,30 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.12
-  resolution: "brace-expansion@npm:1.1.12"
+  version: 1.1.15
+  resolution: "brace-expansion@npm:1.1.15"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/975fecac2bb7758c062c20d0b3b6288c7cc895219ee25f0a64a9de662dbac981ff0b6e89909c3897c1f84fa353113a721923afdec5f8b2350255b097f12b1f73
+  checksum: 10c0/648e273f57cfa9ed67d8a77bdb15b408205465d33da9331808ee3c188d8b55674c9cdbf1f320b65bc562e485e1263360ae62ad355e128e0435891f6430e795d7
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^2.0.1":
-  version: 2.0.2
-  resolution: "brace-expansion@npm:2.0.2"
+  version: 2.1.1
+  resolution: "brace-expansion@npm:2.1.1"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
+  checksum: 10c0/63b5ddce608b70b50a76817c0526faf8ea67a9180073d88bb402f6bbc22a22da6b1dfac4f65efc53e5faa80222fb7d44bbf2fc638c3f55365975573f671d0ccb
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^5.0.5":
+  version: 5.0.6
+  resolution: "brace-expansion@npm:5.0.6"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
   languageName: node
   linkType: hard
 
@@ -2118,17 +2089,17 @@ __metadata:
   linkType: hard
 
 "browserslist@npm:^4.24.0":
-  version: 4.28.1
-  resolution: "browserslist@npm:4.28.1"
+  version: 4.28.4
+  resolution: "browserslist@npm:4.28.4"
   dependencies:
-    baseline-browser-mapping: "npm:^2.9.0"
-    caniuse-lite: "npm:^1.0.30001759"
-    electron-to-chromium: "npm:^1.5.263"
-    node-releases: "npm:^2.0.27"
-    update-browserslist-db: "npm:^1.2.0"
+    baseline-browser-mapping: "npm:^2.10.38"
+    caniuse-lite: "npm:^1.0.30001799"
+    electron-to-chromium: "npm:^1.5.376"
+    node-releases: "npm:^2.0.48"
+    update-browserslist-db: "npm:^1.2.3"
   bin:
     browserslist: cli.js
-  checksum: 10c0/545a5fa9d7234e3777a7177ec1e9134bb2ba60a69e6b95683f6982b1473aad347c77c1264ccf2ac5dea609a9731fbfbda6b85782bdca70f80f86e28a402504bd
+  checksum: 10c0/d86f7319c0e3243ca5122335a98b9de8e007fb10fb5643e5f3ed69428fe81ee8646cf1a7663bcfb65bdfddbe505d39406da7ce30052e65c99df9d02336635a7c
   languageName: node
   linkType: hard
 
@@ -2173,25 +2144,6 @@ __metadata:
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
   checksum: 10c0/76d1c43cbd602794ad8ad2ae94095cddeb1de78c5dddaa7005c51af10b0176c69971a6d88e805a90c2b6550d76636e43c40d8427a808b8645ede885de4a0358e
-  languageName: node
-  linkType: hard
-
-"cacache@npm:^20.0.1":
-  version: 20.0.3
-  resolution: "cacache@npm:20.0.3"
-  dependencies:
-    "@npmcli/fs": "npm:^5.0.0"
-    fs-minipass: "npm:^3.0.0"
-    glob: "npm:^13.0.0"
-    lru-cache: "npm:^11.1.0"
-    minipass: "npm:^7.0.3"
-    minipass-collect: "npm:^2.0.1"
-    minipass-flush: "npm:^1.0.5"
-    minipass-pipeline: "npm:^1.2.4"
-    p-map: "npm:^7.0.2"
-    ssri: "npm:^13.0.0"
-    unique-filename: "npm:^5.0.0"
-  checksum: 10c0/c7da1ca694d20e8f8aedabd21dc11518f809a7d2b59aa76a1fc655db5a9e62379e465c157ddd2afe34b19230808882288effa6911b2de26a088a6d5645123462
   languageName: node
   linkType: hard
 
@@ -2243,10 +2195,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001759":
-  version: 1.0.30001769
-  resolution: "caniuse-lite@npm:1.0.30001769"
-  checksum: 10c0/161b8c30ab967371807d45d361f0d5bc06e38ef2dbf811493d70cd97c21e1522f5b91fd944c419a00047ee09c931ca64627f125a9ffa7a17a9fdff8dad9765b0
+"caniuse-lite@npm:^1.0.30001799":
+  version: 1.0.30001799
+  resolution: "caniuse-lite@npm:1.0.30001799"
+  checksum: 10c0/f24f9834edc7b60188f368ce44714695c3901bc4acb7f2a977dd9b7b697e39ddc0f9947fad6224a955b789f36a73432cb888d620aa7280d728f582d3bd8927a7
   languageName: node
   linkType: hard
 
@@ -2548,18 +2500,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
-  version: 4.4.3
-  resolution: "debug@npm:4.4.3"
-  dependencies:
-    ms: "npm:^2.1.3"
-  peerDependenciesMeta:
-    supports-color:
-      optional: true
-  checksum: 10c0/d79136ec6c83ecbefd0f6a5593da6a9c91ec4d7ddc4b54c883d6e71ec9accb5f67a1a5e96d00a328196b5b5c86d365e98d8a3a70856aaf16b4e7b1985e67f5a6
-  languageName: node
-  linkType: hard
-
 "debug@npm:4.3.2":
   version: 4.3.2
   resolution: "debug@npm:4.3.2"
@@ -2569,6 +2509,18 @@ __metadata:
     supports-color:
       optional: true
   checksum: 10c0/3cc408070bcee066ee9b2a4f3a9c40f53728919ec7c7ff568f7c3a75b0723cb5a8407191a63495be4e10669e99b0ff7f26ec70e10b025da1898cdce4876d96ca
+  languageName: node
+  linkType: hard
+
+"debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
+  version: 4.4.3
+  resolution: "debug@npm:4.4.3"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10c0/d79136ec6c83ecbefd0f6a5593da6a9c91ec4d7ddc4b54c883d6e71ec9accb5f67a1a5e96d00a328196b5b5c86d365e98d8a3a70856aaf16b4e7b1985e67f5a6
   languageName: node
   linkType: hard
 
@@ -2685,10 +2637,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.5.263":
-  version: 1.5.286
-  resolution: "electron-to-chromium@npm:1.5.286"
-  checksum: 10c0/5384510f9682d7e46f98fa48b874c3901d9639de96e9e387afce1fe010fbac31376df0534524edc15f66e9902bfacee54037a5e598004e9c6a617884e379926d
+"electron-to-chromium@npm:^1.5.376":
+  version: 1.5.380
+  resolution: "electron-to-chromium@npm:1.5.380"
+  checksum: 10c0/9132e2d69a1829708894507bacf59f02d881b95113eb9139fcb27c92d026f4504dd1b2a74f024224641d1fb6112b0fcb914ce27acfef9aeb150cdb4c8ae35895
   languageName: node
   linkType: hard
 
@@ -2720,15 +2672,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"encoding@npm:^0.1.13":
-  version: 0.1.13
-  resolution: "encoding@npm:0.1.13"
-  dependencies:
-    iconv-lite: "npm:^0.6.2"
-  checksum: 10c0/36d938712ff00fe1f4bac88b43bcffb5930c1efa57bbcdca9d67e1d9d6c57cfb1200fb01efe0f3109b2ce99b231f90779532814a81370a1bd3274a0f58585039
-  languageName: node
-  linkType: hard
-
 "end-of-stream@npm:^1.1.0":
   version: 1.4.5
   resolution: "end-of-stream@npm:1.4.5"
@@ -2742,13 +2685,6 @@ __metadata:
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
   checksum: 10c0/285325677bf00e30845e330eec32894f5105529db97496ee3f598478e50f008c5352a41a30e5e72ec9de8a542b5a570b85699cd63bd2bc646dbcb9f311d83bc4
-  languageName: node
-  linkType: hard
-
-"err-code@npm:^2.0.2":
-  version: 2.0.3
-  resolution: "err-code@npm:2.0.3"
-  checksum: 10c0/b642f7b4dd4a376e954947550a3065a9ece6733ab8e51ad80db727aaae0817c2e99b02a97a3d6cecc648a97848305e728289cf312d09af395403a90c9d4d8a66
   languageName: node
   linkType: hard
 
@@ -2776,44 +2712,44 @@ __metadata:
   linkType: hard
 
 "es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "es-object-atoms@npm:1.1.1"
+  version: 1.1.2
+  resolution: "es-object-atoms@npm:1.1.2"
   dependencies:
     es-errors: "npm:^1.3.0"
-  checksum: 10c0/65364812ca4daf48eb76e2a3b7a89b3f6a2e62a1c420766ce9f692665a29d94fe41fe88b65f24106f449859549711e4b40d9fb8002d862dfd7eb1c512d10be0c
+  checksum: 10c0/1772861f094f739d6f41b579cfb9a18579daffeb434552a370a5fbef50a32d22227e27b63fdbb757b7ddd429d1b42fe52ccae7966d9302a2ec221b6f1b41bbc4
   languageName: node
   linkType: hard
 
 "esbuild@npm:^0.27.2":
-  version: 0.27.3
-  resolution: "esbuild@npm:0.27.3"
+  version: 0.27.7
+  resolution: "esbuild@npm:0.27.7"
   dependencies:
-    "@esbuild/aix-ppc64": "npm:0.27.3"
-    "@esbuild/android-arm": "npm:0.27.3"
-    "@esbuild/android-arm64": "npm:0.27.3"
-    "@esbuild/android-x64": "npm:0.27.3"
-    "@esbuild/darwin-arm64": "npm:0.27.3"
-    "@esbuild/darwin-x64": "npm:0.27.3"
-    "@esbuild/freebsd-arm64": "npm:0.27.3"
-    "@esbuild/freebsd-x64": "npm:0.27.3"
-    "@esbuild/linux-arm": "npm:0.27.3"
-    "@esbuild/linux-arm64": "npm:0.27.3"
-    "@esbuild/linux-ia32": "npm:0.27.3"
-    "@esbuild/linux-loong64": "npm:0.27.3"
-    "@esbuild/linux-mips64el": "npm:0.27.3"
-    "@esbuild/linux-ppc64": "npm:0.27.3"
-    "@esbuild/linux-riscv64": "npm:0.27.3"
-    "@esbuild/linux-s390x": "npm:0.27.3"
-    "@esbuild/linux-x64": "npm:0.27.3"
-    "@esbuild/netbsd-arm64": "npm:0.27.3"
-    "@esbuild/netbsd-x64": "npm:0.27.3"
-    "@esbuild/openbsd-arm64": "npm:0.27.3"
-    "@esbuild/openbsd-x64": "npm:0.27.3"
-    "@esbuild/openharmony-arm64": "npm:0.27.3"
-    "@esbuild/sunos-x64": "npm:0.27.3"
-    "@esbuild/win32-arm64": "npm:0.27.3"
-    "@esbuild/win32-ia32": "npm:0.27.3"
-    "@esbuild/win32-x64": "npm:0.27.3"
+    "@esbuild/aix-ppc64": "npm:0.27.7"
+    "@esbuild/android-arm": "npm:0.27.7"
+    "@esbuild/android-arm64": "npm:0.27.7"
+    "@esbuild/android-x64": "npm:0.27.7"
+    "@esbuild/darwin-arm64": "npm:0.27.7"
+    "@esbuild/darwin-x64": "npm:0.27.7"
+    "@esbuild/freebsd-arm64": "npm:0.27.7"
+    "@esbuild/freebsd-x64": "npm:0.27.7"
+    "@esbuild/linux-arm": "npm:0.27.7"
+    "@esbuild/linux-arm64": "npm:0.27.7"
+    "@esbuild/linux-ia32": "npm:0.27.7"
+    "@esbuild/linux-loong64": "npm:0.27.7"
+    "@esbuild/linux-mips64el": "npm:0.27.7"
+    "@esbuild/linux-ppc64": "npm:0.27.7"
+    "@esbuild/linux-riscv64": "npm:0.27.7"
+    "@esbuild/linux-s390x": "npm:0.27.7"
+    "@esbuild/linux-x64": "npm:0.27.7"
+    "@esbuild/netbsd-arm64": "npm:0.27.7"
+    "@esbuild/netbsd-x64": "npm:0.27.7"
+    "@esbuild/openbsd-arm64": "npm:0.27.7"
+    "@esbuild/openbsd-x64": "npm:0.27.7"
+    "@esbuild/openharmony-arm64": "npm:0.27.7"
+    "@esbuild/sunos-x64": "npm:0.27.7"
+    "@esbuild/win32-arm64": "npm:0.27.7"
+    "@esbuild/win32-ia32": "npm:0.27.7"
+    "@esbuild/win32-x64": "npm:0.27.7"
   dependenciesMeta:
     "@esbuild/aix-ppc64":
       optional: true
@@ -2869,7 +2805,7 @@ __metadata:
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: 10c0/fdc3f87a3f08b3ef98362f37377136c389a0d180fda4b8d073b26ba930cf245521db0a368f119cc7624bc619248fff1439f5811f062d853576f8ffa3df8ee5f1
+  checksum: 10c0/ccd51f0555708bc9ff4ec9dc3ac92d3daacd45ecaac949ca8645984c5c323bf8cefe98c2df307418685e0b4ce37f9a3bdbfe8e3651fe632a0059a436195a17d4
   languageName: node
   linkType: hard
 
@@ -3178,12 +3114,12 @@ __metadata:
   linkType: hard
 
 "express@npm:^4.17.1":
-  version: 4.22.1
-  resolution: "express@npm:4.22.1"
+  version: 4.22.2
+  resolution: "express@npm:4.22.2"
   dependencies:
     accepts: "npm:~1.3.8"
     array-flatten: "npm:1.1.1"
-    body-parser: "npm:~1.20.3"
+    body-parser: "npm:~1.20.5"
     content-disposition: "npm:~0.5.4"
     content-type: "npm:~1.0.4"
     cookie: "npm:~0.7.1"
@@ -3202,7 +3138,7 @@ __metadata:
     parseurl: "npm:~1.3.3"
     path-to-regexp: "npm:~0.1.12"
     proxy-addr: "npm:~2.0.7"
-    qs: "npm:~6.14.0"
+    qs: "npm:~6.15.1"
     range-parser: "npm:~1.2.1"
     safe-buffer: "npm:5.2.1"
     send: "npm:~0.19.0"
@@ -3212,7 +3148,7 @@ __metadata:
     type-is: "npm:~1.6.18"
     utils-merge: "npm:1.0.1"
     vary: "npm:~1.1.2"
-  checksum: 10c0/ea57f512ab1e05e26b53a14fd432f65a10ec735ece342b37d0b63a7bcb8d337ffbb830ecb8ca15bcdfe423fbff88cea09786277baff200e8cde3ab40faa665cd
+  checksum: 10c0/d06dd4379fd217440b30f8abbe45f0e74931114c1395034f03e7d635196ecdab530d4835a1962a6aa34838d61967dc6f1f77846999bba3032373e9e714222c44
   languageName: node
   linkType: hard
 
@@ -3359,9 +3295,9 @@ __metadata:
   linkType: hard
 
 "flatted@npm:^3.2.9":
-  version: 3.3.3
-  resolution: "flatted@npm:3.3.3"
-  checksum: 10c0/e957a1c6b0254aa15b8cce8533e24165abd98fadc98575db082b786b5da1b7d72062b81bfdcd1da2f4d46b6ed93bec2434e62333e9b4261d79ef2e75a10dd538
+  version: 3.4.2
+  resolution: "flatted@npm:3.4.2"
+  checksum: 10c0/a65b67aae7172d6cdf63691be7de6c5cd5adbdfdfe2e9da1a09b617c9512ed794037741ee53d93114276bff3f93cd3b0d97d54f9b316e1e4885dde6e9ffdf7ed
   languageName: node
   linkType: hard
 
@@ -3376,15 +3312,6 @@ __metadata:
   version: 0.5.2
   resolution: "fresh@npm:0.5.2"
   checksum: 10c0/c6d27f3ed86cc5b601404822f31c900dd165ba63fff8152a3ef714e2012e7535027063bc67ded4cb5b3a49fa596495d46cacd9f47d6328459cf570f08b7d9e5a
-  languageName: node
-  linkType: hard
-
-"fs-minipass@npm:^3.0.0":
-  version: 3.0.3
-  resolution: "fs-minipass@npm:3.0.3"
-  dependencies:
-    minipass: "npm:^7.0.3"
-  checksum: 10c0/63e80da2ff9b621e2cb1596abcb9207f1cf82b968b116ccd7b959e3323144cce7fb141462200971c38bbf2ecca51695069db45265705bed09a7cd93ae5b89f94
   languageName: node
   linkType: hard
 
@@ -3494,13 +3421,13 @@ __metadata:
   linkType: hard
 
 "glob@npm:^13.0.0":
-  version: 13.0.2
-  resolution: "glob@npm:13.0.2"
+  version: 13.0.6
+  resolution: "glob@npm:13.0.6"
   dependencies:
-    minimatch: "npm:^10.1.2"
-    minipass: "npm:^7.1.2"
-    path-scurry: "npm:^2.0.0"
-  checksum: 10c0/3d4b09efa922c4cba9be6d5b9efae14384e7422aeb886eb35fba8a94820b8281474b8d3f16927127fb1a0c8580e18fc00e3fda03c8dc31fa0af3ba918edeeb04
+    minimatch: "npm:^10.2.2"
+    minipass: "npm:^7.1.3"
+    path-scurry: "npm:^2.0.2"
+  checksum: 10c0/269c236f11a9b50357fe7a8c6aadac667e01deb5242b19c84975628f05f4438d8ee1354bb62c5d6c10f37fd59911b54d7799730633a2786660d8c69f1d18120a
   languageName: node
   linkType: hard
 
@@ -3555,8 +3482,8 @@ __metadata:
   linkType: hard
 
 "handlebars@npm:^4.7.7":
-  version: 4.7.8
-  resolution: "handlebars@npm:4.7.8"
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
   dependencies:
     minimist: "npm:^1.2.5"
     neo-async: "npm:^2.6.2"
@@ -3568,7 +3495,7 @@ __metadata:
       optional: true
   bin:
     handlebars: bin/handlebars
-  checksum: 10c0/7aff423ea38a14bb379316f3857fe0df3c5d66119270944247f155ba1f08e07a92b340c58edaa00cfe985c21508870ee5183e0634dcb53dd405f35c93ef7f10d
+  checksum: 10c0/22f8105a7e68e81aff2662bb434edf05f757d21d850731d71cec886d69c10cd33d3c43e34b2892968ec62de8241611851d3d0674c8ef324ea3e01dc66262faa9
   languageName: node
   linkType: hard
 
@@ -3593,12 +3520,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hasown@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "hasown@npm:2.0.2"
+"hasown@npm:^2.0.2, hasown@npm:^2.0.3":
+  version: 2.0.4
+  resolution: "hasown@npm:2.0.4"
   dependencies:
     function-bind: "npm:^1.1.2"
-  checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
+  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
   languageName: node
   linkType: hard
 
@@ -3616,13 +3543,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-cache-semantics@npm:^4.1.1":
-  version: 4.2.0
-  resolution: "http-cache-semantics@npm:4.2.0"
-  checksum: 10c0/45b66a945cf13ec2d1f29432277201313babf4a01d9e52f44b31ca923434083afeca03f18417f599c9ab3d0e7b618ceb21257542338b57c54b710463b4a53e37
-  languageName: node
-  linkType: hard
-
 "http-errors@npm:~2.0.0, http-errors@npm:~2.0.1":
   version: 2.0.1
   resolution: "http-errors@npm:2.0.1"
@@ -3633,26 +3553,6 @@ __metadata:
     statuses: "npm:~2.0.2"
     toidentifier: "npm:~1.0.1"
   checksum: 10c0/fb38906cef4f5c83952d97661fe14dc156cb59fe54812a42cd448fa57b5c5dfcb38a40a916957737bd6b87aab257c0648d63eb5b6a9ca9f548e105b6072712d4
-  languageName: node
-  linkType: hard
-
-"http-proxy-agent@npm:^7.0.0":
-  version: 7.0.2
-  resolution: "http-proxy-agent@npm:7.0.2"
-  dependencies:
-    agent-base: "npm:^7.1.0"
-    debug: "npm:^4.3.4"
-  checksum: 10c0/4207b06a4580fb85dd6dff521f0abf6db517489e70863dca1a0291daa7f2d3d2d6015a57bd702af068ea5cf9f1f6ff72314f5f5b4228d299c0904135d2aef921
-  languageName: node
-  linkType: hard
-
-"https-proxy-agent@npm:^7.0.1":
-  version: 7.0.6
-  resolution: "https-proxy-agent@npm:7.0.6"
-  dependencies:
-    agent-base: "npm:^7.1.2"
-    debug: "npm:4"
-  checksum: 10c0/f729219bc735edb621fa30e6e84e60ee5d00802b8247aac0d7b79b0bd6d4b3294737a337b93b86a0bd9e68099d031858a39260c976dc14cdbba238ba1f8779ac
   languageName: node
   linkType: hard
 
@@ -3676,15 +3576,6 @@ __metadata:
   bin:
     husky: lib/bin.js
   checksum: 10c0/58c0e87c37f0aaea4e0ea02499444df11adb9ec182fd42735385045b51a55cbdcca48afeea337801e50435fbeb0e77c57c2b430695663774afb279bb0e8aa25f
-  languageName: node
-  linkType: hard
-
-"iconv-lite@npm:^0.6.2":
-  version: 0.6.3
-  resolution: "iconv-lite@npm:0.6.3"
-  dependencies:
-    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
-  checksum: 10c0/98102bc66b33fcf5ac044099d1257ba0b7ad5e3ccd3221f34dd508ab4070edff183276221684e1e0555b145fce0850c9f7d2b60a9fcac50fbb4ea0d6e845a3b1
   languageName: node
   linkType: hard
 
@@ -3783,13 +3674,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.0.1":
-  version: 10.1.0
-  resolution: "ip-address@npm:10.1.0"
-  checksum: 10c0/0103516cfa93f6433b3bd7333fa876eb21263912329bfa47010af5e16934eeeff86f3d2ae700a3744a137839ddfad62b900c7a445607884a49b5d1e32a3d7566
-  languageName: node
-  linkType: hard
-
 "ipaddr.js@npm:1.9.1":
   version: 1.9.1
   resolution: "ipaddr.js@npm:1.9.1"
@@ -3814,11 +3698,11 @@ __metadata:
   linkType: hard
 
 "is-core-module@npm:^2.16.1":
-  version: 2.16.1
-  resolution: "is-core-module@npm:2.16.1"
+  version: 2.16.2
+  resolution: "is-core-module@npm:2.16.2"
   dependencies:
-    hasown: "npm:^2.0.2"
-  checksum: 10c0/898443c14780a577e807618aaae2b6f745c8538eca5c7bc11388a3f2dc6de82b9902bcc7eb74f07be672b11bbe82dd6a6edded44a00cb3d8f933d0459905eedd
+    hasown: "npm:^2.0.3"
+  checksum: 10c0/14b4258390283709c15476d023ec173e27458d5d014ccdb8ed39d576e551c3fa45498b7c9fe178f1529c4cb2648ddd58852a6a62107a019f6e349529f277518a
   languageName: node
   linkType: hard
 
@@ -4438,25 +4322,25 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^3.13.1, js-yaml@npm:^3.14.1":
-  version: 3.14.2
-  resolution: "js-yaml@npm:3.14.2"
+  version: 3.15.0
+  resolution: "js-yaml@npm:3.15.0"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/3261f25912f5dd76605e5993d0a126c2b6c346311885d3c483706cd722efe34f697ea0331f654ce27c00a42b426e524518ec89d65ed02ea47df8ad26dcc8ce69
+  checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
   languageName: node
   linkType: hard
 
 "js-yaml@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
   languageName: node
   linkType: hard
 
@@ -4810,10 +4694,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^11.0.0, lru-cache@npm:^11.1.0, lru-cache@npm:^11.2.1":
-  version: 11.2.6
-  resolution: "lru-cache@npm:11.2.6"
-  checksum: 10c0/73bbffb298760e71b2bfe8ebc16a311c6a60ceddbba919cfedfd8635c2d125fbfb5a39b71818200e67973b11f8d59c5a9e31d6f90722e340e90393663a66e5cd
+"lru-cache@npm:^11.0.0":
+  version: 11.5.1
+  resolution: "lru-cache@npm:11.5.1"
+  checksum: 10c0/7b341cea79a8efe9c6a6f20c8757a77eca5b25d7ff983ccf4e11e547b81f6787824baa1c84705251dff84ab4ffac85717ac354b9d02e465f86a9f8b166409979
   languageName: node
   linkType: hard
 
@@ -4848,25 +4732,6 @@ __metadata:
   dependencies:
     semver: "npm:^7.5.3"
   checksum: 10c0/69b98a6c0b8e5c4fe9acb61608a9fbcfca1756d910f51e5dbe7a9e5cfb74fca9b8a0c8a0ffdf1294a740826c1ab4871d5bf3f62f72a3049e5eac6541ddffed68
-  languageName: node
-  linkType: hard
-
-"make-fetch-happen@npm:^15.0.0":
-  version: 15.0.3
-  resolution: "make-fetch-happen@npm:15.0.3"
-  dependencies:
-    "@npmcli/agent": "npm:^4.0.0"
-    cacache: "npm:^20.0.1"
-    http-cache-semantics: "npm:^4.1.1"
-    minipass: "npm:^7.0.2"
-    minipass-fetch: "npm:^5.0.0"
-    minipass-flush: "npm:^1.0.5"
-    minipass-pipeline: "npm:^1.2.4"
-    negotiator: "npm:^1.0.0"
-    proc-log: "npm:^6.0.0"
-    promise-retry: "npm:^2.0.1"
-    ssri: "npm:^13.0.0"
-  checksum: 10c0/525f74915660be60b616bcbd267c4a5b59481b073ba125e45c9c3a041bb1a47a2bd0ae79d028eb6f5f95bf9851a4158423f5068539c3093621abb64027e8e461
   languageName: node
   linkType: hard
 
@@ -4970,30 +4835,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.1.2":
-  version: 10.1.2
-  resolution: "minimatch@npm:10.1.2"
+"minimatch@npm:^10.2.2":
+  version: 10.2.5
+  resolution: "minimatch@npm:10.2.5"
   dependencies:
-    "@isaacs/brace-expansion": "npm:^5.0.1"
-  checksum: 10c0/0cccef3622201703de6ecf9d772c0be1d5513dcc038ed9feb866c20cf798243e678ac35605dac3f1a054650c28037486713fe9e9a34b184b9097959114daf086
+    brace-expansion: "npm:^5.0.5"
+  checksum: 10c0/6bb058bd6324104b9ec2f763476a35386d05079c1f5fe4fbf1f324a25237cd4534d6813ecd71f48208f4e635c1221899bef94c3c89f7df55698fe373aaae20fd
   languageName: node
   linkType: hard
 
 "minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "minimatch@npm:3.1.2"
+  version: 3.1.5
+  resolution: "minimatch@npm:3.1.5"
   dependencies:
     brace-expansion: "npm:^1.1.7"
-  checksum: 10c0/0262810a8fc2e72cca45d6fd86bd349eee435eb95ac6aa45c9ea2180e7ee875ef44c32b55b5973ceabe95ea12682f6e3725cbb63d7a2d1da3ae1163c8b210311
+  checksum: 10c0/2ecbdc0d33f07bddb0315a8b5afbcb761307a8778b48f0b312418ccbced99f104a2d17d8aca7573433c70e8ccd1c56823a441897a45e384ea76ef401a26ace70
   languageName: node
   linkType: hard
 
 "minimatch@npm:^5.0.1":
-  version: 5.1.6
-  resolution: "minimatch@npm:5.1.6"
+  version: 5.1.9
+  resolution: "minimatch@npm:5.1.9"
   dependencies:
     brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/3defdfd230914f22a8da203747c42ee3c405c39d4d37ffda284dac5e45b7e1f6c49aa8be606509002898e73091ff2a3bbfc59c2c6c71d4660609f63aa92f98e3
+  checksum: 10c0/4202718683815a7288b13e470160a4f9560cf392adef4f453927505817e01ef6b3476ecde13cfcaed17e7326dd3b69ad44eb2daeb19a217c5500f9277893f1d6
   languageName: node
   linkType: hard
 
@@ -5004,74 +4869,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass-collect@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "minipass-collect@npm:2.0.1"
-  dependencies:
-    minipass: "npm:^7.0.3"
-  checksum: 10c0/5167e73f62bb74cc5019594709c77e6a742051a647fe9499abf03c71dca75515b7959d67a764bdc4f8b361cf897fbf25e2d9869ee039203ed45240f48b9aa06e
+"minipass@npm:^7.0.4, minipass@npm:^7.1.2, minipass@npm:^7.1.3":
+  version: 7.1.3
+  resolution: "minipass@npm:7.1.3"
+  checksum: 10c0/539da88daca16533211ea5a9ee98dc62ff5742f531f54640dd34429e621955e91cc280a91a776026264b7f9f6735947629f920944e9c1558369e8bf22eb33fbb
   languageName: node
   linkType: hard
 
-"minipass-fetch@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "minipass-fetch@npm:5.0.1"
-  dependencies:
-    encoding: "npm:^0.1.13"
-    minipass: "npm:^7.0.3"
-    minipass-sized: "npm:^2.0.0"
-    minizlib: "npm:^3.0.1"
-  dependenciesMeta:
-    encoding:
-      optional: true
-  checksum: 10c0/50bcf48c9841ebb25e29a2817468595219c72cfffc7c175a1d7327843c8bef9b72cb01778f46df7eca695dfe47ab98e6167af4cb026ddd80f660842919a5193c
-  languageName: node
-  linkType: hard
-
-"minipass-flush@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "minipass-flush@npm:1.0.5"
-  dependencies:
-    minipass: "npm:^3.0.0"
-  checksum: 10c0/2a51b63feb799d2bb34669205eee7c0eaf9dce01883261a5b77410c9408aa447e478efd191b4de6fc1101e796ff5892f8443ef20d9544385819093dbb32d36bd
-  languageName: node
-  linkType: hard
-
-"minipass-pipeline@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "minipass-pipeline@npm:1.2.4"
-  dependencies:
-    minipass: "npm:^3.0.0"
-  checksum: 10c0/cbda57cea20b140b797505dc2cac71581a70b3247b84480c1fed5ca5ba46c25ecc25f68bfc9e6dcb1a6e9017dab5c7ada5eab73ad4f0a49d84e35093e0c643f2
-  languageName: node
-  linkType: hard
-
-"minipass-sized@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "minipass-sized@npm:2.0.0"
-  dependencies:
-    minipass: "npm:^7.1.2"
-  checksum: 10c0/f9201696a6f6d68610d04c9c83e3d2e5cb9c026aae1c8cbf7e17f386105cb79c1bb088dbc21bf0b1eb4f3fb5df384fd1e7aa3bf1f33868c416ae8c8a92679db8
-  languageName: node
-  linkType: hard
-
-"minipass@npm:^3.0.0":
-  version: 3.3.6
-  resolution: "minipass@npm:3.3.6"
-  dependencies:
-    yallist: "npm:^4.0.0"
-  checksum: 10c0/a114746943afa1dbbca8249e706d1d38b85ed1298b530f5808ce51f8e9e941962e2a5ad2e00eae7dd21d8a4aae6586a66d4216d1a259385e9d0358f0c1eba16c
-  languageName: node
-  linkType: hard
-
-"minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.0.4, minipass@npm:^7.1.2":
-  version: 7.1.2
-  resolution: "minipass@npm:7.1.2"
-  checksum: 10c0/b0fd20bb9fb56e5fa9a8bfac539e8915ae07430a619e4b86ff71f5fc757ef3924b23b2c4230393af1eda647ed3d75739e4e0acb250a6b1eb277cf7f8fe449557
-  languageName: node
-  linkType: hard
-
-"minizlib@npm:^3.0.1, minizlib@npm:^3.1.0":
+"minizlib@npm:^3.1.0":
   version: 3.1.0
   resolution: "minizlib@npm:3.1.0"
   dependencies:
@@ -5134,13 +4939,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"negotiator@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "negotiator@npm:1.0.0"
-  checksum: 10c0/4c559dd52669ea48e1914f9d634227c561221dd54734070791f999c52ed0ff36e437b2e07d5c1f6e32909fc625fe46491c16e4a8f0572567d4dd15c3a4fda04b
-  languageName: node
-  linkType: hard
-
 "neo-async@npm:^2.6.2":
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
@@ -5175,22 +4973,22 @@ __metadata:
   linkType: hard
 
 "node-gyp@npm:latest":
-  version: 12.2.0
-  resolution: "node-gyp@npm:12.2.0"
+  version: 13.0.0
+  resolution: "node-gyp@npm:13.0.0"
   dependencies:
     env-paths: "npm:^2.2.0"
     exponential-backoff: "npm:^3.1.1"
     graceful-fs: "npm:^4.2.6"
-    make-fetch-happen: "npm:^15.0.0"
-    nopt: "npm:^9.0.0"
-    proc-log: "npm:^6.0.0"
+    nopt: "npm:^10.0.0"
+    proc-log: "npm:^7.0.0"
     semver: "npm:^7.3.5"
     tar: "npm:^7.5.4"
     tinyglobby: "npm:^0.2.12"
-    which: "npm:^6.0.0"
+    undici: "npm:^6.25.0"
+    which: "npm:^7.0.0"
   bin:
     node-gyp: bin/node-gyp.js
-  checksum: 10c0/3ed046746a5a7d90950cd8b0547332b06598443f31fe213ef4332a7174c7b7d259e1704835feda79b87d3f02e59d7791842aac60642ede4396ab25fdf0f8f759
+  checksum: 10c0/e7525c427db2d16aa368b8947187de83083d2a8dda23e3e096a71c22ae637ac5bb8ed7cf6c871f1b9118cd2729dbfee4ff3a4245e2b79226900227b15831b492
   languageName: node
   linkType: hard
 
@@ -5201,21 +4999,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^2.0.27":
-  version: 2.0.27
-  resolution: "node-releases@npm:2.0.27"
-  checksum: 10c0/f1e6583b7833ea81880627748d28a3a7ff5703d5409328c216ae57befbced10ce2c991bea86434e8ec39003bd017f70481e2e5f8c1f7e0a7663241f81d6e00e2
+"node-releases@npm:^2.0.48":
+  version: 2.0.50
+  resolution: "node-releases@npm:2.0.50"
+  checksum: 10c0/ac75ed433864114cfd9862034960bb4f49838343dc9fc31dc7d5be8189ce5f39510ad0bb3a697efe3193d50ab6921e7a3a6ce3aae2a6f8abe62719ffd40a4cac
   languageName: node
   linkType: hard
 
-"nopt@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "nopt@npm:9.0.0"
+"nopt@npm:^10.0.0":
+  version: 10.0.1
+  resolution: "nopt@npm:10.0.1"
   dependencies:
-    abbrev: "npm:^4.0.0"
+    abbrev: "npm:^5.0.0"
   bin:
     nopt: bin/nopt.js
-  checksum: 10c0/1822eb6f9b020ef6f7a7516d7b64a8036e09666ea55ac40416c36e4b2b343122c3cff0e2f085675f53de1d2db99a2a89a60ccea1d120bcd6a5347bf6ceb4a7fd
+  checksum: 10c0/980d89257f9587f3e1f77877ddbf905d6aa3b738ec33e49a4fa1a059a0dd82eb28063982b150654a7ae9de386f2ead60e56172db7d37cf56de545f7392a2a26a
   languageName: node
   linkType: hard
 
@@ -5256,7 +5054,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-inspect@npm:^1.12.2, object-inspect@npm:^1.13.3":
+"object-inspect@npm:^1.12.2, object-inspect@npm:^1.13.3, object-inspect@npm:^1.13.4":
   version: 1.13.4
   resolution: "object-inspect@npm:1.13.4"
   checksum: 10c0/d7f8711e803b96ea3191c745d6f8056ce1f2496e530e6a19a0e92d89b0fa3c76d910c31f0aa270432db6bd3b2f85500a376a83aaba849a8d518c8845b3211692
@@ -5379,13 +5177,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-map@npm:^7.0.2":
-  version: 7.0.4
-  resolution: "p-map@npm:7.0.4"
-  checksum: 10c0/a5030935d3cb2919d7e89454d1ce82141e6f9955413658b8c9403cfe379283770ed3048146b44cde168aa9e8c716505f196d5689db0ae3ce9a71521a2fef3abd
-  languageName: node
-  linkType: hard
-
 "p-try@npm:^2.0.0":
   version: 2.2.0
   resolution: "p-try@npm:2.2.0"
@@ -5473,20 +5264,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-scurry@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "path-scurry@npm:2.0.1"
+"path-scurry@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "path-scurry@npm:2.0.2"
   dependencies:
     lru-cache: "npm:^11.0.0"
     minipass: "npm:^7.1.2"
-  checksum: 10c0/2a16ed0e81fbc43513e245aa5763354e25e787dab0d539581a6c3f0f967461a159ed6236b2559de23aa5b88e7dc32b469b6c47568833dd142a4b24b4f5cd2620
+  checksum: 10c0/b35ad37cf6557a87fd057121ce2be7695380c9138d93e87ae928609da259ea0a170fac6f3ef1eb3ece8a068e8b7f2f3adf5bb2374cf4d4a57fe484954fcc9482
   languageName: node
   linkType: hard
 
 "path-to-regexp@npm:~0.1.12":
-  version: 0.1.12
-  resolution: "path-to-regexp@npm:0.1.12"
-  checksum: 10c0/1c6ff10ca169b773f3bba943bbc6a07182e332464704572962d277b900aeee81ac6aa5d060ff9e01149636c30b1f63af6e69dd7786ba6e0ddb39d4dee1f0645b
+  version: 0.1.13
+  resolution: "path-to-regexp@npm:0.1.13"
+  checksum: 10c0/1cae3921739c154a8926e136185a10c916f79a249b9072a5001b266d96e193860ca03867e8e8cc808b786862d750f427ed93686bc259355442c3407a62deab1a
   languageName: node
   linkType: hard
 
@@ -5498,25 +5289,25 @@ __metadata:
   linkType: hard
 
 "picomatch@npm:^2.0.4, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "picomatch@npm:2.3.1"
-  checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
+  version: 2.3.2
+  resolution: "picomatch@npm:2.3.2"
+  checksum: 10c0/a554d1709e59be97d1acb9eaedbbc700a5c03dbd4579807baed95100b00420bc729335440ef15004ae2378984e2487a7c1cebd743cfdb72b6fa9ab69223c0d61
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "picomatch@npm:4.0.3"
-  checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
+"picomatch@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "picomatch@npm:4.0.4"
+  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
   languageName: node
   linkType: hard
 
 "pidtree@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "pidtree@npm:0.6.0"
+  version: 0.6.1
+  resolution: "pidtree@npm:0.6.1"
   bin:
     pidtree: bin/pidtree.js
-  checksum: 10c0/0829ec4e9209e230f74ebf4265f5ccc9ebfb488334b525cb13f86ff801dca44b362c41252cd43ae4d7653a10a5c6ab3be39d2c79064d6895e0d78dc50a5ed6e9
+  checksum: 10c0/6abf7ab04941e6ac44cc55e9aca800aba4769407e8faf1d28a8adce44bfca1a0060c1e7c662c2641241c67367a80fc768d71a35391d7e5ffd15f0ee7d5ea74e0
   languageName: node
   linkType: hard
 
@@ -5704,10 +5495,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proc-log@npm:^6.0.0":
-  version: 6.1.0
-  resolution: "proc-log@npm:6.1.0"
-  checksum: 10c0/4f178d4062733ead9d71a9b1ab24ebcecdfe2250916a5b1555f04fe2eda972a0ec76fbaa8df1ad9c02707add6749219d118a4fc46dc56bdfe4dde4b47d80bb82
+"proc-log@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "proc-log@npm:7.0.0"
+  checksum: 10c0/b89c2d862604f35fec795477b0c7e376feab3ba0d4f4d291c4e959567442697cf451ac557d0623c1cc38af45a78128b983410f397a10c5d3a67f76c33de4754b
   languageName: node
   linkType: hard
 
@@ -5715,16 +5506,6 @@ __metadata:
   version: 1.0.0
   resolution: "process-warning@npm:1.0.0"
   checksum: 10c0/43ec4229d64eb5c58340c8aacade49eb5f6fd513eae54140abf365929ca20987f0a35c5868125e2b583cad4de8cd257beb5667d9cc539d9190a7a4c3014adf22
-  languageName: node
-  linkType: hard
-
-"promise-retry@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "promise-retry@npm:2.0.1"
-  dependencies:
-    err-code: "npm:^2.0.2"
-    retry: "npm:^0.12.0"
-  checksum: 10c0/9c7045a1a2928094b5b9b15336dcd2a7b1c052f674550df63cc3f36cd44028e5080448175b6f6ca32b642de81150f5e7b1a98b728f15cb069f2dd60ac2616b96
   languageName: node
   linkType: hard
 
@@ -5756,12 +5537,12 @@ __metadata:
   linkType: hard
 
 "pump@npm:^3.0.0":
-  version: 3.0.3
-  resolution: "pump@npm:3.0.3"
+  version: 3.0.4
+  resolution: "pump@npm:3.0.4"
   dependencies:
     end-of-stream: "npm:^1.1.0"
     once: "npm:^1.3.1"
-  checksum: 10c0/ada5cdf1d813065bbc99aa2c393b8f6beee73b5de2890a8754c9f488d7323ffd2ca5f5a0943b48934e3fcbd97637d0337369c3c631aeb9614915db629f1c75c9
+  checksum: 10c0/2780e66b5471c19e3e3e1063b84f3f6a3a08367f24c5ed552f98cd5901e6ada27c7ad6495d4244f553fd03b01884a4561933064f053f47c8994d84fd352768ea
   languageName: node
   linkType: hard
 
@@ -5779,12 +5560,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:~6.14.0":
-  version: 6.14.1
-  resolution: "qs@npm:6.14.1"
+"qs@npm:~6.15.1":
+  version: 6.15.3
+  resolution: "qs@npm:6.15.3"
   dependencies:
-    side-channel: "npm:^1.1.0"
-  checksum: 10c0/0e3b22dc451f48ce5940cbbc7c7d9068d895074f8c969c0801ac15c1313d1859c4d738e46dc4da2f498f41a9ffd8c201bd9fb12df67799b827db94cc373d2613
+    es-define-property: "npm:^1.0.1"
+    side-channel: "npm:^1.1.1"
+  checksum: 10c0/8f3f6e45ece255347d57696628401cde29e9ec649fff698b53bd3150dea7cefdf33036e1bc1826b9f110bfa7cb0ec4ab9f5297eca628ce216c55af82c304e08e
   languageName: node
   linkType: hard
 
@@ -5973,28 +5755,30 @@ __metadata:
   linkType: hard
 
 "resolve@npm:^1.10.0, resolve@npm:^1.19.0, resolve@npm:^1.20.0":
-  version: 1.22.11
-  resolution: "resolve@npm:1.22.11"
+  version: 1.22.12
+  resolution: "resolve@npm:1.22.12"
   dependencies:
+    es-errors: "npm:^1.3.0"
     is-core-module: "npm:^2.16.1"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/f657191507530f2cbecb5815b1ee99b20741ea6ee02a59c57028e9ec4c2c8d7681afcc35febbd554ac0ded459db6f2d8153382c53a2f266cee2575e512674409
+  checksum: 10c0/b16dc9b537c02e8c3388f7d3dcff9741d3071625f9a97ac1c885f2b0ca51e78df22328fb6d6ef214dd9101fb7cfc19aa2836fe3410402a94f3f7b8639c7149bf
   languageName: node
   linkType: hard
 
 "resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>":
-  version: 1.22.11
-  resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=c3c19d"
+  version: 1.22.12
+  resolution: "resolve@patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"
   dependencies:
+    es-errors: "npm:^1.3.0"
     is-core-module: "npm:^2.16.1"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/ee5b182f2e37cb1165465e58c6abc797fec0a80b5ba3231607beb4677db0c9291ac010c47cf092b6daa2b7f518d69a0e21888e7e2b633f68d501a874212a8c63
+  checksum: 10c0/fc6519984ae1f894d877c0060ba8b1f5ba3bc0e85a02f74e141929c118c23d74d9735619a9cc2965397387e514884245c65d72a40731dcb6cfc84c7bcdc8321e
   languageName: node
   linkType: hard
 
@@ -6005,13 +5789,6 @@ __metadata:
     onetime: "npm:^5.1.0"
     signal-exit: "npm:^3.0.2"
   checksum: 10c0/8051a371d6aa67ff21625fa94e2357bd81ffdc96267f3fb0fc4aaf4534028343836548ef34c240ffa8c25b280ca35eb36be00b3cb2133fa4f51896d7e73c6b4f
-  languageName: node
-  linkType: hard
-
-"retry@npm:^0.12.0":
-  version: 0.12.0
-  resolution: "retry@npm:0.12.0"
-  checksum: 10c0/59933e8501727ba13ad73ef4a04d5280b3717fd650408460c987392efe9d7be2040778ed8ebe933c5cbd63da3dcc37919c141ef8af0a54a6e4fca5a2af177bfe
   languageName: node
   linkType: hard
 
@@ -6058,7 +5835,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0":
+"safer-buffer@npm:>= 2.1.2 < 3":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: 10c0/7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
@@ -6102,11 +5879,11 @@ __metadata:
   linkType: hard
 
 "semver@npm:^7.5.3, semver@npm:^7.5.4":
-  version: 7.7.4
-  resolution: "semver@npm:7.7.4"
+  version: 7.8.5
+  resolution: "semver@npm:7.8.5"
   bin:
     semver: bin/semver.js
-  checksum: 10c0/5215ad0234e2845d4ea5bb9d836d42b03499546ddafb12075566899fc617f68794bb6f146076b6881d755de17d6c6cc73372555879ec7dce2c2feee947866ad2
+  checksum: 10c0/b1f3127a5be8125a94f37188b361c212466c292c6910adce3ec106cff5dc211ccaedc4739c11bb70fda59d6fc1f040a9bca289f4e093451521a2372e5231fe0c
   languageName: node
   linkType: hard
 
@@ -6166,13 +5943,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel-list@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "side-channel-list@npm:1.0.0"
+"side-channel-list@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "side-channel-list@npm:1.0.1"
   dependencies:
     es-errors: "npm:^1.3.0"
-    object-inspect: "npm:^1.13.3"
-  checksum: 10c0/644f4ac893456c9490ff388bf78aea9d333d5e5bfc64cfb84be8f04bf31ddc111a8d4b83b85d7e7e8a7b845bc185a9ad02c052d20e086983cf59f0be517d9b3d
+    object-inspect: "npm:^1.13.4"
+  checksum: 10c0/d346c787fd2f9f1c2fdea14f00e8250118db0e7596d85a6cb9faa75f105d31a73a8f7a341c93d7df2a2429098c3d37a77bd3be9e88c37094b8c01807bc77c7a2
   languageName: node
   linkType: hard
 
@@ -6201,16 +5978,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "side-channel@npm:1.1.0"
+"side-channel@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "side-channel@npm:1.1.1"
   dependencies:
     es-errors: "npm:^1.3.0"
-    object-inspect: "npm:^1.13.3"
-    side-channel-list: "npm:^1.0.0"
+    object-inspect: "npm:^1.13.4"
+    side-channel-list: "npm:^1.0.1"
     side-channel-map: "npm:^1.0.1"
     side-channel-weakmap: "npm:^1.0.2"
-  checksum: 10c0/cb20dad41eb032e6c24c0982e1e5a24963a28aa6122b4f05b3f3d6bf8ae7fd5474ef382c8f54a6a3ab86e0cac4d41a23bd64ede3970e5bfb50326ba02a7996e6
+  checksum: 10c0/dc0ab81d67f61bda9247d053ce93f41c3fd8ad2bdcb9cf9d8d2f8540d488f26d87a5e99ebfc07eea49ec025867b2452b705442d974b1478f0395e69f6bfb3270
   languageName: node
   linkType: hard
 
@@ -6264,34 +6041,6 @@ __metadata:
     ansi-styles: "npm:^6.0.0"
     is-fullwidth-code-point: "npm:^4.0.0"
   checksum: 10c0/2d4d40b2a9d5cf4e8caae3f698fe24ae31a4d778701724f578e984dcb485ec8c49f0c04dab59c401821e80fcdfe89cace9c66693b0244e40ec485d72e543914f
-  languageName: node
-  linkType: hard
-
-"smart-buffer@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "smart-buffer@npm:4.2.0"
-  checksum: 10c0/a16775323e1404dd43fabafe7460be13a471e021637bc7889468eb45ce6a6b207261f454e4e530a19500cc962c4cc5348583520843b363f4193cee5c00e1e539
-  languageName: node
-  linkType: hard
-
-"socks-proxy-agent@npm:^8.0.3":
-  version: 8.0.5
-  resolution: "socks-proxy-agent@npm:8.0.5"
-  dependencies:
-    agent-base: "npm:^7.1.2"
-    debug: "npm:^4.3.4"
-    socks: "npm:^2.8.3"
-  checksum: 10c0/5d2c6cecba6821389aabf18728325730504bf9bb1d9e342e7987a5d13badd7a98838cc9a55b8ed3cb866ad37cc23e1086f09c4d72d93105ce9dfe76330e9d2a6
-  languageName: node
-  linkType: hard
-
-"socks@npm:^2.8.3":
-  version: 2.8.7
-  resolution: "socks@npm:2.8.7"
-  dependencies:
-    ip-address: "npm:^10.0.1"
-    smart-buffer: "npm:^4.2.0"
-  checksum: 10c0/2805a43a1c4bcf9ebf6e018268d87b32b32b06fbbc1f9282573583acc155860dc361500f89c73bfbb157caa1b4ac78059eac0ef15d1811eb0ca75e0bdadbc9d2
   languageName: node
   linkType: hard
 
@@ -6359,9 +6108,9 @@ __metadata:
   linkType: hard
 
 "spdx-license-ids@npm:^3.0.0":
-  version: 3.0.22
-  resolution: "spdx-license-ids@npm:3.0.22"
-  checksum: 10c0/4a85e44c2ccfc06eebe63239193f526508ebec1abc7cf7bca8ee43923755636234395447c2c87f40fb672cf580a9c8e684513a676bfb2da3d38a4983684bbb38
+  version: 3.0.23
+  resolution: "spdx-license-ids@npm:3.0.23"
+  checksum: 10c0/8495620f6f2a237749cce922ea2d593a66f7885c301b1a0f5542183e7041182f27f616a8f13345cefdea0c9b3e0899328e0aa8cec100cf4f3fac4bb3bd975515
   languageName: node
   linkType: hard
 
@@ -6385,15 +6134,6 @@ __metadata:
   version: 1.0.3
   resolution: "sprintf-js@npm:1.0.3"
   checksum: 10c0/ecadcfe4c771890140da5023d43e190b7566d9cf8b2d238600f31bec0fc653f328da4450eb04bd59a431771a8e9cc0e118f0aa3974b683a4981b4e07abc2a5bb
-  languageName: node
-  linkType: hard
-
-"ssri@npm:^13.0.0":
-  version: 13.0.1
-  resolution: "ssri@npm:13.0.1"
-  dependencies:
-    minipass: "npm:^7.0.3"
-  checksum: 10c0/cf6408a18676c57ff2ed06b8a20dc64bb3e748e5c7e095332e6aecaa2b8422b1e94a739a8453bf65156a8a47afe23757ba4ab52d3ea3b62322dc40875763e17a
   languageName: node
   linkType: hard
 
@@ -6478,11 +6218,11 @@ __metadata:
   linkType: hard
 
 "strip-ansi@npm:^7.0.1":
-  version: 7.1.2
-  resolution: "strip-ansi@npm:7.1.2"
+  version: 7.2.0
+  resolution: "strip-ansi@npm:7.2.0"
   dependencies:
-    ansi-regex: "npm:^6.0.1"
-  checksum: 10c0/0d6d7a023de33368fd042aab0bf48f4f4077abdfd60e5393e73c7c411e85e1b3a83507c11af2e656188511475776215df9ca589b4da2295c9455cc399ce1858b
+    ansi-regex: "npm:^6.2.2"
+  checksum: 10c0/544d13b7582f8254811ea97db202f519e189e59d35740c46095897e254e4f1aa9fe1524a83ad6bc5ad67d4dd6c0281d2e0219ed62b880a6238a16a17d375f221
   languageName: node
   linkType: hard
 
@@ -6575,15 +6315,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.4":
-  version: 7.5.7
-  resolution: "tar@npm:7.5.7"
+  version: 7.5.17
+  resolution: "tar@npm:7.5.17"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/51f261afc437e1112c3e7919478d6176ea83f7f7727864d8c2cce10f0b03a631d1911644a567348c3063c45abdae39718ba97abb073d22aa3538b9a53ae1e31c
+  checksum: 10c0/794e80834d6fa29a526d7c6dc82684cd1d0fbc4b7dd4a86c730946a996314149b60e29f1bff8623936bb1442da7de241890c16ce6268f16cc5ef2aa5b9615953
   languageName: node
   linkType: hard
 
@@ -6632,12 +6372,12 @@ __metadata:
   linkType: hard
 
 "tinyglobby@npm:^0.2.12":
-  version: 0.2.15
-  resolution: "tinyglobby@npm:0.2.15"
+  version: 0.2.17
+  resolution: "tinyglobby@npm:0.2.17"
   dependencies:
     fdir: "npm:^6.5.0"
-    picomatch: "npm:^4.0.3"
-  checksum: 10c0/869c31490d0d88eedb8305d178d4c75e7463e820df5a9b9d388291daf93e8b1eb5de1dad1c1e139767e4269fe75f3b10d5009b2cc14db96ff98986920a186844
+    picomatch: "npm:^4.0.4"
+  checksum: 10c0/7f7bb0f197c88bc4b20c231e0deca4240ca3bf313a88f5a7fee93a872b84966a4d50220947c0455ad07a60b3b360961c5b7fd979222aeb716a9f99b412002e4c
   languageName: node
   linkType: hard
 
@@ -6755,10 +6495,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~7.16.0":
-  version: 7.16.0
-  resolution: "undici-types@npm:7.16.0"
-  checksum: 10c0/3033e2f2b5c9f1504bdc5934646cb54e37ecaca0f9249c983f7b1fc2e87c6d18399ebb05dc7fd5419e02b2e915f734d872a65da2e3eeed1813951c427d33cc9a
+"undici-types@npm:~8.3.0":
+  version: 8.3.0
+  resolution: "undici-types@npm:8.3.0"
+  checksum: 10c0/c8aa7e2fbebfce519654dafadc0ece59be888d2ccaf180fb4495da875e7b536d2456345c384069c7e6f3e9c9ab7435f074957da306f142343eee86ff8048855a
   languageName: node
   linkType: hard
 
@@ -6771,21 +6511,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unique-filename@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "unique-filename@npm:5.0.0"
-  dependencies:
-    unique-slug: "npm:^6.0.0"
-  checksum: 10c0/afb897e9cf4c2fb622ea716f7c2bb462001928fc5f437972213afdf1cc32101a230c0f1e9d96fc91ee5185eca0f2feb34127145874975f347be52eb91d6ccc2c
-  languageName: node
-  linkType: hard
-
-"unique-slug@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "unique-slug@npm:6.0.0"
-  dependencies:
-    imurmurhash: "npm:^0.1.4"
-  checksum: 10c0/da7ade4cb04eb33ad0499861f82fe95ce9c7c878b7139dc54d140ecfb6a6541c18a5c8dac16188b8b379fe62c0c1f1b710814baac910cde5f4fec06212126c6a
+"undici@npm:^6.25.0":
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
   languageName: node
   linkType: hard
 
@@ -6813,7 +6542,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.2.0":
+"update-browserslist-db@npm:^1.2.3":
   version: 1.2.3
   resolution: "update-browserslist-db@npm:1.2.3"
   dependencies:
@@ -6940,14 +6669,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^6.0.0":
-  version: 6.0.1
-  resolution: "which@npm:6.0.1"
+"which@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "which@npm:7.0.0"
   dependencies:
     isexe: "npm:^4.0.0"
   bin:
     node-which: bin/which.js
-  checksum: 10c0/7e710e54ea36d2d6183bee2f9caa27a3b47b9baf8dee55a199b736fcf85eab3b9df7556fca3d02b50af7f3dfba5ea3a45644189836df06267df457e354da66d5
+  checksum: 10c0/ca0b54f198f78bbc4b7c02e34bda8d335cb352e0adb4cbca1c37b1a957af3a879a82c4c27ca6525bc942f548d8b64f816ef6528360af9f3de55ffb9b979b620d
   languageName: node
   linkType: hard
 
@@ -7033,11 +6762,11 @@ __metadata:
   linkType: hard
 
 "yaml@npm:^2.1.1, yaml@npm:^2.8.2":
-  version: 2.8.2
-  resolution: "yaml@npm:2.8.2"
+  version: 2.9.0
+  resolution: "yaml@npm:2.9.0"
   bin:
     yaml: bin.mjs
-  checksum: 10c0/703e4dc1e34b324aa66876d63618dcacb9ed49f7e7fe9b70f1e703645be8d640f68ab84f12b86df8ac960bac37acf5513e115de7c970940617ce0343c8c9cd96
+  checksum: 10c0/f340718df45e97a9551b9bf9dac61c80050bc464513b710debfb5067c380c8472e3b67809cffacb4ab5ffb5e66ef9310816c88b05f371cec60abfedd8c88e0a2
   languageName: node
   linkType: hard
 
@@ -7049,8 +6778,8 @@ __metadata:
   linkType: hard
 
 "yargs@npm:^17.3.1":
-  version: 17.7.2
-  resolution: "yargs@npm:17.7.2"
+  version: 17.7.3
+  resolution: "yargs@npm:17.7.3"
   dependencies:
     cliui: "npm:^8.0.1"
     escalade: "npm:^3.1.1"
@@ -7059,7 +6788,7 @@ __metadata:
     string-width: "npm:^4.2.3"
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^21.1.1"
-  checksum: 10c0/ccd7e723e61ad5965fffbb791366db689572b80cca80e0f96aad968dfff4156cd7cd1ad18607afe1046d8241e6fb2d6c08bf7fa7bfb5eaec818735d8feac8f05
+  checksum: 10c0/7a28572f7e785a57886e34fdbddb9b28756dec552e1453d5f6e7cdd00ad8721a4e8c4321d33683f5e61cacb36ad43258adbb48396b71ec4ed14abee0fc0d0c1f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds `not-ready` input for safe release workflows that need assets attached before publishing. Prevents admins from publishing incomplete drafts.

**`not-ready` input** (`bool | string`):
- `'true'` → prepends `> [!CAUTION]` banner with default message
- `'custom string'` → same banner with caller's message
- `'false'`/omitted → no banner (body regenerated from scratch, so banner is automatically removed)

Two usage patterns (2 calls to release-drafter each):

*Pattern A* (third-party attacher): `not-ready: true` → external attach → run again without `not-ready`
*Pattern B* (managed uploads): `not-ready: true` → build → `attach-files` without `not-ready`

**Admin timestamp** — always appended as invisible HTML comment:
```html
<!-- Release drafted at 2025-01-15 4:00pm Pacific from https://github.com/owner/repo/commit/abc123 -->
```
Pacific via `Intl.DateTimeFormat('en-US', { timeZone: 'America/Los_Angeles' })`. Commit URL from `GITHUB_SERVER_URL`/`GITHUB_REPOSITORY`/`GITHUB_SHA` (omitted outside Actions).

Key additions:
- `parseNotReadyInput(raw)` → `false | true | string`
- `formatPacificTimestamp(date)` → `"YYYY-MM-DD h:mmam/pm Pacific"`
- `getCommitUrl()` → commit URL or `null`
- 4 new unit tests, `not-ready-banner` e2e smoke test, README docs section

Requested by @aaronsteers.

Link to Devin session: https://app.devin.ai/sessions/601932cfa6b54ec8a6145cd9300d43aa