### PR TITLE
feat: prepared-release-id finalize + point-in-time SHA pinning (fixes #56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -865,21 +865,23 @@ Since each run regenerates the body from scratch, calling the action without `no
 
 > [!IMPORTANT]
 > When splitting the work across two invocations (create the draft, build, then
-> finalize), pass **both** of these outputs from the first call to the finalize
-> call:
+> finalize), pass just one output from the first call to the finalize call:
 >
-> 1. `release-id: ${{ steps.<id>.outputs.id }}` — targets that exact release via
->    a strongly consistent point-read and updates it in place. Do **not** rely on
->    the finalize call re-discovering the draft from `version`/`tag` alone: the
->    list-releases API is eventually consistent, so a draft created seconds
->    earlier can be missing from the list read by the next step, causing the
->    action to create a **duplicate** draft.
-> 2. `version: ${{ steps.<id>.outputs.resolved-version }}` — pins the version/tag
->    to exactly what the first call resolved (and what you built artifacts
->    against). Without this pin, the finalize call recomputes the version from
->    the latest release plus commits, so a release published by someone else
->    between the two steps could bump the version and retag the release,
->    desyncing it from the built artifacts.
+> `prepared-release-id: ${{ steps.<id>.outputs.id }}` — targets that exact
+> release via a strongly consistent point-read and updates it in place. Do
+> **not** rely on the finalize call re-discovering the draft from `version`/`tag`
+> alone: the list-releases API is eventually consistent, so a draft created
+> seconds earlier can be missing from the list read by the next step, causing
+> the action to create a **duplicate** draft.
+>
+> That is all you need. The prepared release is the source of truth, so the
+> finalize reuses the version, tag, prerelease state, and pinned target commit
+> that the first call froze — nothing can drift if another release is published
+> between the two steps. Because those values come from the release, the inputs
+> that would recompute them (`version`, `tag`, `commitish`, `base-ref-override`,
+> `base-version-override`, `prerelease`, `prerelease-identifier`,
+> `allow-major-bumps`) are **incompatible** with `prepared-release-id` and cause
+> the action to fail if set alongside it.
 
 ### Pattern A: Third-party asset attacher
 
@@ -903,10 +905,9 @@ Since each run regenerates the body from scratch, calling the action without `no
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
-    # Target the exact release from step 1 (point-read by ID)...
-    release-id: ${{ steps.not-ready-draft.outputs.id }}
-    # ...and pin the version so it can't drift if another release is published.
-    version: ${{ steps.not-ready-draft.outputs.resolved-version }}
+    # Target the exact release from step 1 (point-read by ID). The release is
+    # the source of truth, so version/tag/prerelease/commit all come from it.
+    prepared-release-id: ${{ steps.not-ready-draft.outputs.id }}
 ```
 
 ### Pattern B: Release-drafter-managed uploads
@@ -930,10 +931,9 @@ Since each run regenerates the body from scratch, calling the action without `no
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
-    # Target the exact release from step 1 (point-read by ID)...
-    release-id: ${{ steps.not-ready-draft.outputs.id }}
-    # ...and pin the version so it can't drift if another release is published.
-    version: ${{ steps.not-ready-draft.outputs.resolved-version }}
+    # Target the exact release from step 1 (point-read by ID). The release is
+    # the source of truth, so version/tag/prerelease/commit all come from it.
+    prepared-release-id: ${{ steps.not-ready-draft.outputs.id }}
     attach-files: dist/*.whl
 ```
 
@@ -983,8 +983,8 @@ This closes a race in multi-step release flows. A run can take minutes, and
 `main` may move in between — so a naive second invocation could walk a different
 commit range, compute a different version/changelog, and finalize a release that
 no longer matches the artifacts built from the first pass. Because the release is
-pinned to a SHA (and a `release-id` finalize reuses that same SHA), every pass
-stays locked to one snapshot.
+pinned to a SHA (and a `prepared-release-id` finalize reuses that same SHA),
+every pass stays locked to one snapshot.
 
 Downstream build/packaging/inspection steps should consume it to stay in
 lockstep with the release:

--- a/README.md
+++ b/README.md
@@ -863,6 +863,18 @@ Use the `not-ready` input to prevent admins from prematurely publishing a draft 
 
 Since each run regenerates the body from scratch, calling the action without `not-ready` automatically removes the banner.
 
