### PR TITLE
feat(not-ready): render active workflow run URL in the banner

### DIFF
--- a/.github/workflows/e2e-smoke-tests.yml
+++ b/.github/workflows/e2e-smoke-tests.yml
@@ -381,6 +381,8 @@ jobs:
               > **NOT READY FOR PUBLISHING**
               >
               > This release draft is still being prepared. Do not publish until this banner is removed.
+              >
+              > [View the workflow run preparing this release](RUN_URL)
 
               ## Features
 
@@ -652,6 +654,9 @@ jobs:
 
           # Strip the admin metadata comment (appended by the action on every run)
           BODY=$(echo "$BODY" | sed '/^<!-- Release drafted at .* -->$/d')
+
+          # Normalize the dynamic workflow run URL in the not-ready banner
+          BODY=$(echo "$BODY" | sed -E 's#\(https://[^)]*/actions/runs/[0-9]+\)#(RUN_URL)#')
 
           # Normalize whitespace for comparison (trim leading/trailing, normalize newlines)
           BODY_NORMALIZED=$(echo "$BODY" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr -s '\n')

--- a/README.md
+++ b/README.md
@@ -861,6 +861,8 @@ In some cases, you may need to resolve the version string before building. In su
 
 Use the `not-ready` input to prevent admins from prematurely publishing a draft while assets are still being prepared. The `not-ready` input accepts `'true'` (default banner) or a custom string (used as the banner message). When set, a visible `> [!CAUTION]` banner is prepended to the release body.
 
+When running in GitHub Actions, the banner also links to the active workflow run (`$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID`) so admins can jump straight to the run that is preparing the release. The link is added automatically for both the default and custom banner messages, and is omitted when those environment variables are unavailable (e.g. running locally).
+
 Since each run regenerates the body from scratch, calling the action without `not-ready` automatically removes the banner.
 
 > [!IMPORTANT]

--- a/dist/index.js
+++ b/dist/index.js
@@ -154534,11 +154534,15 @@ var require_index = __commonJS({
         });
         if (notReady) {
           const bannerMessage = typeof notReady === "string" ? notReady : "This release draft is still being prepared. Do not publish until this banner is removed.";
+          const runUrl = getWorkflowRunUrl();
+          const runUrlLine = runUrl ? `>
+> [View the workflow run preparing this release](${runUrl})
+` : "";
           releaseInfo.body = `> [!CAUTION]
 > **NOT READY FOR PUBLISHING**
 >
 > ${bannerMessage}
-
+` + runUrlLine + `
 ` + releaseInfo.body;
         }
         const pacificTimestamp = formatPacificTimestamp(/* @__PURE__ */ new Date());
@@ -154779,6 +154783,13 @@ var require_index = __commonJS({
       const sha = process.env.GITHUB_SHA;
       if (!repository || !sha) return null;
       return `${serverUrl}/${repository}/commit/${sha}`;
+    }
+    function getWorkflowRunUrl() {
+      const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
+      const repository = process.env.GITHUB_REPOSITORY;
+      const runId = process.env.GITHUB_RUN_ID;
+      if (!repository || !runId) return null;
+      return `${serverUrl}/${repository}/actions/runs/${runId}`;
     }
   }
 });

--- a/index.js
+++ b/index.js
@@ -307,11 +307,17 @@ module.exports = (app, { getRouter }) => {
         typeof notReady === 'string'
           ? notReady
           : 'This release draft is still being prepared. Do not publish until this banner is removed.'
+      const runUrl = getWorkflowRunUrl()
+      const runUrlLine = runUrl
+        ? `>\n> [View the workflow run preparing this release](${runUrl})\n`
+        : ''
       releaseInfo.body =
         `> [!CAUTION]\n` +
         `> **NOT READY FOR PUBLISHING**\n` +
         `>\n` +
-        `> ${bannerMessage}\n\n` +
+        `> ${bannerMessage}\n` +
+        runUrlLine +
+        `\n` +
         releaseInfo.body
     }
 
