### PR TITLE
fix: ignore-with-warning prepared-release-id inputs instead of failing

### DIFF
--- a/.github/workflows/e2e-smoke-tests.yml
+++ b/.github/workflows/e2e-smoke-tests.yml
@@ -656,7 +656,8 @@ jobs:
           BODY=$(echo "$BODY" | sed '/^<!-- Release drafted at .* -->$/d')
 
           # Normalize the dynamic workflow run URL in the not-ready banner
-          BODY=$(echo "$BODY" | sed -E 's#\(https://[^)]*/actions/runs/[0-9]+\)#(RUN_URL)#')
+          # (matches http/https so custom GITHUB_SERVER_URL values, e.g. GHES, are handled)
+          BODY=$(echo "$BODY" | sed -E 's#\(https?://[^)]*/actions/runs/[0-9]+\)#(RUN_URL)#')
 
           # Normalize whitespace for comparison (trim leading/trailing, normalize newlines)
           BODY_NORMALIZED=$(echo "$BODY" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr -s '\n')

--- a/README.md
+++ b/README.md
@@ -882,8 +882,9 @@ Since each run regenerates the body from scratch, calling the action without `no
 > between the two steps. Because those values come from the release, the inputs
 > that would recompute them (`version`, `tag`, `commitish`, `base-ref-override`,
 > `base-version-override`, `prerelease`, `prerelease-identifier`,
-> `allow-major-bumps`) are **incompatible** with `prepared-release-id` and cause
-> the action to fail if set alongside it.
+> `allow-major-bumps`) are **ignored** when set alongside `prepared-release-id` —
+> the action emits a warning naming them and continues, taking their values from
+> the prepared release.
 
 ### Pattern A: Third-party asset attacher
 

--- a/README.md
+++ b/README.md
@@ -861,7 +861,7 @@ In some cases, you may need to resolve the version string before building. In su
 
 Use the `not-ready` input to prevent admins from prematurely publishing a draft while assets are still being prepared. The `not-ready` input accepts `'true'` (default banner) or a custom string (used as the banner message). When set, a visible `> [!CAUTION]` banner is prepended to the release body.
 
-When running in GitHub Actions, the banner also links to the active workflow run (`$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID`) so admins can jump straight to the run that is preparing the release. The link is added automatically for both the default and custom banner messages, and is omitted when those environment variables are unavailable (e.g. running locally).
+When running in GitHub Actions, the banner also links to the active workflow run (`$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID`) so admins can jump straight to the run that is preparing the release. The link is added automatically for both the default and custom banner messages. It requires `$GITHUB_REPOSITORY` and `$GITHUB_RUN_ID` (`$GITHUB_SERVER_URL` defaults to `https://github.com`), so it is omitted when those are unavailable (e.g. running locally).
 
 Since each run regenerates the body from scratch, calling the action without `not-ready` automatically removes the banner.
 

--- a/action.yml
+++ b/action.yml
@@ -154,10 +154,12 @@ inputs:
   allow-major-bumps:
     description: |
       A boolean indicating whether to allow automatic major version bumps.
-      When false or unset (the default behavior), breaking changes will only
-      bump the minor version, following "marketing-aware" semver semantics. When
-      true, breaking changes will trigger a major version bump according to
-      standard semver rules.
+      When false, breaking changes will only bump the minor version, following
+      "marketing-aware" semver semantics. When true, breaking changes will
+      trigger a major version bump according to standard semver rules. When left
+      unset, the behavior defers to the repo config's
+      `version-resolver.no-auto-major`, which itself defaults to the
+      marketing-aware (minor-only) behavior.
       Note: Pre-1.0 versions always bump minor for breaking changes regardless of this setting.
     required: false
   attach-files:

--- a/action.yml
+++ b/action.yml
@@ -154,12 +154,12 @@ inputs:
   allow-major-bumps:
     description: |
       A boolean indicating whether to allow automatic major version bumps.
-      When false (default), breaking changes will only bump the minor version,
-      following "marketing-aware" semver semantics. When true, breaking changes
-      will trigger a major version bump according to standard semver rules.
+      When false or unset (the default behavior), breaking changes will only
+      bump the minor version, following "marketing-aware" semver semantics. When
+      true, breaking changes will trigger a major version bump according to
+      standard semver rules.
       Note: Pre-1.0 versions always bump minor for breaking changes regardless of this setting.
     required: false
-    default: 'false'
   attach-files:
     description: |
       Files to attach to the draft release as assets. Accepts a single file path,