+> [!IMPORTANT]
+> When splitting the work across two invocations (create the draft, build, then
+> finalize), capture the `id` output from the first call and pass it to the
+> finalize call via `release-id`. The finalize call then fetches that exact
+> release by ID (a strongly consistent point-read) and updates it in place.
+>
+> Do **not** rely on the finalize call re-discovering the draft from
+> `version`/`tag` alone: the list-releases API is eventually consistent, so a
+> draft created seconds earlier can be missing from the list read by the next
+> step, causing the action to create a **duplicate** draft instead of updating
+> the existing one.
+
 ### Pattern A: Third-party asset attacher
 
 ```yaml
@@ -885,7 +897,8 @@ Since each run regenerates the body from scratch, calling the action without `no
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
-    version: ${{ steps.not-ready-draft.outputs.tag-name }}
+    # Update the exact release created in step 1, via a point-read by ID.
+    release-id: ${{ steps.not-ready-draft.outputs.id }}
 ```
 
 ### Pattern B: Release-drafter-managed uploads
@@ -909,7 +922,8 @@ Since each run regenerates the body from scratch, calling the action without `no
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
-    version: ${{ steps.not-ready-draft.outputs.tag-name }}
+    # Update the exact release created in step 1, via a point-read by ID.
+    release-id: ${{ steps.not-ready-draft.outputs.id }}
     attach-files: dist/*.whl
 ```
 

--- a/README.md
+++ b/README.md
@@ -865,15 +865,21 @@ Since each run regenerates the body from scratch, calling the action without `no
 
 > [!IMPORTANT]
 > When splitting the work across two invocations (create the draft, build, then
-> finalize), capture the `id` output from the first call and pass it to the
-> finalize call via `release-id`. The finalize call then fetches that exact
-> release by ID (a strongly consistent point-read) and updates it in place.
+> finalize), pass **both** of these outputs from the first call to the finalize
+> call:
 >
-> Do **not** rely on the finalize call re-discovering the draft from
-> `version`/`tag` alone: the list-releases API is eventually consistent, so a
-> draft created seconds earlier can be missing from the list read by the next
-> step, causing the action to create a **duplicate** draft instead of updating
-> the existing one.
+> 1. `release-id: ${{ steps.<id>.outputs.id }}` — targets that exact release via
+>    a strongly consistent point-read and updates it in place. Do **not** rely on
+>    the finalize call re-discovering the draft from `version`/`tag` alone: the
+>    list-releases API is eventually consistent, so a draft created seconds
+>    earlier can be missing from the list read by the next step, causing the
+>    action to create a **duplicate** draft.
+> 2. `version: ${{ steps.<id>.outputs.resolved-version }}` — pins the version/tag
+>    to exactly what the first call resolved (and what you built artifacts
+>    against). Without this pin, the finalize call recomputes the version from
+>    the latest release plus commits, so a release published by someone else
+>    between the two steps could bump the version and retag the release,
+>    desyncing it from the built artifacts.
 
 ### Pattern A: Third-party asset attacher
 
@@ -897,8 +903,10 @@ Since each run regenerates the body from scratch, calling the action without `no
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
-    # Update the exact release created in step 1, via a point-read by ID.
+    # Target the exact release from step 1 (point-read by ID)...
     release-id: ${{ steps.not-ready-draft.outputs.id }}
+    # ...and pin the version so it can't drift if another release is published.
+    version: ${{ steps.not-ready-draft.outputs.resolved-version }}
 ```
 
 ### Pattern B: Release-drafter-managed uploads
@@ -922,8 +930,10 @@ Since each run regenerates the body from scratch, calling the action without `no
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
-    # Update the exact release created in step 1, via a point-read by ID.
+    # Target the exact release from step 1 (point-read by ID)...
     release-id: ${{ steps.not-ready-draft.outputs.id }}
+    # ...and pin the version so it can't drift if another release is published.
+    version: ${{ steps.not-ready-draft.outputs.resolved-version }}
     attach-files: dist/*.whl
 ```
 

--- a/README.md
+++ b/README.md
@@ -971,9 +971,11 @@ The action sets the following outputs which can be used in subsequent workflow s
 
 ### `resolved-sha` — the point-in-time commit pin
 
-Every pass emits `resolved-sha`: the concrete commit SHA the run evaluated and
-pinned the release's `target_commitish` to. It's the tip of the target branch at
-run time, frozen so it can't drift.
+Whenever SHA pinning applies, the run emits `resolved-sha`: the concrete commit
+SHA it evaluated and pinned the release's `target_commitish` to. It's the tip of
+the target branch at run time, frozen so it can't drift. (It's omitted when you
+opt out — an explicit branch `commitish` or `filter-by-commitish` — or in
+local-git mode.)
 
 This closes a race in multi-step release flows. A run can take minutes, and
 `main` may move in between — so a naive second invocation could walk a different
@@ -1001,7 +1003,8 @@ lockstep with the release:
 > SHA rather than a branch name. This is provenance only — the tag name, release
 > page, assets, and the frozen tag→commit that consumers actually use are all
 > unchanged. To opt out and keep branch behavior, pass an explicit `commitish`
-> (e.g. `commitish: main`).
+> (e.g. `commitish: main`); pinning is also skipped automatically when
+> `filter-by-commitish` is enabled.
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -971,11 +971,13 @@ The action sets the following outputs which can be used in subsequent workflow s
 
 ### `resolved-sha` — the point-in-time commit pin
 
-Whenever SHA pinning applies, the run emits `resolved-sha`: the concrete commit
-SHA it evaluated and pinned the release's `target_commitish` to. It's the tip of
-the target branch at run time, frozen so it can't drift. (It's omitted when you
-opt out — an explicit branch `commitish` or `filter-by-commitish` — or in
-local-git mode.)
+By default, every pass emits `resolved-sha`: the concrete commit SHA it
+evaluated and pinned the release's `target_commitish` to. It's the tip of the
+target branch at run time, frozen so it can't drift. The only exceptions —
+where the release deliberately keeps its branch ref instead — are when you
+explicitly override the ref with a branch `commitish`, when `filter-by-commitish`
+is enabled (that feature matches releases by branch name, so a SHA would break
+it), or in local-git mode.
 
 This closes a race in multi-step release flows. A run can take minutes, and
 `main` may move in between — so a naive second invocation could walk a different

--- a/README.md
+++ b/README.md
@@ -967,6 +967,41 @@ The action sets the following outputs which can be used in subsequent workflow s
 | `major_version`    | Major part of resolved version by [Version Resolver](#version-resolver), e.g. `6`. |
 | `minor_version`    | Minor part of resolved version by [Version Resolver](#version-resolver), e.g. `3`. |
 | `patch_version`    | Patch part of resolved version by [Version Resolver](#version-resolver), e.g. `1`. |
+| `resolved-sha`     | The exact commit SHA this run evaluated and pinned the release to (see below).     |
+
+### `resolved-sha` — the point-in-time commit pin
+
+Every pass emits `resolved-sha`: the concrete commit SHA the run evaluated and
+pinned the release's `target_commitish` to. It's the tip of the target branch at
+run time, frozen so it can't drift.
+
+This closes a race in multi-step release flows. A run can take minutes, and
+`main` may move in between — so a naive second invocation could walk a different
+commit range, compute a different version/changelog, and finalize a release that
+no longer matches the artifacts built from the first pass. Because the release is
+pinned to a SHA (and a `release-id` finalize reuses that same SHA), every pass
+stays locked to one snapshot.
+
+Downstream build/packaging/inspection steps should consume it to stay in
+lockstep with the release:
+
+```yaml
+- uses: aaronsteers/semantic-pr-release-drafter@v2
+  id: draft
+  with:
+    not-ready: true
+- uses: actions/checkout@v4
+  with:
+    # Build against the exact commit the draft was evaluated at.
+    ref: ${{ steps.draft.outputs.resolved-sha }}
+```
+
+> [!NOTE]
+> Pinning means a published release's `target_commitish` REST field reads as a
+> SHA rather than a branch name. This is provenance only — the tag name, release
+> page, assets, and the frozen tag→commit that consumers actually use are all
+> unchanged. To opt out and keep branch behavior, pass an explicit `commitish`
+> (e.g. `commitish: main`).
 
 ## Developing
 

--- a/action.yml
+++ b/action.yml
@@ -262,4 +262,7 @@ outputs:
       instead — are when you explicitly override the ref with a branch
       `commitish`, when `filter-by-commitish` is enabled (that feature matches
       releases by branch name, so a SHA would break it), or in local-git mode.
-      Outputs are only emitted when running in GitHub Actions.
+      The `filter-by-commitish` exception does not apply on a `release-id`
+      finalize: that release is targeted by a deterministic point-read, so
+      commitish-based selection is moot and the pin is still applied. Outputs
+      are only emitted when running in GitHub Actions.

--- a/action.yml
+++ b/action.yml
@@ -250,15 +250,16 @@ outputs:
       The exact commit SHA this run evaluated and pinned the release to — a
       fixed, point-in-time reference to the target branch's tip at run time.
 
-      Set whenever SHA pinning applies, across every pass (dry-run/calculate,
-      create draft, and finalize), so downstream build, packaging, and
-      inspection steps can check out this exact commit and stay in lockstep with
-      the release even if the branch moves afterwards. The resolved SHA is, in
-      priority order: the SHA frozen by an earlier pass (on a `release-id`
-      finalize), an explicit `commitish` when it is itself a SHA, or `GITHUB_SHA`
-      (the triggering commit) on the default path.
+      Set by default on every pass (dry-run/calculate, create draft, and
+      finalize), so downstream build, packaging, and inspection steps can check
+      out this exact commit and stay in lockstep with the release even if the
+      branch moves afterwards. The resolved SHA is, in priority order: the SHA
+      frozen by an earlier pass (on a `release-id` finalize), an explicit
+      `commitish` when it is itself a SHA, or `GITHUB_SHA` (the triggering
+      commit) on the default path.
 
-      NOT set — leaving the release on its branch ref — when you opt out via an
-      explicit branch `commitish`, when `filter-by-commitish` is enabled (that
-      feature matches releases by branch name), or in local-git mode. Outputs
-      are only emitted when running in GitHub Actions.
+      The only exceptions — where the release deliberately keeps its branch ref
+      instead — are when you explicitly override the ref with a branch
+      `commitish`, when `filter-by-commitish` is enabled (that feature matches
+      releases by branch name, so a SHA would break it), or in local-git mode.
+      Outputs are only emitted when running in GitHub Actions.

--- a/action.yml
+++ b/action.yml
@@ -181,11 +181,12 @@ inputs:
       output of a previous invocation.
 
       When set, the action fetches that release directly by ID (a strongly
-      consistent point-read) and updates it in place, bypassing the
-      list-releases discovery entirely. This is the durable way to finalize a
-      draft created by an earlier step: it is immune to the eventual
-      consistency of the list-releases endpoint, which can otherwise cause a
-      just-created draft to be missed and a duplicate release to be created.
+      consistent point-read) and updates it in place, bypassing list-based
+      draft discovery. This is the durable way to finalize a draft created by
+      an earlier step: it is immune to the eventual consistency of the
+      list-releases endpoint, which can otherwise cause a just-created draft to
+      be missed and a duplicate release to be created. (The list endpoint is
+      still consulted to compute the previous release for the changelog.)
 
       Recommended for the two-step (not-ready -> finalize) pattern: capture
       `id` from the first invocation and pass it here on the finalize call.

--- a/action.yml
+++ b/action.yml
@@ -175,6 +175,22 @@ inputs:
       Requires GITHUB_TOKEN with contents: write permission.
     required: false
     default: ''
+  release-id:
+    description: |
+      The numeric ID of an existing release to update, as emitted by the `id`
+      output of a previous invocation.
+
+      When set, the action fetches that release directly by ID (a strongly
+      consistent point-read) and updates it in place, bypassing the
+      list-releases discovery entirely. This is the durable way to finalize a
+      draft created by an earlier step: it is immune to the eventual
+      consistency of the list-releases endpoint, which can otherwise cause a
+      just-created draft to be missed and a duplicate release to be created.
+
+      Recommended for the two-step (not-ready -> finalize) pattern: capture
+      `id` from the first invocation and pass it here on the finalize call.
+    required: false
+    default: ''
   reset-files:
     description: |
       Controls whether existing release assets are deleted before uploading new ones.

--- a/action.yml
+++ b/action.yml
@@ -175,10 +175,10 @@ inputs:
       Requires GITHUB_TOKEN with contents: write permission.
     required: false
     default: ''
-  release-id:
+  prepared-release-id:
     description: |
-      The numeric ID of an existing release to update, as emitted by the `id`
-      output of a previous invocation.
+      The numeric ID of an already-prepared release to finalize, as emitted by
+      the `id` output of a previous (`not-ready`) invocation.
 
       When set, the action fetches that release directly by ID (a strongly
       consistent point-read) and updates it in place, bypassing list-based
@@ -188,10 +188,19 @@ inputs:
       be missed and a duplicate release to be created. (The list endpoint is
       still consulted to compute the previous release for the changelog.)
 
+      The prepared release is the source of truth: its version, tag, prerelease
+      state, and pinned target commit are reused as-is rather than recomputed,
+      so the finalize can't drift if another release is published between the
+      steps. Because of this, inputs that would recompute or re-select those
+      values are incompatible and cause the action to fail if set alongside
+      `prepared-release-id`: `version`, `tag`, `commitish`, `base-ref-override`,
+      `base-version-override`, `prerelease`, `prerelease-identifier`, and
+      `allow-major-bumps`. (The `filter-by-commitish` config option is likewise
+      ignored on this path.)
+
       Recommended for the two-step (not-ready -> finalize) pattern: capture
-      `id` from the first invocation and pass it here on the finalize call.
-      Pass the first call's `resolved-version` as `version` too, so the pinned
-      version can't drift if another release is published between the steps.
+      `id` from the first invocation and pass it here on the finalize call —
+      that is all you need; the release carries everything else.
     required: false
     default: ''
   reset-files:
@@ -254,7 +263,7 @@ outputs:
       finalize), so downstream build, packaging, and inspection steps can check
       out this exact commit and stay in lockstep with the release even if the
       branch moves afterwards. The resolved SHA is, in priority order: the SHA
-      frozen by an earlier pass (on a `release-id` finalize), an explicit
+      frozen by an earlier pass (on a `prepared-release-id` finalize), an explicit
       `commitish` when it is itself a SHA, or `GITHUB_SHA` (the triggering
       commit) on the default path.
 
@@ -262,7 +271,7 @@ outputs:
       instead — are when you explicitly override the ref with a branch
       `commitish`, when `filter-by-commitish` is enabled (that feature matches
       releases by branch name, so a SHA would break it), or in local-git mode.
-      The `filter-by-commitish` exception does not apply on a `release-id`
+      The `filter-by-commitish` exception does not apply on a `prepared-release-id`
       finalize: that release is targeted by a deterministic point-read, so
       commitish-based selection is moot and the pin is still applied. Outputs
       are only emitted when running in GitHub Actions.

--- a/action.yml
+++ b/action.yml
@@ -190,6 +190,8 @@ inputs:
 
       Recommended for the two-step (not-ready -> finalize) pattern: capture
       `id` from the first invocation and pass it here on the finalize call.
+      Pass the first call's `resolved-version` as `version` too, so the pinned
+      version can't drift if another release is published between the steps.
     required: false
     default: ''
   reset-files:

--- a/action.yml
+++ b/action.yml
@@ -245,3 +245,16 @@ outputs:
     description: The next patch version number, with 'v' prefix removed (if applicable).
   resolved-version:
     description: The next resolved version number, based on semantic commit types, with 'v' prefix removed (if applicable).
+  resolved-sha:
+    description: |
+      The exact commit SHA this run evaluated and pinned the release to — a
+      fixed, point-in-time reference to the target branch's tip at run time.
+
+      Emitted on every pass (dry-run/calculate, create draft, and finalize), so
+      downstream build, packaging, and inspection steps can check out this exact
+      commit and stay in lockstep with the release, even if the branch moves
+      afterwards. On a finalize call targeting a `release-id`, this echoes the
+      SHA frozen by the earlier invocation, so both passes share one snapshot.
+
+      Only set in standard GitHub API mode when the commit can be resolved
+      (i.e. running in GitHub Actions, or when `commitish` is itself a SHA).

--- a/action.yml
+++ b/action.yml
@@ -250,11 +250,15 @@ outputs:
       The exact commit SHA this run evaluated and pinned the release to — a
       fixed, point-in-time reference to the target branch's tip at run time.
 
-      Emitted on every pass (dry-run/calculate, create draft, and finalize), so
-      downstream build, packaging, and inspection steps can check out this exact
-      commit and stay in lockstep with the release, even if the branch moves
-      afterwards. On a finalize call targeting a `release-id`, this echoes the
-      SHA frozen by the earlier invocation, so both passes share one snapshot.
+      Set whenever SHA pinning applies, across every pass (dry-run/calculate,
+      create draft, and finalize), so downstream build, packaging, and
+      inspection steps can check out this exact commit and stay in lockstep with
+      the release even if the branch moves afterwards. The resolved SHA is, in
+      priority order: the SHA frozen by an earlier pass (on a `release-id`
+      finalize), an explicit `commitish` when it is itself a SHA, or `GITHUB_SHA`
+      (the triggering commit) on the default path.
 
-      Only set in standard GitHub API mode when the commit can be resolved
-      (i.e. running in GitHub Actions, or when `commitish` is itself a SHA).
+      NOT set — leaving the release on its branch ref — when you opt out via an
+      explicit branch `commitish`, when `filter-by-commitish` is enabled (that
+      feature matches releases by branch name), or in local-git mode. Outputs
+      are only emitted when running in GitHub Actions.

--- a/dist/index.js
+++ b/dist/index.js
@@ -150459,12 +150459,13 @@ var require_releases = __commonJS({
     };
     var RELEASE_COUNT_LIMIT = 1e3;
     var getReleaseById = async ({ context, releaseId }) => {
-      const id = Number.parseInt(releaseId, 10);
-      if (!Number.isInteger(id)) {
+      const raw = String(releaseId).trim();
+      if (!/^\d+$/.test(raw)) {
         throw new TypeError(
-          `Invalid release-id "${releaseId}": expected a numeric ID.`
+          `Invalid release-id "${releaseId}": expected a positive integer ID.`
         );
       }
+      const id = Number.parseInt(raw, 10);
       try {
         const { data } = await context.octokit.repos.getRelease(
           context.repo({ release_id: id })

--- a/dist/index.js
+++ b/dist/index.js
@@ -154409,6 +154409,7 @@ var require_index = __commonJS({
           const pinnedSha = resolveTargetSha({
             targetCommitish,
             hasExplicitCommitish,
+            filterByCommitish,
             finalizeRelease: input.releaseId ? draftRelease : null
           });
           if (pinnedSha) {
@@ -154688,6 +154689,7 @@ var require_index = __commonJS({
     function resolveTargetSha({
       targetCommitish,
       hasExplicitCommitish,
+      filterByCommitish,
       finalizeRelease
     }) {
       const finalizeSha = finalizeRelease && finalizeRelease.target_commitish;
@@ -154697,7 +154699,7 @@ var require_index = __commonJS({
       if (FULL_SHA_REGEX.test(targetCommitish)) {
         return targetCommitish;
       }
-      if (!hasExplicitCommitish && process.env.GITHUB_SHA) {
+      if (!hasExplicitCommitish && !filterByCommitish && FULL_SHA_REGEX.test(process.env.GITHUB_SHA || "")) {
         return process.env.GITHUB_SHA;
       }
       return;

--- a/dist/index.js
+++ b/dist/index.js
@@ -150460,12 +150460,12 @@ var require_releases = __commonJS({
     var RELEASE_COUNT_LIMIT = 1e3;
     var getReleaseById = async ({ context, releaseId }) => {
       const raw = String(releaseId).trim();
-      if (!/^\d+$/.test(raw)) {
+      const id = Number.parseInt(raw, 10);
+      if (!/^\d+$/.test(raw) || id <= 0) {
         throw new TypeError(
           `Invalid release-id "${releaseId}": expected a positive integer ID.`
         );
       }
-      const id = Number.parseInt(raw, 10);
       try {
         const { data } = await context.octokit.repos.getRelease(
           context.repo({ release_id: id })

--- a/dist/index.js
+++ b/dist/index.js
@@ -154699,7 +154699,8 @@ var require_index = __commonJS({
       if (FULL_SHA_REGEX.test(targetCommitish)) {
         return targetCommitish;
       }
-      if (!hasExplicitCommitish && !filterByCommitish && FULL_SHA_REGEX.test(process.env.GITHUB_SHA || "")) {
+      const isReleaseIdFinalize = Boolean(finalizeRelease);
+      if (!hasExplicitCommitish && (!filterByCommitish || isReleaseIdFinalize) && FULL_SHA_REGEX.test(process.env.GITHUB_SHA || "")) {
         return process.env.GITHUB_SHA;
       }
       return;

--- a/dist/index.js
+++ b/dist/index.js
@@ -150458,6 +150458,30 @@ var require_releases = __commonJS({
       });
     };
     var RELEASE_COUNT_LIMIT = 1e3;
+    var getReleaseById = async ({ context, releaseId }) => {
+      const id = Number.parseInt(releaseId, 10);
+      if (!Number.isInteger(id)) {
+        throw new TypeError(
+          `Invalid release-id "${releaseId}": expected a numeric ID.`
+        );
+      }
+      try {
+        const { data } = await context.octokit.repos.getRelease(
+          context.repo({ release_id: id })
+        );
+        log({
+          context,
+          message: `Fetched release by id ${id}: ${data.tag_name || data.name}`
+        });
+        return data;
+      } catch (error) {
+        if (error.status === 404) {
+          log({ context, message: `No release found for release-id ${id}` });
+          return null;
+        }
+        throw error;
+      }
+    };
     var findReleases = async ({
       context,
       targetCommitish,
@@ -150726,6 +150750,7 @@ var require_releases = __commonJS({
       return updateReleaseParameters;
     }
     exports2.findReleases = findReleases;
+    exports2.getReleaseById = getReleaseById;
     exports2.generateChangeLog = generateChangeLog;
     exports2.generateReleaseInfo = generateReleaseInfo;
     exports2.createRelease = createRelease;
@@ -154285,6 +154310,7 @@ var require_index = __commonJS({
     var { isTriggerableReference } = require_triggerable_reference();
     var {
       findReleases,
+      getReleaseById,
       generateReleaseInfo,
       createRelease,
       updateRelease
@@ -154364,6 +154390,19 @@ var require_index = __commonJS({
           });
           draftRelease = releasesResult.draftRelease;
           lastRelease = releasesResult.lastRelease;
+          if (input.releaseId) {
+            const targetedRelease = await getReleaseById({
+              context,
+              releaseId: input.releaseId
+            });
+            if (targetedRelease) {
+              draftRelease = targetedRelease;
+            } else {
+              core2.warning(
+                `release-id "${input.releaseId}" did not resolve to an existing release; falling back to list-based discovery.`
+              );
+            }
+          }
           const commitsResult = await findCommitsWithAssociatedPullRequests({
             context,
             targetCommitish,
@@ -154550,6 +154589,7 @@ var require_index = __commonJS({
         shouldDraft: core2.getInput("publish").toLowerCase() !== "true",
         version: core2.getInput("version") || void 0,
         tag: core2.getInput("tag") || void 0,
+        releaseId: core2.getInput("release-id") || void 0,
         name: core2.getInput("name") || void 0,
         dryRun: core2.getInput("dry-run").toLowerCase() === "true",
         localGitRoot: core2.getInput("local-git-root") || void 0,

--- a/dist/index.js
+++ b/dist/index.js
@@ -150463,7 +150463,7 @@ var require_releases = __commonJS({
       const id = Number.parseInt(raw, 10);
       if (!/^\d+$/.test(raw) || id <= 0) {
         throw new TypeError(
-          `Invalid release-id "${releaseId}": expected a positive integer ID.`
+          `Invalid prepared-release-id "${releaseId}": expected a positive integer ID.`
         );
       }
       try {
@@ -150477,7 +150477,10 @@ var require_releases = __commonJS({
         return data;
       } catch (error) {
         if (error.status === 404) {
-          log({ context, message: `No release found for release-id ${id}` });
+          log({
+            context,
+            message: `No release found for prepared-release-id ${id}`
+          });
           return null;
         }
         throw error;
@@ -154340,6 +154343,11 @@ var require_index = __commonJS({
       }
       const drafter = async (context) => {
         const input = getInput();
+        const preparedReleaseConflict = getPreparedReleaseConflict(input);
+        if (preparedReleaseConflict) {
+          core2.setFailed(preparedReleaseConflict);
+          return;
+        }
         const config = await getConfig({
           context,
           configName: input.configName,
@@ -154364,8 +154372,14 @@ var require_index = __commonJS({
         const shouldIncludePreReleases = Boolean(
           includePreReleases || preReleaseIdentifier
         );
-        const { localGitRoot, baseRefOverride, baseVersionOverride } = input;
+        const {
+          localGitRoot,
+          baseRefOverride,
+          baseVersionOverride,
+          preparedReleaseId
+        } = input;
         let draftRelease, lastRelease, commits, mergedPullRequests;
+        let preparedRelease = null;
         let resolvedSha;
         if (localGitRoot) {
           log({
@@ -154393,16 +154407,17 @@ var require_index = __commonJS({
           });
           draftRelease = releasesResult.draftRelease;
           lastRelease = releasesResult.lastRelease;
-          if (input.releaseId) {
+          if (preparedReleaseId) {
             const targetedRelease = await getReleaseById({
               context,
-              releaseId: input.releaseId
+              releaseId: preparedReleaseId
             });
             if (targetedRelease) {
               draftRelease = targetedRelease;
+              preparedRelease = targetedRelease;
             } else {
               core2.warning(
-                `release-id "${input.releaseId}" did not resolve to an existing release; falling back to list-based discovery.`
+                `prepared-release-id "${preparedReleaseId}" did not resolve to an existing release; falling back to list-based discovery.`
               );
             }
           }
@@ -154410,7 +154425,7 @@ var require_index = __commonJS({
             targetCommitish,
             hasExplicitCommitish,
             filterByCommitish,
-            finalizeRelease: input.releaseId ? draftRelease : null
+            finalizeRelease: preparedRelease
           });
           if (pinnedSha) {
             resolvedSha = pinnedSha;
@@ -154459,7 +154474,7 @@ var require_index = __commonJS({
         } else {
           shouldResetFiles = !!attachFiles;
         }
-        const overrideVersion = version2;
+        let overrideVersion = version2;
         let draftVersion;
         if (draftRelease) {
           const draftVersionStr = draftRelease.tag_name || draftRelease.name;
@@ -154491,6 +154506,17 @@ var require_index = __commonJS({
             }
           }
         }
+        let effectiveTag = tag;
+        let effectiveIsPreRelease = prerelease;
+        if (preparedRelease) {
+          if (draftVersion) {
+            overrideVersion = draftVersion;
+          }
+          if (preparedRelease.tag_name) {
+            effectiveTag = preparedRelease.tag_name;
+          }
+          effectiveIsPreRelease = Boolean(preparedRelease.prerelease);
+        }
         const releaseInfo = generateReleaseInfo({
           context,
           commits,
@@ -154499,9 +154525,9 @@ var require_index = __commonJS({
           mergedPullRequests: sortedMergedPullRequests,
           overrideVersion,
           draftVersion,
-          tag,
+          tag: effectiveTag,
           name,
-          isPreRelease: prerelease,
+          isPreRelease: effectiveIsPreRelease,
           latest,
           shouldDraft,
           targetCommitish
@@ -154602,7 +154628,7 @@ var require_index = __commonJS({
         shouldDraft: core2.getInput("publish").toLowerCase() !== "true",
         version: core2.getInput("version") || void 0,
         tag: core2.getInput("tag") || void 0,
-        releaseId: core2.getInput("release-id") || void 0,
+        preparedReleaseId: core2.getInput("prepared-release-id") || void 0,
         name: core2.getInput("name") || void 0,
         dryRun: core2.getInput("dry-run").toLowerCase() === "true",
         localGitRoot: core2.getInput("local-git-root") || void 0,
@@ -154619,6 +154645,21 @@ var require_index = __commonJS({
         notReady: parseNotReadyInput(core2.getInput("not-ready")),
         allowMajorBumps: core2.getInput("allow-major-bumps") !== "" ? core2.getInput("allow-major-bumps").toLowerCase() === "true" : void 0
       };
+    }
+    function getPreparedReleaseConflict(input) {
+      if (!input.preparedReleaseId) return;
+      const incompatible = [
+        ["version", input.version],
+        ["tag", input.tag],
+        ["commitish", input.commitish],
+        ["base-ref-override", input.baseRefOverride],
+        ["base-version-override", input.baseVersionOverride],
+        ["prerelease", input.prerelease],
+        ["prerelease-identifier", input.preReleaseIdentifier],
+        ["allow-major-bumps", input.allowMajorBumps]
+      ].filter(([, value]) => value !== void 0).map(([name]) => name);
+      if (incompatible.length === 0) return;
+      return `prepared-release-id targets an already-prepared release as the source of truth, so the following input(s) are incompatible and must not be set alongside it: ${incompatible.join(", ")}. Remove them; their values are taken from the prepared release.`;
     }
     function updateConfigFromInput(config, input) {
       if (input.commitish) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -154351,7 +154351,8 @@ var require_index = __commonJS({
         if (!isTriggerableReference({ ref, context, config })) {
           return;
         }
-        const targetCommitish = config.commitish || ref;
+        let targetCommitish = config.commitish || ref;
+        const hasExplicitCommitish = Boolean(config.commitish);
         const {
           "filter-by-commitish": filterByCommitish,
           "include-pre-releases": includePreReleases,
@@ -154365,6 +154366,7 @@ var require_index = __commonJS({
         );
         const { localGitRoot, baseRefOverride, baseVersionOverride } = input;
         let draftRelease, lastRelease, commits, mergedPullRequests;
+        let resolvedSha;
         if (localGitRoot) {
           log({
             context,
@@ -154403,6 +154405,15 @@ var require_index = __commonJS({
                 `release-id "${input.releaseId}" did not resolve to an existing release; falling back to list-based discovery.`
               );
             }
+          }
+          const pinnedSha = resolveTargetSha({
+            targetCommitish,
+            hasExplicitCommitish,
+            finalizeRelease: input.releaseId ? draftRelease : null
+          });
+          if (pinnedSha) {
+            resolvedSha = pinnedSha;
+            targetCommitish = pinnedSha;
           }
           const commitsResult = await findCommitsWithAssociatedPullRequests({
             context,
@@ -154536,7 +154547,7 @@ var require_index = __commonJS({
             }
           }
           if (runnerIsActions()) {
-            setDryRunOutput(releaseInfo);
+            setDryRunOutput(releaseInfo, resolvedSha);
           }
           return;
         }
@@ -154575,7 +154586,7 @@ var require_index = __commonJS({
           });
         }
         if (runnerIsActions()) {
-          setActionOutput(createOrUpdateReleaseResponse, releaseInfo);
+          setActionOutput(createOrUpdateReleaseResponse, releaseInfo, resolvedSha);
         }
       };
       if (runnerIsActions()) {
@@ -154632,7 +154643,7 @@ var require_index = __commonJS({
       }
       config.latest = config.prerelease ? "false" : input.latest || config.latest || void 0;
     }
-    function setActionOutput(releaseResponse, { body, resolvedVersion, majorVersion, minorVersion, patchVersion }) {
+    function setActionOutput(releaseResponse, { body, resolvedVersion, majorVersion, minorVersion, patchVersion }, resolvedSha) {
       const {
         data: {
           id: releaseId,
@@ -154652,6 +154663,7 @@ var require_index = __commonJS({
       if (majorVersion) core2.setOutput("major-version", majorVersion);
       if (minorVersion) core2.setOutput("minor-version", minorVersion);
       if (patchVersion) core2.setOutput("patch-version", patchVersion);
+      if (resolvedSha) core2.setOutput("resolved-sha", resolvedSha);
       core2.setOutput("body", body);
     }
     function setDryRunOutput({
@@ -154662,14 +154674,33 @@ var require_index = __commonJS({
       patchVersion,
       tag,
       name
-    }) {
+    }, resolvedSha) {
       if (resolvedVersion) core2.setOutput("resolved-version", resolvedVersion);
       if (majorVersion) core2.setOutput("major-version", majorVersion);
       if (minorVersion) core2.setOutput("minor-version", minorVersion);
       if (patchVersion) core2.setOutput("patch-version", patchVersion);
       if (tag) core2.setOutput("tag-name", tag);
       if (name) core2.setOutput("name", name);
+      if (resolvedSha) core2.setOutput("resolved-sha", resolvedSha);
       core2.setOutput("body", body);
+    }
+    var FULL_SHA_REGEX = /^[\da-f]{40}$/i;
+    function resolveTargetSha({
+      targetCommitish,
+      hasExplicitCommitish,
+      finalizeRelease
+    }) {
+      const finalizeSha = finalizeRelease && finalizeRelease.target_commitish;
+      if (finalizeSha && FULL_SHA_REGEX.test(finalizeSha)) {
+        return finalizeSha;
+      }
+      if (FULL_SHA_REGEX.test(targetCommitish)) {
+        return targetCommitish;
+      }
+      if (!hasExplicitCommitish && process.env.GITHUB_SHA) {
+        return process.env.GITHUB_SHA;
+      }
+      return;
     }
     function parseNotReadyInput(raw) {
       if (!raw) return false;

--- a/index.js
+++ b/index.js
@@ -52,7 +52,8 @@ module.exports = (app, { getRouter }) => {
       return
     }
 
-    const targetCommitish = config.commitish || ref
+    let targetCommitish = config.commitish || ref
+    const hasExplicitCommitish = Boolean(config.commitish)
 
     const {
       'filter-by-commitish': filterByCommitish,
@@ -71,6 +72,8 @@ module.exports = (app, { getRouter }) => {
 
     // Local git mode: use git log instead of GitHub API
     let draftRelease, lastRelease, commits, mergedPullRequests
+    // The concrete, point-in-time commit SHA this run evaluated/pinned to.
+    let resolvedSha
 
     if (localGitRoot) {
       log({
@@ -126,6 +129,20 @@ module.exports = (app, { getRouter }) => {
               `falling back to list-based discovery.`
           )
         }
+      }
+
+      // Resolve a fixed, point-in-time commit SHA and pin the release to it, so
+      // the commit set, version, changelog, and eventual tag all correspond to
+      // exactly what this run evaluated — immune to the default branch moving
+      // between invocations (e.g. between a `not-ready` pass and its finalize).
+      const pinnedSha = resolveTargetSha({
+        targetCommitish,
+        hasExplicitCommitish,
+        finalizeRelease: input.releaseId ? draftRelease : null,
+      })
+      if (pinnedSha) {
+        resolvedSha = pinnedSha
+        targetCommitish = pinnedSha
       }
 
       const commitsResult = await findCommitsWithAssociatedPullRequests({
@@ -309,7 +326,7 @@ module.exports = (app, { getRouter }) => {
       }
 
       if (runnerIsActions()) {
-        setDryRunOutput(releaseInfo)
+        setDryRunOutput(releaseInfo, resolvedSha)
       }
       return
     }
@@ -353,7 +370,7 @@ module.exports = (app, { getRouter }) => {
     }
 
     if (runnerIsActions()) {
-      setActionOutput(createOrUpdateReleaseResponse, releaseInfo)
+      setActionOutput(createOrUpdateReleaseResponse, releaseInfo, resolvedSha)
     }
   }
 
@@ -434,7 +451,8 @@ function updateConfigFromInput(config, input) {
 
 function setActionOutput(
   releaseResponse,
-  { body, resolvedVersion, majorVersion, minorVersion, patchVersion }
+  { body, resolvedVersion, majorVersion, minorVersion, patchVersion },
+  resolvedSha
 ) {
   const {
     data: {
@@ -455,28 +473,68 @@ function setActionOutput(
   if (majorVersion) core.setOutput('major-version', majorVersion)
   if (minorVersion) core.setOutput('minor-version', minorVersion)
   if (patchVersion) core.setOutput('patch-version', patchVersion)
+  if (resolvedSha) core.setOutput('resolved-sha', resolvedSha)
   core.setOutput('body', body)
 }
 
 /**
  * Set outputs for dry-run mode (no release created/updated)
  */
