### PR TITLE
ci: clean up smoke-test releases even when the action step fails

### DIFF
--- a/.github/workflows/e2e-smoke-tests.yml
+++ b/.github/workflows/e2e-smoke-tests.yml
@@ -618,13 +618,30 @@ jobs:
             ([.assets[].name] | sort) == ["app-1.0.0.whl", "file1.txt", "file2.txt"]
           ' "$RUNNER_TEMP/release.json"
 
-      - name: Clean up live draft release
-        if: matrix.live-release == true && always()
+      - name: Clean up live draft release by id
+        if: matrix.live-release == true && always() && steps.release-drafter.outputs.id != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_ID: ${{ steps.release-drafter.outputs.id }}
         run: |
-          [ -z "$RELEASE_ID" ] || gh api --method DELETE "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" 2>/dev/null || true
+          gh api --method DELETE "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" 2>/dev/null || true
+
+      - name: Clean up live draft release by name
+        if: matrix.live-release == true && always() && steps.release-drafter.outputs.id == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NAME: ${{ format('v0.0.{0}', github.run_id) }}
+        run: |
+          release_id="$(gh api "repos/$GITHUB_REPOSITORY/releases" --paginate --jq ".[] | select(.name == \"$RELEASE_NAME\") | .id" 2>/dev/null | head -n 1 || true)"
+          [ -z "$release_id" ] || gh api --method DELETE "repos/$GITHUB_REPOSITORY/releases/$release_id" 2>/dev/null || true
+
+      - name: Clean up live draft release tag
+        if: matrix.live-release == true && always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ format('v0.0.{0}', github.run_id) }}
+        run: |
+          gh api --method DELETE "repos/$GITHUB_REPOSITORY/git/refs/tags/$RELEASE_TAG" 2>/dev/null || true
 
       - name: Run release-drafter expecting failure
         id: release-drafter-failure


### PR DESCRIPTION
## Summary

#61 made smoke-test cleanup rely solely on `steps.release-drafter.outputs.id`, which the action only emits when its step *succeeds*. If the action creates the release and then fails — an asset upload error being the obvious case — the id is empty, cleanup silently skips, and a stray draft release accumulates in the repo. Since #60 that stray release also carries the hold banner, so it looks like a real half-finished release.

The id point-read stays the primary path (that's what fixed the flake in #61); the name-based scan comes back only as a fallback when the id is empty, and tag deletion is now its own always-run step:

```yaml
- name: Clean up live draft release by id
  if: ... && steps.release-drafter.outputs.id != ''
- name: Clean up live draft release by name    # fallback: action step failed
  if: ... && steps.release-drafter.outputs.id == ''
- name: Clean up live draft release tag
  if: ...                                       # unconditional
```

Every path stays non-fatal, since these run under `always()` and must not mask the real failure.

## Test plan

The smoke workflow runs on this PR; the happy path exercises the id branch. The fallback branch is only reachable on an action failure, so it is verified by inspection.


Link to Devin session: https://app.devin.ai/sessions/82cc18c737aa4b6580711ffafac909ec
Requested by: @aaronsteers