### PR TITLE
ci: add CodeQL analysis for GitHub Actions

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,6 @@
+name: "CodeQL Config"
+
+# Run the extended "security-and-quality" query suite (a superset of the
+# default security queries) for every analyzed language.
+queries:
+  - uses: security-and-quality

--- a/.github/workflows/codeql-vulnerability-checks.yml
+++ b/.github/workflows/codeql-vulnerability-checks.yml
@@ -37,7 +37,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql-vulnerability-checks.yml
+++ b/.github/workflows/codeql-vulnerability-checks.yml
@@ -23,7 +23,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/codeql-vulnerability-checks.yml
+++ b/.github/workflows/codeql-vulnerability-checks.yml
@@ -23,17 +23,17 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: actions
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:actions"

--- a/.github/workflows/codeql-vulnerability-checks.yml
+++ b/.github/workflows/codeql-vulnerability-checks.yml
@@ -1,4 +1,4 @@
-name: "CodeQL"
+name: "CodeQL Vulnerability Checks"
 
 on:
   push:

--- a/.github/workflows/codeql-vulnerability-checks.yml
+++ b/.github/workflows/codeql-vulnerability-checks.yml
@@ -21,6 +21,12 @@ jobs:
       security-events: write
       contents: read
       actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+          - actions
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -30,10 +36,10 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
-          languages: actions
+          languages: ${{ matrix.language }}
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
-          category: "/language:actions"
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: actions
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:actions"


### PR DESCRIPTION
## Summary

Adds CodeQL security scanning with the `actions` language analyzer using the `security-and-quality` query suite.

Detects GitHub Actions-specific vulnerabilities like script injection, missing permissions blocks, and untrusted checkout.

Runs on push/PR to `main` and weekly on Monday.

Link to Devin session: https://app.devin.ai/sessions/fe5d63b3474f4fe6990b6f8f7a47f8ed
Requested by: @aaronsteers