### PR TITLE
fix: fall back to release identity in banner patch

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -150740,11 +150740,17 @@ var require_releases = __commonJS({
         })
       );
     };
-    var updateReleaseBody = ({ context, releaseId, body, releaseInfo }) => {
+    var updateReleaseBody = ({
+      context,
+      releaseId,
+      body,
+      releaseInfo,
+      release
+    }) => {
       const updateReleaseParameters = updateDraftReleaseParameters({
-        name: releaseInfo.name,
-        tag_name: releaseInfo.tag,
-        target_commitish: releaseInfo.targetCommitish
+        name: releaseInfo.name || release.name,
+        tag_name: releaseInfo.tag || release.tag_name,
+        target_commitish: releaseInfo.targetCommitish || release.target_commitish
       });
       return context.octokit.repos.updateRelease(
         context.repo({
@@ -154636,7 +154642,8 @@ var require_index = __commonJS({
               context,
               releaseId,
               body: finalReleaseBody,
-              releaseInfo
+              releaseInfo,
+              release: createOrUpdateReleaseResponse.data
             });
           }
         }

--- a/index.js
+++ b/index.js
@@ -422,6 +422,7 @@ module.exports = (app, { getRouter }) => {
           releaseId,
           body: finalReleaseBody,
           releaseInfo,
+          release: createOrUpdateReleaseResponse.data,
         })
       }
     }

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -386,11 +386,17 @@ const updateRelease = ({ context, draftRelease, releaseInfo }) => {
   )
 }
 
-const updateReleaseBody = ({ context, releaseId, body, releaseInfo }) => {
+const updateReleaseBody = ({
+  context,
+  releaseId,
+  body,
+  releaseInfo,
+  release,
+}) => {
   const updateReleaseParameters = updateDraftReleaseParameters({
-    name: releaseInfo.name,
-    tag_name: releaseInfo.tag,
-    target_commitish: releaseInfo.targetCommitish,
+    name: releaseInfo.name || release.name,
+    tag_name: releaseInfo.tag || release.tag_name,
+    target_commitish: releaseInfo.targetCommitish || release.target_commitish,
   })
 
   return context.octokit.repos.updateRelease(

--- a/test/fixtures/config/config-empty-templates.yml
+++ b/test/fixtures/config/config-empty-templates.yml
@@ -1,0 +1,2 @@
+name-template: ''
+tag-template: ''

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4105,6 +4105,13 @@ describe('release-drafter', () => {
         publish = false,
         expectHoldBody,
         expectFinalBody,
+        configFile = 'config.yml',
+        expectCreateIdentity,
+        expectFinalIdentity = {
+          name: 'v0.1.0',
+          tag_name: 'v0.1.0',
+          target_commitish: 'refs/heads/master',
+        },
       } = {}) => {
         const environment = {
           GITHUB_WORKSPACE: workspace,
@@ -4128,7 +4135,7 @@ describe('release-drafter', () => {
           }
         }
 
-        getConfigMock()
+        getConfigMock(configFile)
 
         nock('https://api.github.com')
           .get(
@@ -4152,6 +4159,9 @@ describe('release-drafter', () => {
               } else {
                 expect(body.body).not.toContain('NOT READY FOR PUBLISHING')
                 expect(body.body).not.toContain('[!CAUTION]')
+              }
+              if (expectCreateIdentity) {
+                expect(body).toMatchObject(expectCreateIdentity)
               }
               if (publish) expect(body.draft).toBe(false)
               expect(body.body).toContain('<!-- Release drafted at')
@@ -4180,11 +4190,9 @@ describe('release-drafter', () => {
             .patch(
               '/repos/toolmantim/release-drafter-test-project/releases/11691725',
               (body) => {
-                expect(body).toMatchObject({
+                expect(body).toEqual({
                   body: expectFinalBody,
-                  name: 'v0.1.0',
-                  tag_name: 'v0.1.0',
-                  target_commitish: 'refs/heads/master',
+                  ...expectFinalIdentity,
                 })
                 expect(body.body).not.toContain(
                   'Release assets are still uploading'
@@ -4203,6 +4211,31 @@ describe('release-drafter', () => {
           expectHoldBody:
             'Release assets are still uploading. Do not publish until this banner is removed.',
           expectFinalBody: expect.any(String),
+        })
+
+        await probot.receive({
+          name: 'push',
+          payload: pushPayload,
+        })
+
+        restore()
+      })
+
+      it('preserves the existing tag when templates resolve empty', async () => {
+        const restore = setupAttachFilesMocks({
+          configFile: 'config-empty-templates.yml',
+          expectCreateIdentity: {
+            name: '',
+            tag_name: '',
+          },
+          expectHoldBody:
+            'Release assets are still uploading. Do not publish until this banner is removed.',
+          expectFinalBody: expect.any(String),
+          expectFinalIdentity: {
+            name: releasePayload.name,
+            tag_name: releasePayload.tag_name,
+            target_commitish: 'refs/heads/master',
+          },
         })
 
         await probot.receive({


### PR DESCRIPTION
## Summary

Follow-up to #63, which closed the common case but left a narrower one open. `tag-template` and `name-template` both `allow('')`, and `generateReleaseInfo` returns `''` when there is no version info — so `updateDraftReleaseParameters` drops the empty fields and the banner-removal PATCH degrades back to body-only, which GitHub answers by resetting the draft to `untagged-<hash>`.

`updateRelease` already guards this with `releaseInfo.tag || draftRelease.tag_name`; the banner path now gets the equivalent, sourced from the release that step 1 just created or updated (which also covers the newly-created case, where there is no `draftRelease` at all):

```diff
-    tag_name: releaseInfo.tag,
+    tag_name: releaseInfo.tag || release.tag_name,
```

Reachable today with `tag-template: ''` plus a manually tagged draft: the tag survives the main update and is wiped once uploads finish.

The test assertion also goes back to exact `toEqual` — Copilot's point, and correct. #63 relaxed it to `toMatchObject`, which stopped enforcing that `draft` / `prerelease` / `make_latest` are *absent* from that PATCH; keeping them out is what stops a body edit from flipping release state. New regression test drives the blank-template path end to end (upload, banner removal, exact final payload).

`dist/` rebuilt.

## Test plan

- `yarn test --runInBand`: 9 suites / 280 tests / 57 snapshots pass, including the new blank-template case.
- `yarn lint` and `prettier --check` pass.
- #63's fix is already confirmed in production: dispatching Release Drafter on `airbytehq/airbyte-ops-mcp` produced draft `v0.94.1` with assets attached, banner removed, and `tag_name` intact. This PR only extends that guarantee to empty templates.


Link to Devin session: https://app.devin.ai/sessions/c8d2030bffb64d3db2cf8ff843bbd211
Requested by: @aaronsteers