@@ -192,11 +192,11 @@ inputs:
       state, and pinned target commit are reused as-is rather than recomputed,
       so the finalize can't drift if another release is published between the
       steps. Because of this, inputs that would recompute or re-select those
-      values are incompatible and cause the action to fail if set alongside
-      `prepared-release-id`: `version`, `tag`, `commitish`, `base-ref-override`,
-      `base-version-override`, `prerelease`, `prerelease-identifier`, and
-      `allow-major-bumps`. (The `filter-by-commitish` config option is likewise
-      ignored on this path.)
+      values are ignored (a no-op) when set alongside `prepared-release-id`, and
+      the action emits a warning naming them: `version`, `tag`, `commitish`,
+      `base-ref-override`, `base-version-override`, `prerelease`,
+      `prerelease-identifier`, and `allow-major-bumps`. (The `filter-by-commitish`
+      config option is likewise ignored on this path.)
 
       Recommended for the two-step (not-ready -> finalize) pattern: capture
       `id` from the first invocation and pass it here on the finalize call —

--- a/dist/index.js
+++ b/dist/index.js
@@ -154343,12 +154343,10 @@ var require_index = __commonJS({
       }
       const drafter = async (context) => {
         const input = getInput();
-        const ignoredPreparedReleaseInputs = getIgnoredPreparedReleaseInputs(input);
+        const ignoredPreparedReleaseInputs = neutralizeIgnoredPreparedReleaseInputs(input);
         if (ignoredPreparedReleaseInputs.length > 0) {
           core2.warning(
-            `prepared-release-id targets an already-prepared release as the source of truth, so the following input(s) are ignored: ${ignoredPreparedReleaseInputs.join(
-              ", "
-            )}. Their values are taken from the prepared release.`
+            `prepared-release-id is set, so the following input(s) are ignored (no-op): ${ignoredPreparedReleaseInputs.join(", ")}. Their values come from the targeted release.`
           );
         }
         const config = await getConfig({
@@ -154653,18 +154651,22 @@ var require_index = __commonJS({
         allowMajorBumps: core2.getInput("allow-major-bumps") !== "" ? core2.getInput("allow-major-bumps").toLowerCase() === "true" : void 0
       };
     }
-    function getIgnoredPreparedReleaseInputs(input) {
+    function neutralizeIgnoredPreparedReleaseInputs(input) {
       if (!input.preparedReleaseId) return [];
-      return [
-        ["version", input.version],
-        ["tag", input.tag],
-        ["commitish", input.commitish],
-        ["base-ref-override", input.baseRefOverride],
-        ["base-version-override", input.baseVersionOverride],
-        ["prerelease", input.prerelease],
-        ["prerelease-identifier", input.preReleaseIdentifier],
-        ["allow-major-bumps", input.allowMajorBumps]
-      ].filter(([, value]) => value !== void 0).map(([name]) => name);
+      const ignored = [
+        ["version", "version"],
+        ["tag", "tag"],
+        ["commitish", "commitish"],
+        ["base-ref-override", "baseRefOverride"],
+        ["base-version-override", "baseVersionOverride"],
+        ["prerelease", "prerelease"],
+        ["prerelease-identifier", "preReleaseIdentifier"],
+        ["allow-major-bumps", "allowMajorBumps"]
+      ].filter(([, key]) => input[key] !== void 0);
+      for (const [, key] of ignored) {
+        input[key] = void 0;
+      }
+      return ignored.map(([name]) => name);
     }
     function updateConfigFromInput(config, input) {
       if (input.commitish) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -154660,7 +154660,12 @@ var require_index = __commonJS({
         ["base-version-override", input.baseVersionOverride],
         ["prerelease", input.prerelease],
         ["prerelease-identifier", input.preReleaseIdentifier],
-        ["allow-major-bumps", input.allowMajorBumps]
+        // `allow-major-bumps` has a non-empty default ('false') in action.yml, so it
+        // always arrives via getInput and can't be distinguished from an explicit
+        // `false`. Only an explicit `true` expresses intent to influence the (now
+        // frozen) version resolution, so treat only that as a conflict — otherwise
+        // the default would make every prepared-release-id finalize fail.
+        ["allow-major-bumps", input.allowMajorBumps === true ? true : void 0]
       ].filter(([, value]) => value !== void 0).map(([name]) => name);
       if (incompatible.length === 0) return;
       return `prepared-release-id targets an already-prepared release as the source of truth, so the following input(s) are incompatible and must not be set alongside it: ${incompatible.join(", ")}. Remove them; their values are taken from the prepared release.`;

--- a/dist/index.js
+++ b/dist/index.js
@@ -154346,7 +154346,7 @@ var require_index = __commonJS({
         const ignoredPreparedReleaseInputs = neutralizeIgnoredPreparedReleaseInputs(input);
         if (ignoredPreparedReleaseInputs.length > 0) {
           core2.warning(
-            `prepared-release-id is set, so the following input(s) are ignored (no-op): ${ignoredPreparedReleaseInputs.join(", ")}. Their values come from the targeted release.`
+            `prepared-release-id is set, so the following input(s) are ignored (no-op) and will not affect this run: ${ignoredPreparedReleaseInputs.join(", ")}.`
           );
         }
         const config = await getConfig({

--- a/dist/index.js
+++ b/dist/index.js
@@ -154343,10 +154343,13 @@ var require_index = __commonJS({
       }
       const drafter = async (context) => {
         const input = getInput();
-        const preparedReleaseConflict = getPreparedReleaseConflict(input);
-        if (preparedReleaseConflict) {
-          core2.setFailed(preparedReleaseConflict);
-          return;
+        const ignoredPreparedReleaseInputs = getIgnoredPreparedReleaseInputs(input);
+        if (ignoredPreparedReleaseInputs.length > 0) {
+          core2.warning(
+            `prepared-release-id targets an already-prepared release as the source of truth, so the following input(s) are ignored: ${ignoredPreparedReleaseInputs.join(
+              ", "
+            )}. Their values are taken from the prepared release.`
+          );
         }
         const config = await getConfig({
           context,
@@ -154650,9 +154653,9 @@ var require_index = __commonJS({
         allowMajorBumps: core2.getInput("allow-major-bumps") !== "" ? core2.getInput("allow-major-bumps").toLowerCase() === "true" : void 0
       };
     }
-    function getPreparedReleaseConflict(input) {
-      if (!input.preparedReleaseId) return;
-      const incompatible = [
+    function getIgnoredPreparedReleaseInputs(input) {
+      if (!input.preparedReleaseId) return [];
+      return [
         ["version", input.version],
         ["tag", input.tag],
         ["commitish", input.commitish],
@@ -154660,15 +154663,8 @@ var require_index = __commonJS({
         ["base-version-override", input.baseVersionOverride],
         ["prerelease", input.prerelease],
         ["prerelease-identifier", input.preReleaseIdentifier],
-        // `allow-major-bumps` has a non-empty default ('false') in action.yml, so it
-        // always arrives via getInput and can't be distinguished from an explicit
-        // `false`. Only an explicit `true` expresses intent to influence the (now
-        // frozen) version resolution, so treat only that as a conflict — otherwise
-        // the default would make every prepared-release-id finalize fail.
-        ["allow-major-bumps", input.allowMajorBumps === true ? true : void 0]
+        ["allow-major-bumps", input.allowMajorBumps]
       ].filter(([, value]) => value !== void 0).map(([name]) => name);
-      if (incompatible.length === 0) return;
-      return `prepared-release-id targets an already-prepared release as the source of truth, so the following input(s) are incompatible and must not be set alongside it: ${incompatible.join(", ")}. Remove them; their values are taken from the prepared release.`;
     }
     function updateConfigFromInput(config, input) {
       if (input.commitish) {

--- a/index.js
+++ b/index.js
@@ -34,15 +34,13 @@ module.exports = (app, { getRouter }) => {
   const drafter = async (context) => {
     const input = getInput()
 
-    const ignoredPreparedReleaseInputs = getIgnoredPreparedReleaseInputs(input)
+    const ignoredPreparedReleaseInputs =
+      neutralizeIgnoredPreparedReleaseInputs(input)
     if (ignoredPreparedReleaseInputs.length > 0) {
       core.warning(
-        `prepared-release-id targets an already-prepared release as the ` +
-          `source of truth, so the following input(s) are ignored: ` +
-          `${ignoredPreparedReleaseInputs.join(
-            ', '
-          )}. Their values are taken ` +
-          `from the prepared release.`
+        `prepared-release-id is set, so the following input(s) are ignored ` +
+          `(no-op): ${ignoredPreparedReleaseInputs.join(', ')}. Their values ` +
+          `come from the targeted release.`
       )
     }
 
@@ -277,8 +275,9 @@ module.exports = (app, { getRouter }) => {
     // On a `prepared-release-id` finalize the targeted release is the source of
     // truth: reuse the version, tag, and prerelease state frozen by the earlier
     // pass rather than recomputing them (recomputing could drift if a release
-    // landed in between). Inputs that would recompute these are ignored with a
-    // warning (see getIgnoredPreparedReleaseInputs), so nothing here is overridden.
+    // landed in between). Inputs that would recompute these are neutralized with
+    // a warning (see neutralizeIgnoredPreparedReleaseInputs), so nothing here is
+    // overridden.
     let effectiveTag = tag
     let effectiveIsPreRelease = prerelease
     if (preparedRelease) {
@@ -460,28 +459,34 @@ function getInput() {
 /**
  * `prepared-release-id` finalizes an already-prepared release: its version,
  * tag, prerelease state, and target commit are the frozen source of truth. Any
- * input that would recompute or re-select those values is therefore a no-op on
- * this path — its value comes from the prepared release regardless. Rather than
- * failing (which would force callers to reason about which inputs are set by
- * default vs. explicitly), collect them so the caller can warn and continue.
- * (`filter-by-commitish` is a repo config-file option, not an action input, so
- * it is a silent no-op here instead — handled where the release is targeted.)
- * Returns the names of the ignored inputs (empty when none apply).
+ * input that would recompute or re-select those values (or shift the commit
+ * range used to regenerate the changelog, e.g. `commitish`) must be a no-op on
+ * this path. Rather than failing (which would force callers to reason about
+ * which inputs are set by default vs. explicitly), this *neutralizes* those
+ * inputs in place so they genuinely can't affect config merging or downstream
+ * resolution, and returns their names so the caller can warn. Clearing them
+ * (rather than only warning) is what makes the no-op real — otherwise they
+ * would still flow through `updateConfigFromInput`. (`filter-by-commitish` is a
+ * repo config-file option, not an action input, so it is handled where the
+ * release is targeted.) Returns the names of the neutralized inputs, or `[]`
+ * when `prepared-release-id` is not set.
  */
-function getIgnoredPreparedReleaseInputs(input) {
+function neutralizeIgnoredPreparedReleaseInputs(input) {
   if (!input.preparedReleaseId) return []
-  return [
-    ['version', input.version],
-    ['tag', input.tag],
-    ['commitish', input.commitish],
-    ['base-ref-override', input.baseRefOverride],
-    ['base-version-override', input.baseVersionOverride],
-    ['prerelease', input.prerelease],
-    ['prerelease-identifier', input.preReleaseIdentifier],
-    ['allow-major-bumps', input.allowMajorBumps],
-  ]
-    .filter(([, value]) => value !== undefined)
-    .map(([name]) => name)
+  const ignored = [
+    ['version', 'version'],
+    ['tag', 'tag'],
+    ['commitish', 'commitish'],
+    ['base-ref-override', 'baseRefOverride'],
+    ['base-version-override', 'baseVersionOverride'],
+    ['prerelease', 'prerelease'],
+    ['prerelease-identifier', 'preReleaseIdentifier'],
+    ['allow-major-bumps', 'allowMajorBumps'],
+  ].filter(([, key]) => input[key] !== undefined)
+  for (const [, key] of ignored) {
+    input[key] = undefined
+  }
+  return ignored.map(([name]) => name)
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -472,7 +472,12 @@ function getPreparedReleaseConflict(input) {
     ['base-version-override', input.baseVersionOverride],
     ['prerelease', input.prerelease],
     ['prerelease-identifier', input.preReleaseIdentifier],
-    ['allow-major-bumps', input.allowMajorBumps],
+    // `allow-major-bumps` has a non-empty default ('false') in action.yml, so it
+    // always arrives via getInput and can't be distinguished from an explicit
+    // `false`. Only an explicit `true` expresses intent to influence the (now
+    // frozen) version resolution, so treat only that as a conflict — otherwise
+    // the default would make every prepared-release-id finalize fail.
+    ['allow-major-bumps', input.allowMajorBumps === true ? true : undefined],
   ]
     .filter(([, value]) => value !== undefined)
     .map(([name]) => name)

--- a/index.js
+++ b/index.js
@@ -39,8 +39,8 @@ module.exports = (app, { getRouter }) => {
     if (ignoredPreparedReleaseInputs.length > 0) {
       core.warning(
         `prepared-release-id is set, so the following input(s) are ignored ` +
-          `(no-op): ${ignoredPreparedReleaseInputs.join(', ')}. Their values ` +
-          `come from the targeted release.`
+          `(no-op) and will not affect this run: ` +
+          `${ignoredPreparedReleaseInputs.join(', ')}.`
       )
     }
 

--- a/index.js
+++ b/index.js
@@ -34,10 +34,16 @@ module.exports = (app, { getRouter }) => {
   const drafter = async (context) => {
     const input = getInput()
 
-    const preparedReleaseConflict = getPreparedReleaseConflict(input)
-    if (preparedReleaseConflict) {
-      core.setFailed(preparedReleaseConflict)
-      return
+    const ignoredPreparedReleaseInputs = getIgnoredPreparedReleaseInputs(input)
+    if (ignoredPreparedReleaseInputs.length > 0) {
+      core.warning(
+        `prepared-release-id targets an already-prepared release as the ` +
+          `source of truth, so the following input(s) are ignored: ` +
+          `${ignoredPreparedReleaseInputs.join(
+            ', '
+          )}. Their values are taken ` +
+          `from the prepared release.`
+      )
     }
 
     const config = await getConfig({
@@ -271,8 +277,8 @@ module.exports = (app, { getRouter }) => {
     // On a `prepared-release-id` finalize the targeted release is the source of
     // truth: reuse the version, tag, and prerelease state frozen by the earlier
     // pass rather than recomputing them (recomputing could drift if a release
-    // landed in between). Inputs that would recompute these are rejected up
-    // front (see getPreparedReleaseConflict), so nothing here is overridden.
+    // landed in between). Inputs that would recompute these are ignored with a
+    // warning (see getIgnoredPreparedReleaseInputs), so nothing here is overridden.
     let effectiveTag = tag
     let effectiveIsPreRelease = prerelease
     if (preparedRelease) {
@@ -454,17 +460,17 @@ function getInput() {
 /**
  * `prepared-release-id` finalizes an already-prepared release: its version,
  * tag, prerelease state, and target commit are the frozen source of truth. Any
- * input that would recompute or re-select those values is therefore
- * incompatible — passing it would either be silently ignored or reintroduce the
- * cross-invocation drift this path exists to prevent. Reject the combination up
- * front with a clear error rather than resolving the contradiction quietly.
+ * input that would recompute or re-select those values is therefore a no-op on
+ * this path — its value comes from the prepared release regardless. Rather than
+ * failing (which would force callers to reason about which inputs are set by
+ * default vs. explicitly), collect them so the caller can warn and continue.
  * (`filter-by-commitish` is a repo config-file option, not an action input, so
  * it is a silent no-op here instead — handled where the release is targeted.)
- * Returns an error message describing the conflict, or `undefined` when clear.
+ * Returns the names of the ignored inputs (empty when none apply).
  */
-function getPreparedReleaseConflict(input) {
-  if (!input.preparedReleaseId) return
-  const incompatible = [
+function getIgnoredPreparedReleaseInputs(input) {
+  if (!input.preparedReleaseId) return []
+  return [
     ['version', input.version],
     ['tag', input.tag],
     ['commitish', input.commitish],
@@ -472,22 +478,10 @@ function getPreparedReleaseConflict(input) {
     ['base-version-override', input.baseVersionOverride],
     ['prerelease', input.prerelease],
     ['prerelease-identifier', input.preReleaseIdentifier],
-    // `allow-major-bumps` has a non-empty default ('false') in action.yml, so it
-    // always arrives via getInput and can't be distinguished from an explicit
-    // `false`. Only an explicit `true` expresses intent to influence the (now
-    // frozen) version resolution, so treat only that as a conflict — otherwise
-    // the default would make every prepared-release-id finalize fail.
-    ['allow-major-bumps', input.allowMajorBumps === true ? true : undefined],
+    ['allow-major-bumps', input.allowMajorBumps],
   ]
     .filter(([, value]) => value !== undefined)
     .map(([name]) => name)
-  if (incompatible.length === 0) return
-  return (
-    `prepared-release-id targets an already-prepared release as the source of ` +
-    `truth, so the following input(s) are incompatible and must not be set ` +
-    `alongside it: ${incompatible.join(', ')}. Remove them; their values are ` +
-    `taken from the prepared release.`
-  )
 }
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4211,9 +4211,22 @@ describe('release-drafter', () => {
           .reply(200, releaseDrafterFixture)
 
         nock('https://api.github.com')
-          .post('/graphql', (body) =>
-            body.query.includes('query findCommitsWithAssociatedPullRequests')
-          )
+          .post('/graphql', (body) => {
+            if (
+              !body.query.includes(
+                'query findCommitsWithAssociatedPullRequests'
+              )
+            ) {
+              return false
+            }
+            // Proves neutralization: the injected commitish must NOT drive the
+            // commit range used to regenerate the changelog. If it leaked
+            // through updateConfigFromInput, targetCommitish would be it.
+            expect(body.variables.targetCommitish).not.toBe(
+              'refs/heads/some-other-branch'
+            )
+            return true
+          })
           .reply(200, graphqlCommitsMergeCommit)
 
         nock('https://api.github.com')
@@ -4232,7 +4245,7 @@ describe('release-drafter', () => {
           expect.stringContaining('commitish')
         )
         expect(setFailedSpy).not.toHaveBeenCalled()
-        expect.assertions(2)
+        expect.assertions(3)
 
         warningSpy.mockRestore()
         setFailedSpy.mockRestore()

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4182,7 +4182,7 @@ describe('release-drafter', () => {
         restoreEnvironment()
       })
 
-      it('fails when an incompatible input is set alongside prepared-release-id', async () => {
+      it('warns but still finalizes when an ignored input is set alongside prepared-release-id', async () => {
         let restoreEnvironment = mockedEnv({
           'INPUT_PREPARED-RELEASE-ID': '11691725',
           INPUT_VERSION: '3.0.0',
@@ -4190,36 +4190,64 @@ describe('release-drafter', () => {
         const setFailedSpy = jest
           .spyOn(core, 'setFailed')
           .mockImplementation(() => {})
+        const warningSpy = jest
+          .spyOn(core, 'warning')
+          .mockImplementation(() => {})
 
-        // No API is mocked: the conflict is caught before any release lookup,
-        // so the run must short-circuit without touching the GitHub API.
+        getConfigMock()
+
+        nock('https://api.github.com')
+          .get('/repos/toolmantim/release-drafter-test-project/releases')
+          .query(true)
+          .reply(200, [{ ...releasePayload, id: 999, draft: false }])
+
+        nock('https://api.github.com')
+          .get(
+            '/repos/toolmantim/release-drafter-test-project/releases/11691725'
+          )
+          .reply(200, releaseDrafterFixture)
+
+        nock('https://api.github.com')
+          .post('/graphql', (body) =>
+            body.query.includes('query findCommitsWithAssociatedPullRequests')
+          )
+          .reply(200, graphqlCommitsMergeCommit)
+
+        nock('https://api.github.com')
+          .patch(
+            '/repos/toolmantim/release-drafter-test-project/releases/11691725'
+          )
+          .reply(200, releaseDrafterFixture)
+
         await probot.receive({
           name: 'push',
           payload: pushPayload,
         })
 
-        expect(setFailedSpy).toHaveBeenCalledWith(
+        // The ignored input is warned about, naming it, but the run does not fail.
+        expect(warningSpy).toHaveBeenCalledWith(
           expect.stringContaining('version')
         )
-        expect(setFailedSpy).toHaveBeenCalledWith(
-          expect.stringContaining('prepared-release-id')
-        )
+        expect(setFailedSpy).not.toHaveBeenCalled()
         expect.assertions(2)
 
+        warningSpy.mockRestore()
         setFailedSpy.mockRestore()
         restoreEnvironment()
       })
 
-      it('does not treat allow-major-bumps=false (the action default) as a conflict', async () => {
-        // `allow-major-bumps` has a non-empty default ('false') in action.yml,
-        // so real Actions runs always pass it. It must NOT be flagged as an
-        // incompatible input, otherwise every prepared-release-id finalize fails.
+      it('does not warn when allow-major-bumps is unset (action has no default)', async () => {
+        // `allow-major-bumps` has no default in action.yml, so an unset input
+        // arrives as undefined and must not be reported as ignored — otherwise
+        // every real prepared-release-id finalize would warn spuriously.
         let restoreEnvironment = mockedEnv({
           'INPUT_PREPARED-RELEASE-ID': '11691725',
-          'INPUT_ALLOW-MAJOR-BUMPS': 'false',
         })
         const setFailedSpy = jest
           .spyOn(core, 'setFailed')
+          .mockImplementation(() => {})
+        const warningSpy = jest
+          .spyOn(core, 'warning')
           .mockImplementation(() => {})
 
         getConfigMock()
@@ -4256,14 +4284,16 @@ describe('release-drafter', () => {
           payload: pushPayload,
         })
 
+        expect(warningSpy).not.toHaveBeenCalled()
         expect(setFailedSpy).not.toHaveBeenCalled()
-        expect.assertions(2)
+        expect.assertions(3)
 
+        warningSpy.mockRestore()
         setFailedSpy.mockRestore()
         restoreEnvironment()
       })
 
-      it('fails when allow-major-bumps=true is set alongside prepared-release-id', async () => {
+      it('warns but still finalizes when allow-major-bumps=true is set alongside prepared-release-id', async () => {
         let restoreEnvironment = mockedEnv({
           'INPUT_PREPARED-RELEASE-ID': '11691725',
           'INPUT_ALLOW-MAJOR-BUMPS': 'true',
@@ -4271,21 +4301,47 @@ describe('release-drafter', () => {
         const setFailedSpy = jest
           .spyOn(core, 'setFailed')
           .mockImplementation(() => {})
+        const warningSpy = jest
+          .spyOn(core, 'warning')
+          .mockImplementation(() => {})
 
-        // No API is mocked: the conflict is caught before any release lookup.
+        getConfigMock()
+
+        nock('https://api.github.com')
+          .get('/repos/toolmantim/release-drafter-test-project/releases')
+          .query(true)
+          .reply(200, [{ ...releasePayload, id: 999, draft: false }])
+
+        nock('https://api.github.com')
+          .get(
+            '/repos/toolmantim/release-drafter-test-project/releases/11691725'
+          )
+          .reply(200, releaseDrafterFixture)
+
+        nock('https://api.github.com')
+          .post('/graphql', (body) =>
+            body.query.includes('query findCommitsWithAssociatedPullRequests')
+          )
+          .reply(200, graphqlCommitsMergeCommit)
+
+        nock('https://api.github.com')
+          .patch(
+            '/repos/toolmantim/release-drafter-test-project/releases/11691725'
+          )
+          .reply(200, releaseDrafterFixture)
+
         await probot.receive({
           name: 'push',
           payload: pushPayload,
         })
 
-        expect(setFailedSpy).toHaveBeenCalledWith(
+        expect(warningSpy).toHaveBeenCalledWith(
           expect.stringContaining('allow-major-bumps')
         )
-        expect(setFailedSpy).toHaveBeenCalledWith(
-          expect.stringContaining('prepared-release-id')
-        )
+        expect(setFailedSpy).not.toHaveBeenCalled()
         expect.assertions(2)
 
+        warningSpy.mockRestore()
         setFailedSpy.mockRestore()
         restoreEnvironment()
       })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4182,10 +4182,13 @@ describe('release-drafter', () => {
         restoreEnvironment()
       })
 
-      it('warns but still finalizes when an ignored input is set alongside prepared-release-id', async () => {
+      it('warns but still finalizes when an ignored input (commitish) is set alongside prepared-release-id', async () => {
+        // `commitish` is the subtle case: it flows through updateConfigFromInput
+        // and would otherwise shift the commit range used to regenerate the
+        // changelog. Neutralizing it keeps the prepared release authoritative.
         let restoreEnvironment = mockedEnv({
           'INPUT_PREPARED-RELEASE-ID': '11691725',
-          INPUT_VERSION: '3.0.0',
+          INPUT_COMMITISH: 'refs/heads/some-other-branch',
         })
         const setFailedSpy = jest
           .spyOn(core, 'setFailed')
@@ -4226,7 +4229,7 @@ describe('release-drafter', () => {
 
         // The ignored input is warned about, naming it, but the run does not fail.
         expect(warningSpy).toHaveBeenCalledWith(
-          expect.stringContaining('version')
+          expect.stringContaining('commitish')
         )
         expect(setFailedSpy).not.toHaveBeenCalled()
         expect.assertions(2)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4209,6 +4209,86 @@ describe('release-drafter', () => {
         setFailedSpy.mockRestore()
         restoreEnvironment()
       })
+
+      it('does not treat allow-major-bumps=false (the action default) as a conflict', async () => {
+        // `allow-major-bumps` has a non-empty default ('false') in action.yml,
+        // so real Actions runs always pass it. It must NOT be flagged as an
+        // incompatible input, otherwise every prepared-release-id finalize fails.
+        let restoreEnvironment = mockedEnv({
+          'INPUT_PREPARED-RELEASE-ID': '11691725',
+          'INPUT_ALLOW-MAJOR-BUMPS': 'false',
+        })
+        const setFailedSpy = jest
+          .spyOn(core, 'setFailed')
+          .mockImplementation(() => {})
+
+        getConfigMock()
+
+        nock('https://api.github.com')
+          .get('/repos/toolmantim/release-drafter-test-project/releases')
+          .query(true)
+          .reply(200, [{ ...releasePayload, id: 999, draft: false }])
+
+        nock('https://api.github.com')
+          .get(
+            '/repos/toolmantim/release-drafter-test-project/releases/11691725'
+          )
+          .reply(200, releaseDrafterFixture)
+
+        nock('https://api.github.com')
+          .post('/graphql', (body) =>
+            body.query.includes('query findCommitsWithAssociatedPullRequests')
+          )
+          .reply(200, graphqlCommitsMergeCommit)
+
+        nock('https://api.github.com')
+          .patch(
+            '/repos/toolmantim/release-drafter-test-project/releases/11691725',
+            (body) => {
+              expect(body.draft).toBe(true)
+              return true
+            }
+          )
+          .reply(200, releaseDrafterFixture)
+
+        await probot.receive({
+          name: 'push',
+          payload: pushPayload,
+        })
+
+        expect(setFailedSpy).not.toHaveBeenCalled()
+        expect.assertions(2)
+
+        setFailedSpy.mockRestore()
+        restoreEnvironment()
+      })
+
+      it('fails when allow-major-bumps=true is set alongside prepared-release-id', async () => {
+        let restoreEnvironment = mockedEnv({
+          'INPUT_PREPARED-RELEASE-ID': '11691725',
+          'INPUT_ALLOW-MAJOR-BUMPS': 'true',
+        })
+        const setFailedSpy = jest
+          .spyOn(core, 'setFailed')
+          .mockImplementation(() => {})
+
+        // No API is mocked: the conflict is caught before any release lookup.
+        await probot.receive({
+          name: 'push',
+          payload: pushPayload,
+        })
+
+        expect(setFailedSpy).toHaveBeenCalledWith(
+          expect.stringContaining('allow-major-bumps')
+        )
+        expect(setFailedSpy).toHaveBeenCalledWith(
+          expect.stringContaining('prepared-release-id')
+        )
+        expect.assertions(2)
+
+        setFailedSpy.mockRestore()
+        restoreEnvironment()
+      })
     })
 
     describe('with resolved SHA pinning', () => {


### PR DESCRIPTION
## Summary

The two-stage `not-ready` → `prepared-release-id` flow (from #57/#58) **failed on every real Actions run** in the finalize step:

```
prepared-release-id targets an already-prepared release ... incompatible ...: allow-major-bumps
```

Root cause: `allow-major-bumps` is the only input in the `prepared-release-id` incompatibility list with a **non-empty default** (`'false'`) in `action.yml`, so `core.getInput('allow-major-bumps')` always returned it and the hard-fail check flagged it even when the user never set it. Unit tests missed it because they inject inputs via env and never set the action.yml default.

Per maintainer feedback, rather than bifurcating failure conditions by *how* each input was supplied, this takes the simpler, easier-to-support approach: on a `prepared-release-id` finalize, any recompute/re-select input is **ignored (a no-op) with a `core.warning`** — the targeted release stays the source of truth. No more hard failure.

Crucially, "ignored" is made real by **neutralizing** the inputs up front (setting them to `undefined` before config merging) — not just warning. Otherwise inputs like `commitish` would still flow through `updateConfigFromInput` and shift the commit range used to regenerate the changelog:

```js
- const conflict = getPreparedReleaseConflict(input)   // core.setFailed + return
- if (conflict) { core.setFailed(conflict); return }
+ const ignored = neutralizeIgnoredPreparedReleaseInputs(input)  // clears them in place
+ if (ignored.length) core.warning(`... ignored (no-op): ${ignored.join(', ')} ...`)  // continue
```

To keep detection uniform (no per-input special-casing) and avoid a spurious warning on every finalize, the `allow-major-bumps` **default is removed from `action.yml`**. This is behavior-preserving: `no-auto-major` already defaults to `true` in `lib/default-config.js` and `lib/schema.js`, so an unset input (`undefined`) falls through to the same marketing-aware default it had before.

Also folds in two Copilot nits from #58:
1. README: clarify the run-URL only needs `$GITHUB_REPOSITORY` + `$GITHUB_RUN_ID` (`$GITHUB_SERVER_URL` defaults to `https://github.com`).
2. e2e smoke test: normalize `https?://` so a custom `GITHUB_SERVER_URL` (e.g. `http://` GHES) is handled.

Docs (`action.yml`, README) updated to say these inputs are *ignored with a warning* rather than *incompatible / cause failure*, and the `allow-major-bumps` description clarifies that *unset* defers to the repo config's `version-resolver.no-auto-major`.

## Test plan
- Prepared-release-id tests: an ignored input (`commitish`, the subtle changelog-affecting case) and an explicit `allow-major-bumps=true` now **warn and still finalize** (no `setFailed`); unset `allow-major-bumps` produces **no warning** and finalizes.
- `yarn test`: 275 passing. `yarn lint`: clean. `dist/index.js` rebuilt via `yarn build`.
- Reproduced by the failed ops run: airbytehq/airbyte-ops-mcp#1134 → https://github.com/airbytehq/airbyte-ops-mcp/actions/runs/29958759379 (banner rendered correctly, finalize failed on this exact conflict).


Link to Devin session: https://app.devin.ai/sessions/75369861ab7c4a79879856ab6e0bc782
Requested by: @aaronsteers