### PR TITLE
fix: preserve release identity when removing upload banner

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -150740,11 +150740,17 @@ var require_releases = __commonJS({
         })
       );
     };
-    var updateReleaseBody = ({ context, releaseId, body }) => {
+    var updateReleaseBody = ({ context, releaseId, body, releaseInfo }) => {
+      const updateReleaseParameters = updateDraftReleaseParameters({
+        name: releaseInfo.name,
+        tag_name: releaseInfo.tag,
+        target_commitish: releaseInfo.targetCommitish
+      });
       return context.octokit.repos.updateRelease(
         context.repo({
           release_id: releaseId,
-          body
+          body,
+          ...updateReleaseParameters
         })
       );
     };
@@ -154629,7 +154635,8 @@ var require_index = __commonJS({
             await updateReleaseBody({
               context,
               releaseId,
-              body: finalReleaseBody
+              body: finalReleaseBody,
+              releaseInfo
             });
           }
         }

--- a/index.js
+++ b/index.js
@@ -421,6 +421,7 @@ module.exports = (app, { getRouter }) => {
           context,
           releaseId,
           body: finalReleaseBody,
+          releaseInfo,
         })
       }
     }

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -386,11 +386,18 @@ const updateRelease = ({ context, draftRelease, releaseInfo }) => {
   )
 }
 
-const updateReleaseBody = ({ context, releaseId, body }) => {
+const updateReleaseBody = ({ context, releaseId, body, releaseInfo }) => {
+  const updateReleaseParameters = updateDraftReleaseParameters({
+    name: releaseInfo.name,
+    tag_name: releaseInfo.tag,
+    target_commitish: releaseInfo.targetCommitish,
+  })
+
   return context.octokit.repos.updateRelease(
     context.repo({
       release_id: releaseId,
       body,
+      ...updateReleaseParameters,
     })
   )
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4180,7 +4180,12 @@ describe('release-drafter', () => {
             .patch(
               '/repos/toolmantim/release-drafter-test-project/releases/11691725',
               (body) => {
-                expect(body).toEqual({ body: expectFinalBody })
+                expect(body).toMatchObject({
+                  body: expectFinalBody,
+                  name: 'v0.1.0',
+                  tag_name: 'v0.1.0',
+                  target_commitish: 'refs/heads/master',
+                })
                 expect(body.body).not.toContain(
                   'Release assets are still uploading'
                 )


### PR DESCRIPTION
## Summary

The banner-removal PATCH added in c0ff440 silently un-tags the draft it just finalized. GitHub does not treat an omitted `tag_name` on `PATCH /releases/{id}` as "leave it alone" for a draft — it resets the draft to its `untagged-<hash>` placeholder, so the release loses the tag it would have created on publish.

Verified against the live API on a throwaway draft (created and deleted):

```
before:  tag_name = "zz-devin-probe/v0.0.1"
PATCH    { body: "..." }            # body only, exactly what updateReleaseBody sent
after:   tag_name = "untagged-5e3c65563ae49eca4ecc"
```

Observed in the wild in `airbytehq/airbyte-ops-mcp` (which tracks `@main`): stage 1 created `v0.94.0`, stage 2's `updateRelease` re-sent `v0.94.0`, assets uploaded, and then the banner PATCH left both waiting drafts with no tag — REST and GraphQL both report `tagName: untagged-…`, `tag: null`.

The fix routes that final PATCH through the same `updateDraftReleaseParameters` guard the main update already uses, so a body edit can no longer change the release's identity:

```diff
-const updateReleaseBody = ({ context, releaseId, body }) => {
+const updateReleaseBody = ({ context, releaseId, body, releaseInfo }) => {
+  const updateReleaseParameters = updateDraftReleaseParameters({
+    name: releaseInfo.name,
+    tag_name: releaseInfo.tag,
+    target_commitish: releaseInfo.targetCommitish,
+  })
   return context.octokit.repos.updateRelease(
-    context.repo({ release_id: releaseId, body })
+    context.repo({ release_id: releaseId, body, ...updateReleaseParameters })
   )
 }
```

`draft` / `prerelease` / `make_latest` are deliberately still absent, so the call remains a body edit and cannot flip release state; the helper keeps omitting empty identity fields.

The existing test asserted `expect(body).toEqual({ body: expectFinalBody })` — i.e. it pinned the omission in place, which is why the regression shipped. It now asserts the preserved `name` / `tag_name` / `target_commitish` alongside the swapped body.

`dist/` is rebuilt, since `action.yml` runs the bundle.

## Test plan

- `yarn test --runInBand`: 9 suites / 279 tests / 57 snapshots pass.
- `yarn lint` and `prettier --check` pass.
- Live API probe above confirms both the failure mode and that identity fields are what GitHub needs on the final PATCH.
- End-to-end confirmation after merge: dispatch Release Drafter in `airbytehq/airbyte-ops-mcp` (it pins `@main`) and check the two stranded drafts get repaired to `v0.94.0` and `airbyte-cloud-cli/v0.2.0`.


Link to Devin session: https://app.devin.ai/sessions/c8d2030bffb64d3db2cf8ff843bbd211
Requested by: @aaronsteers