### PR TITLE
ci: look up the live smoke-test release by id, not by name

### DIFF
--- a/.github/workflows/e2e-smoke-tests.yml
+++ b/.github/workflows/e2e-smoke-tests.yml
@@ -608,15 +608,10 @@ jobs:
         if: matrix.live-release == true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_NAME: ${{ format('v0.0.{0}', github.run_id) }}
+          RELEASE_ID: ${{ steps.release-drafter.outputs.id }}
         run: |
-          for attempt in 1 2 3 4 5; do
-            release_id="$(gh api "repos/$GITHUB_REPOSITORY/releases" --paginate --jq ".[] | select(.name == \"$RELEASE_NAME\") | .id" | head -n 1)"
-            [ -n "$release_id" ] && break
-            sleep 2
-          done
-          [ -n "$release_id" ]
-          gh api "repos/$GITHUB_REPOSITORY/releases/$release_id" > "$RUNNER_TEMP/release.json"
+          [ -n "$RELEASE_ID" ]
+          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" > "$RUNNER_TEMP/release.json"
           jq -e '
             .draft == true and
             (.body | contains("[!CAUTION]") | not) and
@@ -627,14 +622,9 @@ jobs:
         if: matrix.live-release == true && always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_NAME: ${{ format('v0.0.{0}', github.run_id) }}
+          RELEASE_ID: ${{ steps.release-drafter.outputs.id }}
         run: |
-          for attempt in 1 2 3 4 5; do
-            release_id="$(gh api "repos/$GITHUB_REPOSITORY/releases" --paginate --jq ".[] | select(.name == \"$RELEASE_NAME\") | .id" 2>/dev/null | head -n 1 || true)"
-            [ -n "$release_id" ] && break
-            sleep 2
-          done
-          [ -z "$release_id" ] || gh api --method DELETE "repos/$GITHUB_REPOSITORY/releases/$release_id"
+          [ -z "$RELEASE_ID" ] || gh api --method DELETE "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" 2>/dev/null || true
 
       - name: Run release-drafter expecting failure
         id: release-drafter-failure

--- a/.github/workflows/e2e-smoke-tests.yml
+++ b/.github/workflows/e2e-smoke-tests.yml
@@ -610,7 +610,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_NAME: ${{ format('v0.0.{0}', github.run_id) }}
         run: |
-          release_id="$(gh api "repos/$GITHUB_REPOSITORY/releases" --paginate --jq ".[] | select(.name == \"$RELEASE_NAME\") | .id" | head -n 1)"
+          for attempt in 1 2 3 4 5; do
+            release_id="$(gh api "repos/$GITHUB_REPOSITORY/releases" --paginate --jq ".[] | select(.name == \"$RELEASE_NAME\") | .id" | head -n 1)"
+            [ -n "$release_id" ] && break
+            sleep 2
+          done
           [ -n "$release_id" ]
           gh api "repos/$GITHUB_REPOSITORY/releases/$release_id" > "$RUNNER_TEMP/release.json"
           jq -e '
@@ -625,7 +629,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_NAME: ${{ format('v0.0.{0}', github.run_id) }}
         run: |
-          release_id="$(gh api "repos/$GITHUB_REPOSITORY/releases" --paginate --jq ".[] | select(.name == \"$RELEASE_NAME\") | .id" 2>/dev/null | head -n 1 || true)"
+          for attempt in 1 2 3 4 5; do
+            release_id="$(gh api "repos/$GITHUB_REPOSITORY/releases" --paginate --jq ".[] | select(.name == \"$RELEASE_NAME\") | .id" 2>/dev/null | head -n 1 || true)"
+            [ -n "$release_id" ] && break
+            sleep 2
+          done
           [ -z "$release_id" ] || gh api --method DELETE "repos/$GITHUB_REPOSITORY/releases/$release_id"
 
       - name: Run release-drafter expecting failure


### PR DESCRIPTION
## Summary

The `attach-files-draft-final-body` smoke case added in #60 passed on the PR but failed on the post-merge push to main ([job](https://github.com/aaronsteers/semantic-pr-release-drafter/actions/runs/30956465802/job/92150578156)). The action itself succeeded — "Successfully attached 3 assets to release" — and the *verification* step then failed to find the release, because it scanned `GET /releases` for a matching `.name`. That endpoint is eventually consistent, so a draft created seconds earlier can be missing from the list: the exact read-after-write race the `prepared-release-id` input exists to avoid.

The verify and cleanup steps now use the release id the action already emits, which is a strongly consistent point-read:

```diff
-  RELEASE_NAME: ${{ format('v0.0.{0}', github.run_id) }}
+  RELEASE_ID: ${{ steps.release-drafter.outputs.id }}
-  release_id="$(gh api .../releases --paginate --jq '... select(.name == ...) ...' | head -n 1)"
-  gh api ".../releases/$release_id"
+  gh api ".../releases/$RELEASE_ID"
```

Cleanup runs under `always()`, so it still tolerates an empty id and a delete that 404s.

## Test plan

The smoke workflow runs on this PR and exercises the same live-release case; a green `attach-files-draft-final-body` leg is the verification.


Link to Devin session: https://app.devin.ai/sessions/82cc18c737aa4b6580711ffafac909ec
Requested by: @aaronsteers