@@ -668,4 +674,16 @@ function getCommitUrl() {
   const sha = process.env.GITHUB_SHA
   if (!repository || !sha) return null
   return `${serverUrl}/${repository}/commit/${sha}`
+}
+
+/**
+ * Builds the active workflow run URL from GitHub Actions environment variables.
+ * Returns `null` when not running in GitHub Actions.
+ */
+function getWorkflowRunUrl() {
+  const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com'
+  const repository = process.env.GITHUB_REPOSITORY
+  const runId = process.env.GITHUB_RUN_ID
+  if (!repository || !runId) return null
+  return `${serverUrl}/${repository}/actions/runs/${runId}`
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3881,6 +3881,93 @@ describe('release-drafter', () => {
         restoreEnvironment()
       })
 
+      it('renders the active workflow run URL in the banner when running in GitHub Actions', async () => {
+        let restoreEnvironment = mockedEnv({
+          'INPUT_NOT-READY': 'true',
+          GITHUB_SERVER_URL: 'https://github.com',
+          GITHUB_REPOSITORY: 'toolmantim/release-drafter-test-project',
+          GITHUB_RUN_ID: '123456789',
+        })
+
+        getConfigMock()
+
+        nock('https://api.github.com')
+          .get(
+            '/repos/toolmantim/release-drafter-test-project/releases?per_page=100'
+          )
+          .reply(200, [releasePayload])
+
+        nock('https://api.github.com')
+          .post('/graphql', (body) =>
+            body.query.includes('query findCommitsWithAssociatedPullRequests')
+          )
+          .reply(200, graphqlCommitsMergeCommit)
+
+        nock('https://api.github.com')
+          .post(
+            '/repos/toolmantim/release-drafter-test-project/releases',
+            (body) => {
+              expect(body.body).toContain('> **NOT READY FOR PUBLISHING**')
+              expect(body.body).toContain(
+                '> [View the workflow run preparing this release](https://github.com/toolmantim/release-drafter-test-project/actions/runs/123456789)'
+              )
+              return true
+            }
+          )
+          .reply(200, releasePayload)
+
+        await probot.receive({
+          name: 'push',
+          payload: pushPayload,
+        })
+
+        expect.assertions(2)
+
+        restoreEnvironment()
+      })
+
+      it('omits the run URL line when not running in GitHub Actions', async () => {
+        let restoreEnvironment = mockedEnv({
+          'INPUT_NOT-READY': 'true',
+        })
+
+        getConfigMock()
+
+        nock('https://api.github.com')
+          .get(
+            '/repos/toolmantim/release-drafter-test-project/releases?per_page=100'
+          )
+          .reply(200, [releasePayload])
+
+        nock('https://api.github.com')
+          .post('/graphql', (body) =>
+            body.query.includes('query findCommitsWithAssociatedPullRequests')
+          )
+          .reply(200, graphqlCommitsMergeCommit)
+
+        nock('https://api.github.com')
+          .post(
+            '/repos/toolmantim/release-drafter-test-project/releases',
+            (body) => {
+              expect(body.body).toContain('> **NOT READY FOR PUBLISHING**')
+              expect(body.body).not.toContain(
+                'View the workflow run preparing this release'
+              )
+              return true
+            }
+          )
+          .reply(200, releasePayload)
+
+        await probot.receive({
+          name: 'push',
+          payload: pushPayload,
+        })
+
+        expect.assertions(2)
+
+        restoreEnvironment()
+      })
+
       it('prepends custom banner when not-ready is a custom string', async () => {
         let restoreEnvironment = mockedEnv({
           'INPUT_NOT-READY': 'Assets are still being uploaded. Please wait.',


### PR DESCRIPTION
## Summary

When the `not-ready` banner is rendered in GitHub Actions, it now also links to the **active workflow run** so admins can jump straight to the run that is preparing the release. This lands the upstream half of AJ's request; the ops repo then adopts the two-stage (`not-ready` → build → `prepared-release-id` finalize) flow.

The link is derived from the standard Actions env vars and added for both the default and custom banner messages. It is omitted (with no empty line) when those env vars are unavailable (e.g. running locally), so behavior outside Actions is unchanged.

```js
// index.js — inside the `if (notReady)` block
const runUrl = getWorkflowRunUrl()
const runUrlLine = runUrl
  ? `>\n> [View the workflow run preparing this release](${runUrl})\n`
  : ''
releaseInfo.body =
  `> [!CAUTION]\n` +
  `> **NOT READY FOR PUBLISHING**\n>\n` +
  `> ${bannerMessage}\n` +
  runUrlLine + `\n` +
  releaseInfo.body

// new helper (mirrors getCommitUrl)
function getWorkflowRunUrl() {
  const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com'
  const repository = process.env.GITHUB_REPOSITORY
  const runId = process.env.GITHUB_RUN_ID
  if (!repository || !runId) return null
  return `${serverUrl}/${repository}/actions/runs/${runId}`
}
```

Rendered banner (in Actions):

```
> [!CAUTION]
> **NOT READY FOR PUBLISHING**
>
> This release draft is still being prepared. Do not publish until this banner is removed.
>
> [View the workflow run preparing this release](https://github.com/OWNER/REPO/actions/runs/123456789)
```

## Changes
- `index.js`: add `getWorkflowRunUrl()` and append the run-URL line to the `not-ready` banner.
- `dist/index.js`: rebuilt bundle (surgical edit to keep the diff minimal).
- `test/index.test.js`: two new tests — renders the run URL when in Actions, omits the line when not.
- `README.md`: document the auto-added run-URL link under the Safe Release Workflow section.

## Test plan
- `yarn test` (or `npm test`): 273 passing, including the two new not-ready cases.
- `yarn lint`: clean.


Link to Devin session: https://app.devin.ai/sessions/75369861ab7c4a79879856ab6e0bc782
Requested by: @aaronsteers