-function setDryRunOutput({
-  body,
-  resolvedVersion,
-  majorVersion,
-  minorVersion,
-  patchVersion,
-  tag,
-  name,
-}) {
+function setDryRunOutput(
+  {
+    body,
+    resolvedVersion,
+    majorVersion,
+    minorVersion,
+    patchVersion,
+    tag,
+    name,
+  },
+  resolvedSha
+) {
   if (resolvedVersion) core.setOutput('resolved-version', resolvedVersion)
   if (majorVersion) core.setOutput('major-version', majorVersion)
   if (minorVersion) core.setOutput('minor-version', minorVersion)
   if (patchVersion) core.setOutput('patch-version', patchVersion)
   if (tag) core.setOutput('tag-name', tag)
   if (name) core.setOutput('name', name)
+  if (resolvedSha) core.setOutput('resolved-sha', resolvedSha)
   core.setOutput('body', body)
+}
+
+// A full-length (40 hex) commit SHA.
+const FULL_SHA_REGEX = /^[\da-f]{40}$/i
+
+/**
+ * Resolves the release target to a fixed, point-in-time commit SHA so the
+ * release can be pinned to exactly what this run evaluated (immune to the
+ * branch moving between invocations). Resolution order, highest priority first:
+ *   1. The finalize target's own `target_commitish`, when a `release-id` pass
+ *      resolved a release already pinned to a SHA — reuses the commit frozen by
+ *      the earlier invocation so the finalize re-evaluates the same snapshot.
+ *   2. `targetCommitish`, when it is itself a SHA (an explicit `commitish` SHA).
+ *   3. `GITHUB_SHA` — the exact commit that triggered this run — but only on
+ *      the default path (no explicit `commitish`), where it is the tip of the
+ *      target ref.
+ * Returns `undefined` when none apply (an explicit branch `commitish`, or when
+ * running outside GitHub Actions), leaving the existing ref behavior intact.
+ */
+function resolveTargetSha({
+  targetCommitish,
+  hasExplicitCommitish,
+  finalizeRelease,
+}) {
+  const finalizeSha = finalizeRelease && finalizeRelease.target_commitish
+  if (finalizeSha && FULL_SHA_REGEX.test(finalizeSha)) {
+    return finalizeSha
+  }
+  if (FULL_SHA_REGEX.test(targetCommitish)) {
+    return targetCommitish
+  }
+  if (!hasExplicitCommitish && process.env.GITHUB_SHA) {
+    return process.env.GITHUB_SHA
+  }
+  return
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const { getConfig } = require('./lib/config')
 const { isTriggerableReference } = require('./lib/triggerable-reference')
 const {
   findReleases,
+  getReleaseById,
   generateReleaseInfo,
   createRelease,
   updateRelease,
@@ -106,6 +107,26 @@ module.exports = (app, { getRouter }) => {
       })
       draftRelease = releasesResult.draftRelease
       lastRelease = releasesResult.lastRelease
+
+      if (input.releaseId) {
+        // Durable finalize path: when a `release-id` is supplied (e.g. captured
+        // from the `id` output of an earlier `not-ready` invocation), resolve
+        // the target release by ID via a strongly consistent point-read. This
+        // bypasses list-releases discovery, which is eventually consistent and
+        // can miss a just-created draft — causing a duplicate release.
+        const targetedRelease = await getReleaseById({
+          context,
+          releaseId: input.releaseId,
+        })
+        if (targetedRelease) {
+          draftRelease = targetedRelease
+        } else {
+          core.warning(
+            `release-id "${input.releaseId}" did not resolve to an existing release; ` +
+              `falling back to list-based discovery.`
+          )
+        }
+      }
 
       const commitsResult = await findCommitsWithAssociatedPullRequests({
         context,
@@ -349,6 +370,7 @@ function getInput() {
     shouldDraft: core.getInput('publish').toLowerCase() !== 'true',
     version: core.getInput('version') || undefined,
     tag: core.getInput('tag') || undefined,
+    releaseId: core.getInput('release-id') || undefined,
     name: core.getInput('name') || undefined,
     dryRun: core.getInput('dry-run').toLowerCase() === 'true',
     localGitRoot: core.getInput('local-git-root') || undefined,

--- a/index.js
+++ b/index.js
@@ -112,8 +112,8 @@ module.exports = (app, { getRouter }) => {
         // Durable finalize path: when a `release-id` is supplied (e.g. captured
         // from the `id` output of an earlier `not-ready` invocation), resolve
         // the target release by ID via a strongly consistent point-read. This
-        // bypasses list-releases discovery, which is eventually consistent and
-        // can miss a just-created draft — causing a duplicate release.
+        // bypasses list-based draft discovery, which is eventually consistent
+        // and can miss a just-created draft — causing a duplicate release.
         const targetedRelease = await getReleaseById({
           context,
           releaseId: input.releaseId,

--- a/index.js
+++ b/index.js
@@ -138,6 +138,7 @@ module.exports = (app, { getRouter }) => {
       const pinnedSha = resolveTargetSha({
         targetCommitish,
         hasExplicitCommitish,
+        filterByCommitish,
         finalizeRelease: input.releaseId ? draftRelease : null,
       })
       if (pinnedSha) {
@@ -513,15 +514,19 @@ const FULL_SHA_REGEX = /^[\da-f]{40}$/i
  *      resolved a release already pinned to a SHA — reuses the commit frozen by
  *      the earlier invocation so the finalize re-evaluates the same snapshot.
  *   2. `targetCommitish`, when it is itself a SHA (an explicit `commitish` SHA).
- *   3. `GITHUB_SHA` — the exact commit that triggered this run — but only on
- *      the default path (no explicit `commitish`), where it is the tip of the
- *      target ref.
- * Returns `undefined` when none apply (an explicit branch `commitish`, or when
- * running outside GitHub Actions), leaving the existing ref behavior intact.
+ *   3. `GITHUB_SHA` — the exact commit that triggered this run, when it is a
+ *      valid 40-hex SHA (i.e. running in GitHub Actions) — but only on the
+ *      default path, where it is the tip of the target ref.
+ * Returns `undefined` when none apply, leaving the existing ref behavior
+ * intact. The auto-pin (case 3) is deliberately skipped when an explicit branch
+ * `commitish` is set (opt-out) or when `filter-by-commitish` is enabled — that
+ * feature matches releases by branch name, so writing a SHA into
+ * `target_commitish` would break selection on later runs.
  */
 function resolveTargetSha({
   targetCommitish,
   hasExplicitCommitish,
+  filterByCommitish,
   finalizeRelease,
 }) {
   const finalizeSha = finalizeRelease && finalizeRelease.target_commitish
@@ -531,7 +536,11 @@ function resolveTargetSha({
   if (FULL_SHA_REGEX.test(targetCommitish)) {
     return targetCommitish
   }
-  if (!hasExplicitCommitish && process.env.GITHUB_SHA) {
+  if (
+    !hasExplicitCommitish &&
+    !filterByCommitish &&
+    FULL_SHA_REGEX.test(process.env.GITHUB_SHA || '')
+  ) {
     return process.env.GITHUB_SHA
   }
   return

--- a/index.js
+++ b/index.js
@@ -34,6 +34,12 @@ module.exports = (app, { getRouter }) => {
   const drafter = async (context) => {
     const input = getInput()
 
+    const preparedReleaseConflict = getPreparedReleaseConflict(input)
+    if (preparedReleaseConflict) {
+      core.setFailed(preparedReleaseConflict)
+      return
+    }
+
     const config = await getConfig({
       context,
       configName: input.configName,
@@ -68,10 +74,18 @@ module.exports = (app, { getRouter }) => {
       includePreReleases || preReleaseIdentifier
     )
 
-    const { localGitRoot, baseRefOverride, baseVersionOverride } = input
+    const {
+      localGitRoot,
+      baseRefOverride,
+      baseVersionOverride,
+      preparedReleaseId,
+    } = input
 
     // Local git mode: use git log instead of GitHub API
     let draftRelease, lastRelease, commits, mergedPullRequests
+    // The already-prepared release resolved via `prepared-release-id`, when the
+    // finalize pass targets an earlier `not-ready` draft by its id.
+    let preparedRelease = null
     // The concrete, point-in-time commit SHA this run evaluated/pinned to.
     let resolvedSha
 
@@ -111,21 +125,22 @@ module.exports = (app, { getRouter }) => {
       draftRelease = releasesResult.draftRelease
       lastRelease = releasesResult.lastRelease
 
-      if (input.releaseId) {
-        // Durable finalize path: when a `release-id` is supplied (e.g. captured
-        // from the `id` output of an earlier `not-ready` invocation), resolve
-        // the target release by ID via a strongly consistent point-read. This
-        // bypasses list-based draft discovery, which is eventually consistent
-        // and can miss a just-created draft — causing a duplicate release.
+      if (preparedReleaseId) {
+        // Durable finalize path: when a `prepared-release-id` is supplied (the
+        // `id` output of an earlier `not-ready` invocation), resolve the target
+        // release by ID via a strongly consistent point-read. This bypasses
+        // list-based draft discovery, which is eventually consistent and can
+        // miss a just-created draft — causing a duplicate release.
         const targetedRelease = await getReleaseById({
           context,
-          releaseId: input.releaseId,
+          releaseId: preparedReleaseId,
         })
         if (targetedRelease) {
           draftRelease = targetedRelease
+          preparedRelease = targetedRelease
         } else {
           core.warning(
-            `release-id "${input.releaseId}" did not resolve to an existing release; ` +
+            `prepared-release-id "${preparedReleaseId}" did not resolve to an existing release; ` +
               `falling back to list-based discovery.`
           )
         }
@@ -139,7 +154,7 @@ module.exports = (app, { getRouter }) => {
         targetCommitish,
         hasExplicitCommitish,
         filterByCommitish,
-        finalizeRelease: input.releaseId ? draftRelease : null,
+        finalizeRelease: preparedRelease,
       })
       if (pinnedSha) {
         resolvedSha = pinnedSha
@@ -202,7 +217,7 @@ module.exports = (app, { getRouter }) => {
     // Separate explicit user input from draft release version:
     // - overrideVersion: explicit user input via action arg (always wins, skips calculations)
     // - draftVersion: extracted from draft release (acts as floor vs computed version)
-    const overrideVersion = version
+    let overrideVersion = version
     let draftVersion
 
     if (draftRelease) {
@@ -253,6 +268,23 @@ module.exports = (app, { getRouter }) => {
       }
     }
 
+    // On a `prepared-release-id` finalize the targeted release is the source of
+    // truth: reuse the version, tag, and prerelease state frozen by the earlier
+    // pass rather than recomputing them (recomputing could drift if a release
+    // landed in between). Inputs that would recompute these are rejected up
+    // front (see getPreparedReleaseConflict), so nothing here is overridden.
+    let effectiveTag = tag
+    let effectiveIsPreRelease = prerelease
+    if (preparedRelease) {
+      if (draftVersion) {
+        overrideVersion = draftVersion
+      }
+      if (preparedRelease.tag_name) {
+        effectiveTag = preparedRelease.tag_name
+      }
+      effectiveIsPreRelease = Boolean(preparedRelease.prerelease)
+    }
+
     const releaseInfo = generateReleaseInfo({
       context,
       commits,
@@ -261,9 +293,9 @@ module.exports = (app, { getRouter }) => {
       mergedPullRequests: sortedMergedPullRequests,
       overrideVersion,
       draftVersion,
-      tag,
+      tag: effectiveTag,
       name,
-      isPreRelease: prerelease,
+      isPreRelease: effectiveIsPreRelease,
       latest,
       shouldDraft,
       targetCommitish,
@@ -388,7 +420,7 @@ function getInput() {
     shouldDraft: core.getInput('publish').toLowerCase() !== 'true',
     version: core.getInput('version') || undefined,
     tag: core.getInput('tag') || undefined,
-    releaseId: core.getInput('release-id') || undefined,
+    preparedReleaseId: core.getInput('prepared-release-id') || undefined,
     name: core.getInput('name') || undefined,
     dryRun: core.getInput('dry-run').toLowerCase() === 'true',
     localGitRoot: core.getInput('local-git-root') || undefined,
@@ -411,6 +443,40 @@ function getInput() {
         ? core.getInput('allow-major-bumps').toLowerCase() === 'true'
         : undefined,
   }
+}
+
+/**
+ * `prepared-release-id` finalizes an already-prepared release: its version,
+ * tag, prerelease state, and target commit are the frozen source of truth. Any
+ * input that would recompute or re-select those values is therefore
+ * incompatible — passing it would either be silently ignored or reintroduce the
+ * cross-invocation drift this path exists to prevent. Reject the combination up
+ * front with a clear error rather than resolving the contradiction quietly.
+ * (`filter-by-commitish` is a repo config-file option, not an action input, so
+ * it is a silent no-op here instead — handled where the release is targeted.)
+ * Returns an error message describing the conflict, or `undefined` when clear.
+ */
+function getPreparedReleaseConflict(input) {
+  if (!input.preparedReleaseId) return
+  const incompatible = [
+    ['version', input.version],
+    ['tag', input.tag],
+    ['commitish', input.commitish],
+    ['base-ref-override', input.baseRefOverride],
+    ['base-version-override', input.baseVersionOverride],
+    ['prerelease', input.prerelease],
+    ['prerelease-identifier', input.preReleaseIdentifier],
+    ['allow-major-bumps', input.allowMajorBumps],
+  ]
+    .filter(([, value]) => value !== undefined)
+    .map(([name]) => name)
+  if (incompatible.length === 0) return
+  return (
+    `prepared-release-id targets an already-prepared release as the source of ` +
+    `truth, so the following input(s) are incompatible and must not be set ` +
+    `alongside it: ${incompatible.join(', ')}. Remove them; their values are ` +
+    `taken from the prepared release.`
+  )
 }
 
 /**
@@ -510,9 +576,10 @@ const FULL_SHA_REGEX = /^[\da-f]{40}$/i
  * Resolves the release target to a fixed, point-in-time commit SHA so the
  * release can be pinned to exactly what this run evaluated (immune to the
  * branch moving between invocations). Resolution order, highest priority first:
- *   1. The finalize target's own `target_commitish`, when a `release-id` pass
- *      resolved a release already pinned to a SHA — reuses the commit frozen by
- *      the earlier invocation so the finalize re-evaluates the same snapshot.
+ *   1. The finalize target's own `target_commitish`, when a `prepared-release-id`
+ *      pass resolved a release already pinned to a SHA — reuses the commit
+ *      frozen by the earlier invocation so the finalize re-evaluates the same
+ *      snapshot.
  *   2. `targetCommitish`, when it is itself a SHA (an explicit `commitish` SHA).
  *   3. `GITHUB_SHA` — the exact commit that triggered this run, when it is a
  *      valid 40-hex SHA (i.e. running in GitHub Actions) — but only on the
@@ -522,9 +589,10 @@ const FULL_SHA_REGEX = /^[\da-f]{40}$/i
  * `commitish` is set (opt-out) or when `filter-by-commitish` is enabled — that
  * feature matches releases by branch name, so writing a SHA into
  * `target_commitish` would break selection on later runs. That opt-out is
- * itself skipped on a `release-id` finalize (`finalizeRelease` present): the
- * release is targeted by a deterministic point-read, so `filter-by-commitish`
- * (a list-selection heuristic) is moot for it and must not suppress the pin.
+ * itself skipped on a `prepared-release-id` finalize (`finalizeRelease`
+ * present): the release is targeted by a deterministic point-read, so
+ * `filter-by-commitish` (a list-selection heuristic) is moot for it and must
+ * not suppress the pin.
  */
 function resolveTargetSha({
   targetCommitish,

--- a/index.js
+++ b/index.js
@@ -521,7 +521,10 @@ const FULL_SHA_REGEX = /^[\da-f]{40}$/i
  * intact. The auto-pin (case 3) is deliberately skipped when an explicit branch
  * `commitish` is set (opt-out) or when `filter-by-commitish` is enabled — that
  * feature matches releases by branch name, so writing a SHA into
- * `target_commitish` would break selection on later runs.
+ * `target_commitish` would break selection on later runs. That opt-out is
+ * itself skipped on a `release-id` finalize (`finalizeRelease` present): the
+ * release is targeted by a deterministic point-read, so `filter-by-commitish`
+ * (a list-selection heuristic) is moot for it and must not suppress the pin.
  */
 function resolveTargetSha({
   targetCommitish,
@@ -536,9 +539,10 @@ function resolveTargetSha({
   if (FULL_SHA_REGEX.test(targetCommitish)) {
     return targetCommitish
   }
+  const isReleaseIdFinalize = Boolean(finalizeRelease)
   if (
     !hasExplicitCommitish &&
-    !filterByCommitish &&
+    (!filterByCommitish || isReleaseIdFinalize) &&
     FULL_SHA_REGEX.test(process.env.GITHUB_SHA || '')
   ) {
     return process.env.GITHUB_SHA

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -30,6 +30,35 @@ const sortReleases = (releases, tagPrefix) => {
 // GitHub API currently returns a 500 HTTP response if you attempt to fetch over 1000 releases.
 const RELEASE_COUNT_LIMIT = 1000
 
+// Fetch a single release directly by its numeric ID. This is a strongly
+// consistent point-read, unlike the list-releases endpoint, so it reliably
+// resolves a release created moments earlier. Returns `null` on 404.
+const getReleaseById = async ({ context, releaseId }) => {
+  const id = Number.parseInt(releaseId, 10)
+  if (!Number.isInteger(id)) {
+    throw new TypeError(
+      `Invalid release-id "${releaseId}": expected a numeric ID.`
+    )
+  }
+
+  try {
+    const { data } = await context.octokit.repos.getRelease(
+      context.repo({ release_id: id })
+    )
+    log({
+      context,
+      message: `Fetched release by id ${id}: ${data.tag_name || data.name}`,
+    })
+    return data
+  } catch (error) {
+    if (error.status === 404) {
+      log({ context, message: `No release found for release-id ${id}` })
+      return null
+    }
+    throw error
+  }
+}
+
 const findReleases = async ({
   context,
   targetCommitish,
@@ -374,6 +403,7 @@ function updateDraftReleaseParameters(parameters) {
 }
 
 exports.findReleases = findReleases
+exports.getReleaseById = getReleaseById
 exports.generateChangeLog = generateChangeLog
 exports.generateReleaseInfo = generateReleaseInfo
 exports.createRelease = createRelease

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -35,12 +35,12 @@ const RELEASE_COUNT_LIMIT = 1000
 // resolves a release created moments earlier. Returns `null` on 404.
 const getReleaseById = async ({ context, releaseId }) => {
   const raw = String(releaseId).trim()
-  if (!/^\d+$/.test(raw)) {
+  const id = Number.parseInt(raw, 10)
+  if (!/^\d+$/.test(raw) || id <= 0) {
     throw new TypeError(
       `Invalid release-id "${releaseId}": expected a positive integer ID.`
     )
   }
-  const id = Number.parseInt(raw, 10)
 
   try {
     const { data } = await context.octokit.repos.getRelease(

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -34,12 +34,13 @@ const RELEASE_COUNT_LIMIT = 1000
 // consistent point-read, unlike the list-releases endpoint, so it reliably
 // resolves a release created moments earlier. Returns `null` on 404.
 const getReleaseById = async ({ context, releaseId }) => {
-  const id = Number.parseInt(releaseId, 10)
-  if (!Number.isInteger(id)) {
+  const raw = String(releaseId).trim()
+  if (!/^\d+$/.test(raw)) {
     throw new TypeError(
-      `Invalid release-id "${releaseId}": expected a numeric ID.`
+      `Invalid release-id "${releaseId}": expected a positive integer ID.`
     )
   }
+  const id = Number.parseInt(raw, 10)
 
   try {
     const { data } = await context.octokit.repos.getRelease(

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -38,7 +38,7 @@ const getReleaseById = async ({ context, releaseId }) => {
   const id = Number.parseInt(raw, 10)
   if (!/^\d+$/.test(raw) || id <= 0) {
     throw new TypeError(
-      `Invalid release-id "${releaseId}": expected a positive integer ID.`
+      `Invalid prepared-release-id "${releaseId}": expected a positive integer ID.`
     )
   }
 
@@ -53,7 +53,10 @@ const getReleaseById = async ({ context, releaseId }) => {
     return data
   } catch (error) {
     if (error.status === 404) {
-      log({ context, message: `No release found for release-id ${id}` })
+      log({
+        context,
+        message: `No release found for prepared-release-id ${id}`,
+      })
       return null
     }
     throw error

--- a/test/fixtures/config/config-filter-by-commitish.yml
+++ b/test/fixtures/config/config-filter-by-commitish.yml
@@ -1,0 +1,2 @@
+filter-by-commitish: true
+template: 'dummy'

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3996,5 +3996,105 @@ describe('release-drafter', () => {
         expect.assertions(1)
       })
     })
+
+    describe('with release-id input', () => {
+      it('finalizes by fetching the release directly by id and updating it, bypassing list discovery', async () => {
+        let restoreEnvironment = mockedEnv({
+          'INPUT_RELEASE-ID': '11691725',
+          INPUT_VERSION: '3.0.0',
+        })
+
+        getConfigMock()
+
+        // The list read is used only for `lastRelease`; it contains NO draft
+        // (and a different id), proving finalize does not depend on it.
+        const publishedRelease = {
+          ...releasePayload,
+          id: 999,
+          draft: false,
+        }
+
+        nock('https://api.github.com')
+          .get('/repos/toolmantim/release-drafter-test-project/releases')
+          .query(true)
+          .reply(200, [publishedRelease])
+
+        // Strongly consistent point-read resolves the just-created draft.
+        nock('https://api.github.com')
+          .get(
+            '/repos/toolmantim/release-drafter-test-project/releases/11691725'
+          )
+          .reply(200, releaseDrafterFixture)
+
+        nock('https://api.github.com')
+          .post('/graphql', (body) =>
+            body.query.includes('query findCommitsWithAssociatedPullRequests')
+          )
+          .reply(200, graphqlCommitsMergeCommit)
+
+        nock('https://api.github.com')
+          .patch(
+            '/repos/toolmantim/release-drafter-test-project/releases/11691725',
+            (body) => {
+              expect(body.draft).toBe(true)
+              return true
+            }
+          )
+          .reply(200, releaseDrafterFixture)
+
+        await probot.receive({
+          name: 'push',
+          payload: pushPayload,
+        })
+
+        expect.assertions(1)
+
+        restoreEnvironment()
+      })
+
+      it('falls back to list-based discovery when release-id does not resolve', async () => {
+        let restoreEnvironment = mockedEnv({
+          'INPUT_RELEASE-ID': '424242',
+          INPUT_VERSION: '3.0.0',
+        })
+
+        getConfigMock()
+
+        nock('https://api.github.com')
+          .get('/repos/toolmantim/release-drafter-test-project/releases')
+          .query(true)
+          .reply(200, [releaseDrafterFixture])
+
+        // Point-read 404s -> action warns and keeps the draft found via the list.
+        nock('https://api.github.com')
+          .get('/repos/toolmantim/release-drafter-test-project/releases/424242')
+          .reply(404, {})
+
+        nock('https://api.github.com')
+          .post('/graphql', (body) =>
+            body.query.includes('query findCommitsWithAssociatedPullRequests')
+          )
+          .reply(200, graphqlCommitsMergeCommit)
+
+        nock('https://api.github.com')
+          .patch(
+            '/repos/toolmantim/release-drafter-test-project/releases/11691725',
+            (body) => {
+              expect(body.draft).toBe(true)
+              return true
+            }
+          )
+          .reply(200, releaseDrafterFixture)
+
+        await probot.receive({
+          name: 'push',
+          payload: pushPayload,
+        })
+
+        expect.assertions(1)
+
+        restoreEnvironment()
+      })
+    })
   })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4203,6 +4203,55 @@ describe('release-drafter', () => {
 
         restoreEnvironment()
       })
+
+      it('does not pin (or output resolved-sha) when filter-by-commitish is enabled', async () => {
+        const sha = '1496a1f82f32f240f7cbe1a42eb0b0c7a06a5093'
+        let restoreEnvironment = mockedEnv({
+          GITHUB_ACTIONS: 'true',
+          GITHUB_SHA: sha,
+        })
+        const setOutputSpy = jest
+          .spyOn(core, 'setOutput')
+          .mockImplementation(() => {})
+
+        getConfigMock('config-filter-by-commitish.yml')
+
+        nock('https://api.github.com')
+          .get('/repos/toolmantim/release-drafter-test-project/releases')
+          .query(true)
+          .reply(200, [releaseDrafterFixture])
+
+        nock('https://api.github.com')
+          .post('/graphql', (body) =>
+            body.query.includes('query findCommitsWithAssociatedPullRequests')
+          )
+          .reply(200, graphqlCommitsMergeCommit)
+
+        // The release keeps its branch ref — pinning a SHA would break
+        // branch-name matching on later `filter-by-commitish` runs.
+        nock('https://api.github.com')
+          .patch(
+            '/repos/toolmantim/release-drafter-test-project/releases/11691725',
+            (body) => {
+              expect(/^[\da-f]{40}$/i.test(body.target_commitish)).toBe(false)
+              return true
+            }
+          )
+          .reply(200, releaseDrafterFixture)
+
+        await probot.receive({
+          name: 'push',
+          payload: pushPayload,
+        })
+
+        expect(setOutputSpy).not.toHaveBeenCalledWith(
+          'resolved-sha',
+          expect.anything()
+        )
+        expect.assertions(2)
+
+        restoreEnvironment()
+      })
     })
   })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4252,6 +4252,61 @@ describe('release-drafter', () => {
 
         restoreEnvironment()
       })
+
+      it('still pins on a release-id finalize even when filter-by-commitish is enabled', async () => {
+        const sha = '1496a1f82f32f240f7cbe1a42eb0b0c7a06a5093'
+        let restoreEnvironment = mockedEnv({
+          'INPUT_RELEASE-ID': '11691725',
+          GITHUB_ACTIONS: 'true',
+          GITHUB_SHA: sha,
+        })
+        const setOutputSpy = jest
+          .spyOn(core, 'setOutput')
+          .mockImplementation(() => {})
+
+        getConfigMock('config-filter-by-commitish.yml')
+
+        nock('https://api.github.com')
+          .get('/repos/toolmantim/release-drafter-test-project/releases')
+          .query(true)
+          .reply(200, [releaseDrafterFixture])
+
+        // Point-read target is still on its branch ref (an earlier
+        // filter-by-commitish pass didn't freeze it).
+        nock('https://api.github.com')
+          .get(
+            '/repos/toolmantim/release-drafter-test-project/releases/11691725'
+          )
+          .reply(200, releaseDrafterFixture)
+
+        nock('https://api.github.com')
+          .post('/graphql', (body) =>
+            body.query.includes('query findCommitsWithAssociatedPullRequests')
+          )
+          .reply(200, graphqlCommitsMergeCommit)
+
+        // release-id targets the release deterministically, so filter-by-commitish
+        // is moot for it — the pin is applied rather than suppressed.
+        nock('https://api.github.com')
+          .patch(
+            '/repos/toolmantim/release-drafter-test-project/releases/11691725',
+            (body) => {
+              expect(body.target_commitish).toBe(sha)
+              return true
+            }
+          )
+          .reply(200, releaseDrafterFixture)
+
+        await probot.receive({
+          name: 'push',
+          payload: pushPayload,
+        })
+
+        expect(setOutputSpy).toHaveBeenCalledWith('resolved-sha', sha)
+        expect.assertions(2)
+
+        restoreEnvironment()
+      })
     })
   })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,6 +2,7 @@ const nock = require('nock')
 const { Probot, ProbotOctokit } = require('probot')
 const { configFixture, getConfigMock } = require('./helpers/config-mock')
 const releaseDrafter = require('../index')
+const core = require('@actions/core')
 const mockedEnv = require('mocked-env')
 const pino = require('pino')
 const Stream = require('node:stream')
@@ -4092,6 +4093,113 @@ describe('release-drafter', () => {
         })
 
         expect.assertions(1)
+
+        restoreEnvironment()
+      })
+    })
+
+    describe('with resolved SHA pinning', () => {
+      it('pins the release target_commitish to GITHUB_SHA and outputs resolved-sha', async () => {
+        const sha = '1496a1f82f32f240f7cbe1a42eb0b0c7a06a5093'
+        let restoreEnvironment = mockedEnv({
+          GITHUB_ACTIONS: 'true',
+          GITHUB_SHA: sha,
+        })
+        const setOutputSpy = jest
+          .spyOn(core, 'setOutput')
+          .mockImplementation(() => {})
+
+        getConfigMock()
+
+        // Existing draft discovered via the list; it will be updated in place.
+        nock('https://api.github.com')
+          .get('/repos/toolmantim/release-drafter-test-project/releases')
+          .query(true)
+          .reply(200, [releaseDrafterFixture])
+
+        nock('https://api.github.com')
+          .post('/graphql', (body) =>
+            body.query.includes('query findCommitsWithAssociatedPullRequests')
+          )
+          .reply(200, graphqlCommitsMergeCommit)
+
+        // The release is pinned to the exact commit that triggered the run.
+        nock('https://api.github.com')
+          .patch(
+            '/repos/toolmantim/release-drafter-test-project/releases/11691725',
+            (body) => {
+              expect(body.target_commitish).toBe(sha)
+              return true
+            }
+          )
+          .reply(200, releaseDrafterFixture)
+
+        await probot.receive({
+          name: 'push',
+          payload: pushPayload,
+        })
+
+        expect(setOutputSpy).toHaveBeenCalledWith('resolved-sha', sha)
+        expect.assertions(2)
+
+        restoreEnvironment()
+      })
+
+      it('reuses the finalize target release\u2019s frozen SHA over GITHUB_SHA', async () => {
+        const frozenSha = 'ca068ecaa5373b170c571b3da6155b30b78ef481'
+        const headSha = '1496a1f82f32f240f7cbe1a42eb0b0c7a06a5093'
+        let restoreEnvironment = mockedEnv({
+          'INPUT_RELEASE-ID': '11691725',
+          INPUT_VERSION: '3.0.0',
+          GITHUB_ACTIONS: 'true',
+          GITHUB_SHA: headSha,
+        })
+        const setOutputSpy = jest
+          .spyOn(core, 'setOutput')
+          .mockImplementation(() => {})
+
+        getConfigMock()
+
+        // List is consulted only for `lastRelease`.
+        nock('https://api.github.com')
+          .get('/repos/toolmantim/release-drafter-test-project/releases')
+          .query(true)
+          .reply(200, [releasePayload])
+
+        // Point-read returns the release the earlier pass froze to `frozenSha`.
+        nock('https://api.github.com')
+          .get(
+            '/repos/toolmantim/release-drafter-test-project/releases/11691725'
+          )
+          .reply(200, {
+            ...releaseDrafterFixture,
+            target_commitish: frozenSha,
+          })
+
+        nock('https://api.github.com')
+          .post('/graphql', (body) =>
+            body.query.includes('query findCommitsWithAssociatedPullRequests')
+          )
+          .reply(200, graphqlCommitsMergeCommit)
+
+        // Finalize re-pins to the frozen SHA, not the run's HEAD SHA.
+        nock('https://api.github.com')
+          .patch(
+            '/repos/toolmantim/release-drafter-test-project/releases/11691725',
+            (body) => {
+              expect(body.target_commitish).toBe(frozenSha)
+              return true
+            }
+          )
+          .reply(200, releaseDrafterFixture)
+
+        await probot.receive({
+          name: 'push',
+          payload: pushPayload,
+        })
+
+        expect(setOutputSpy).toHaveBeenCalledWith('resolved-sha', frozenSha)
+        expect.assertions(2)
 
         restoreEnvironment()
       })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3998,11 +3998,10 @@ describe('release-drafter', () => {
       })
     })
 
-    describe('with release-id input', () => {
+    describe('with prepared-release-id input', () => {
       it('finalizes by fetching the release directly by id and updating it, bypassing list discovery', async () => {
         let restoreEnvironment = mockedEnv({
-          'INPUT_RELEASE-ID': '11691725',
-          INPUT_VERSION: '3.0.0',
+          'INPUT_PREPARED-RELEASE-ID': '11691725',
         })
 
         getConfigMock()
@@ -4053,10 +4052,9 @@ describe('release-drafter', () => {
         restoreEnvironment()
       })
 
-      it('falls back to list-based discovery when release-id does not resolve', async () => {
+      it('falls back to list-based discovery when prepared-release-id does not resolve', async () => {
         let restoreEnvironment = mockedEnv({
-          'INPUT_RELEASE-ID': '424242',
-          INPUT_VERSION: '3.0.0',
+          'INPUT_PREPARED-RELEASE-ID': '424242',
         })
 
         getConfigMock()
@@ -4094,6 +4092,34 @@ describe('release-drafter', () => {
 
         expect.assertions(1)
 
+        restoreEnvironment()
+      })
+
+      it('fails when an incompatible input is set alongside prepared-release-id', async () => {
+        let restoreEnvironment = mockedEnv({
+          'INPUT_PREPARED-RELEASE-ID': '11691725',
+          INPUT_VERSION: '3.0.0',
+        })
+        const setFailedSpy = jest
+          .spyOn(core, 'setFailed')
+          .mockImplementation(() => {})
+
+        // No API is mocked: the conflict is caught before any release lookup,
+        // so the run must short-circuit without touching the GitHub API.
+        await probot.receive({
+          name: 'push',
+          payload: pushPayload,
+        })
+
+        expect(setFailedSpy).toHaveBeenCalledWith(
+          expect.stringContaining('version')
+        )
+        expect(setFailedSpy).toHaveBeenCalledWith(
+          expect.stringContaining('prepared-release-id')
+        )
+        expect.assertions(2)
+
+        setFailedSpy.mockRestore()
         restoreEnvironment()
       })
     })
@@ -4149,8 +4175,7 @@ describe('release-drafter', () => {
         const frozenSha = 'ca068ecaa5373b170c571b3da6155b30b78ef481'
         const headSha = '1496a1f82f32f240f7cbe1a42eb0b0c7a06a5093'
         let restoreEnvironment = mockedEnv({
-          'INPUT_RELEASE-ID': '11691725',
-          INPUT_VERSION: '3.0.0',
+          'INPUT_PREPARED-RELEASE-ID': '11691725',
           GITHUB_ACTIONS: 'true',
           GITHUB_SHA: headSha,
         })
@@ -4253,10 +4278,10 @@ describe('release-drafter', () => {
         restoreEnvironment()
       })
 
-      it('still pins on a release-id finalize even when filter-by-commitish is enabled', async () => {
+      it('still pins on a prepared-release-id finalize even when filter-by-commitish is enabled', async () => {
         const sha = '1496a1f82f32f240f7cbe1a42eb0b0c7a06a5093'
         let restoreEnvironment = mockedEnv({
-          'INPUT_RELEASE-ID': '11691725',
+          'INPUT_PREPARED-RELEASE-ID': '11691725',
           GITHUB_ACTIONS: 'true',
           GITHUB_SHA: sha,
         })
@@ -4285,7 +4310,7 @@ describe('release-drafter', () => {
           )
           .reply(200, graphqlCommitsMergeCommit)
 
-        // release-id targets the release deterministically, so filter-by-commitish
+        // prepared-release-id targets the release deterministically, so filter-by-commitish
         // is moot for it — the pin is applied rather than suppressed.
         nock('https://api.github.com')
           .patch(


### PR DESCRIPTION
## Summary

Fixes #56, and adds a point-in-time commit pin so a slow multi-step release can't drift.

**Part 1 — durable finalize (`prepared-release-id`).** In the two-step (`not-ready` → build → finalize) pattern, finalize re-discovered its draft by **listing** releases. `GET /releases` is eventually consistent, so a draft created seconds earlier can be missing from the next step's list → the action logs `No draft release found` → `Creating new release`, producing a **duplicate** draft while CI stays green. The new `prepared-release-id` input resolves the target via a strongly consistent **point-read** (`GET /releases/{id}`) and updates it in place, bypassing list discovery:

```js
findReleases(...)                        // still runs, for lastRelease / changelog
if (preparedReleaseId) {
  const targeted = await getReleaseById({ context, releaseId })  // GET /releases/{id}
  if (targeted) { draftRelease = targeted; preparedRelease = targeted }  // deterministic target
  else core.warning(...)                 // 404 → fall back to list discovery
}
```

`getReleaseById` validates the id strictly (`^\d+$`, rejects `0`) and returns `null` on 404, so the fallback keeps it backward compatible.

**The prepared release is the source of truth.** On a `prepared-release-id` finalize the release's own frozen values are reused rather than recomputed — so nothing drifts if another release is published between the two steps:

```js
if (preparedRelease) {
  overrideVersion = draftVersion            // pin version from the release (exact, not floor)
  effectiveTag = preparedRelease.tag_name   // reuse its tag
  effectiveIsPreRelease = preparedRelease.prerelease  // reuse its prerelease state
  // target_commitish SHA is likewise reused (see Part 2)
}
```

Because those values come from the release, inputs that would recompute/re-select them are **incompatible** and hard-fail up front (a clear error beats silently ignoring a contradictory input):

```js
// getPreparedReleaseConflict — rejects if any set alongside prepared-release-id:
version, tag, commitish, base-ref-override, base-version-override,
prerelease, prerelease-identifier, allow-major-bumps
```

`filter-by-commitish` is a repo **config-file** option (not an action input), so it's a silent no-op on this path instead of a hard-fail. Still honored (they drive the publish action, not the frozen snapshot): `publish`/`not-ready`, `latest`, `attach-files`/`reset-files`, the name/body/changelog templates, `config-name`, `dry-run`.

**Part 2 — point-in-time SHA pin.** A run can take minutes and `main` can move between invocations, so a naive finalize could walk a different commit range → different version/changelog → finalize a release that no longer matches the artifacts built from pass 1. Now every pass resolves a concrete commit SHA and pins the release to it, and a `prepared-release-id` finalize **reuses** that same SHA rather than re-reading the moving branch:

```js
// resolveTargetSha: precedence for the frozen commit
if (finalizeRelease?.target_commitish is a 40-hex SHA) return it   // reuse pass-1 freeze
if (!hasExplicitCommitish && (!filterByCommitish || isPreparedFinalize) && isSha(GITHUB_SHA))
                                                       return GITHUB_SHA  // freeze branch tip
return undefined   // explicit branch commitish → keep old branch-ref behavior (opt-out)
```

New `resolved-sha` output (emitted in **every** pass — calc/dry-run, create, update, finalize, one-pass) hands the frozen commit to downstream build/inspection steps so they stay in lockstep:

```yaml
- uses: aaronsteers/semantic-pr-release-drafter@v2
  id: draft
  with: { not-ready: true }
- uses: actions/checkout@v4
  with:
    ref: ${{ steps.draft.outputs.resolved-sha }}   # build the exact evaluated commit
```

**Behavior note (provenance only):** pinning means a published release's `target_commitish` REST field reads as a SHA instead of a branch name. The tag name, release page, assets, and the frozen tag→commit that consumers actually use are all unchanged. Opt out on the default path by passing an explicit branch `commitish` (e.g. `commitish: main`); pinning is also skipped automatically when `filter-by-commitish` is enabled (that feature matches releases by branch name, so a SHA would break selection) — except on a `prepared-release-id` finalize, where the release is targeted by point-read and commitish selection is moot.

## Changes

- `action.yml` — new `prepared-release-id` input (documents the source-of-truth + incompatible-inputs contract); new `resolved-sha` output.
- `lib/releases.js` — `getReleaseById` point-read helper (strict validation, `null` on 404).
- `index.js` — `prepared-release-id` point-read override; `getPreparedReleaseConflict` hard-fail guard; reuse version/tag/prerelease/SHA from the prepared release; `resolveTargetSha` freeze logic; emit `resolved-sha`.
- `README.md` — two-step patterns now pass only `prepared-release-id`; document the source-of-truth contract, incompatible inputs, and `resolved-sha`/pinning.
- `dist/index.js` — rebuilt (esbuild).

## Testing

- `yarn lint` clean; `yarn test` → 271 passing.
- New/updated tests: (1) finalize by `prepared-release-id` updates via point-read while the list has no visible draft; (2) 404 warns + falls back to list discovery; (3) hard-fail when an incompatible input (`version`) is passed alongside `prepared-release-id`, short-circuiting before any API call; (4) pin `target_commitish` to `GITHUB_SHA` and emit `resolved-sha`; (5) `prepared-release-id` finalize reuses the fetched release's frozen SHA over the run's HEAD SHA; (6) `filter-by-commitish` disables pinning on the default path (no SHA written); (7) `filter-by-commitish` does NOT disable pinning on a `prepared-release-id` finalize.

## Note on CONTRIBUTING integration-test rule

`CONTRIBUTING.md` requires a matrix entry in the integration workflow for new features, but that harness (`e2e-smoke-tests.yml`) runs only in `dry-run` + `local-git-root` mode, and these code paths execute only in the standard GitHub API branch — so they're covered by unit tests instead. (`CONTRIBUTING.md` also still references the old `integration-tests.yml` filename.)

Link to Devin session: https://app.devin.ai/sessions/c5aa9e420587440b9e2e5f4e92f65383
Requested by: @aaronsteers